### PR TITLE
Add concatWith, mergeWith & zipWith operators.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ packages
 *.packages
 .idea/
 web/experimental
+doc
 
 # Or the files created by dart2js.
 *.dart.js

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This has two major implications:
 
 ### Instantiation
 
-Generally speaking, creating a new Observable is either done by wrapping a Dart Stream using the top-level method `observable()`, or by calling a factory method on the Observable class.  
+Generally speaking, creating a new Observable is either done by wrapping a Dart Stream using the top-level constructor `new Observable()`, or by calling a factory method on the Observable class.
 But to better support Dart's strong mode, `combineLatest` and `zip` have been pulled apart into fixed-length constructors. 
 These methods are supplied as static methods, since Dart's factory methods don't support generic types.
 
@@ -56,7 +56,7 @@ These methods are supplied as static methods, since Dart's factory methods don't
 
 ###### Usage
 ```dart
-var myObservable = observable(myStream);
+var myObservable = new Observable(myStream);
 ```
 
 ##### Available Factory Methods
@@ -87,7 +87,7 @@ var myObservable = Observable.combineLatest3(
     myFirstStream, 
     mySecondStream, 
     myThirdStream, 
-    (firstData, secondData, thirdData) => print(firstData + ' ' + secondData + ' ' + thirdData));
+    (firstData, secondData, thirdData) => print("$firstData $secondData $thirdData"));
 ```
 
 ### Transformations
@@ -96,6 +96,7 @@ var myObservable = Observable.combineLatest3(
 - bufferWithCount
 - call
 - concatMap
+- concatWith
 - debounce
 - dematerialize
 - flatMapLatest
@@ -103,6 +104,7 @@ var myObservable = Observable.combineLatest3(
 - groupBy
 - interval  
 - materialize
+- mergeWith
 - max
 - min
 - pluck  
@@ -115,16 +117,16 @@ var myObservable = Observable.combineLatest3(
 - takeUntil  
 - timeInterval  
 - timestamp
-- tap
-- throttle  
+- throttle
 - windowWithCount
-- withLatestFrom  
+- withLatestFrom
+- zipWith
 
 ###### Usage
 ```Dart
 var myObservable = observable(myStream)
     .bufferWithCount(5)
-    .distinct()
+    .distinct();
 ```
 
 ### Objects

--- a/examples/web/search_github/search_github.dart
+++ b/examples/web/search_github/search_github.dart
@@ -40,7 +40,7 @@ void main() {
     })
     .listen((result) {
       result.forEach((item) => resultsField.innerHtml +=
-        '<li>' + item['fullName'] + " (" + item['url'] + ")" + '</li>');
+        "<li>${item['fullName']} (${item['url']})</li>");
     });
 }
 

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -719,6 +719,17 @@ class Observable<T> extends Stream<T> {
   Observable<S> concatMap<S>(Stream<S> predicate(T value)) =>
       transform(concatMapTransformer(predicate));
 
+  /// Returns an Observable that emits all items from the current Observable,
+  /// then emits all items from the given observable, one after the next.
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.timer(1, new Duration(seconds: 10))
+  ///         .concatWith([new Observable.just(2)])
+  ///         .listen(print); // prints 1, 2
+  Observable<T> concatWith(Iterable<Stream<T>> other) =>
+      new Observable<T>(new ConcatStream<T>(<Stream<T>>[stream]..addAll(other)));
+
   @override
   Future<bool> contains(Object needle) => stream.contains(needle);
 
@@ -945,6 +956,18 @@ class Observable<T> extends Stream<T> {
   /// sequence according to the specified compare function.
   Observable<T> max([int compare(T a, T b)]) =>
       transform(maxTransformer(compare));
+
+  /// Combines the items emitted by multiple streams into a single stream of
+  /// items. The items are emitted in the order they are emitted by their
+  /// sources.
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.timer(1, new Duration(seconds: 10))
+  ///         .mergeWith([new Observable.just(2)])
+  ///         .listen(print); // prints 2, 1
+  Observable<T> mergeWith(Iterable<Stream<T>> streams) =>
+      new Observable<T>(new MergeStream<T>(<Stream<T>>[stream]..addAll(streams)));
 
   /// Creates an Observable that returns the minimum value in the source
   /// sequence according to the specified compare function.
@@ -1202,4 +1225,16 @@ class Observable<T> extends Stream<T> {
   Observable<R> withLatestFrom<S, R>(
           Stream<S> latestFromStream, R fn(T t, S s)) =>
       transform(withLatestFromTransformer(latestFromStream, fn));
+
+  /// Returns an Observable that combines the current stream together with
+  /// another stream using a given function.
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.just(1)
+  ///         .zipWith(new Observable.just(2), (one, two) => one + two)
+  ///         .listen(print); // prints 3
+  Observable<R> zipWith<S, R>(Stream<S> other, R predicate(T t, S s)) =>
+      new Observable<R>(
+          new ZipStream<R>(<Stream<dynamic>>[stream, other], predicate));
 }

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -27,6 +27,7 @@ import 'transformers/async_map_test.dart' as async_map_test;
 import 'transformers/buffer_with_count_test.dart' as buffer_with_count_test;
 import 'transformers/call_test.dart' as call_test;
 import 'transformers/concat_map_test.dart' as concat_map_test;
+import 'transformers/concat_with_test.dart' as concat_with_test;
 import 'transformers/contains_test.dart' as contains_test;
 import 'transformers/debounce_test.dart' as debounce_test;
 import 'transformers/default_if_empty_test.dart' as default_if_empty_test;
@@ -52,6 +53,7 @@ import 'transformers/last_test.dart' as last_test;
 import 'transformers/last_where_test.dart' as last_where_test;
 import 'transformers/materialize_test.dart' as materialize_test;
 import 'transformers/max_test.dart' as max_test;
+import 'transformers/merge_with_test.dart' as merge_with_test;
 import 'transformers/min_test.dart' as min_test;
 import 'transformers/of_type_test.dart' as of_type_test;
 import 'transformers/on_error_resume_next_test.dart'
@@ -81,6 +83,7 @@ import 'transformers/transform_test.dart' as transform_test;
 import 'transformers/where_test.dart' as where_test;
 import 'transformers/window_with_count_test.dart' as window_with_count_test;
 import 'transformers/with_latest_from_test.dart' as with_latest_from_test;
+import 'transformers/zip_with_test.dart' as zip_with_test;
 
 import 'subject/replay_subject_test.dart' as replay_subject_test;
 import 'subject/behaviour_subject_test.dart' as behaviour_subject_test;
@@ -112,6 +115,7 @@ void main() {
   buffer_with_count_test.main();
   call_test.main();
   concat_map_test.main();
+  concat_with_test.main();
   contains_test.main();
   debounce_test.main();
   default_if_empty_test.main();
@@ -138,6 +142,7 @@ void main() {
   last_where_test.main();
   materialize_test.main();
   max_test.main();
+  merge_with_test.main();
   min_test.main();
   of_type_test.main();
   on_error_resume_next_test.main();
@@ -168,6 +173,7 @@ void main() {
   where_test.main();
   window_with_count_test.main();
   with_latest_from_test.main();
+  zip_with_test.main();
 
   behaviour_subject_test.main();
   replay_subject_test.main();

--- a/test/transformers/concat_with_test.dart
+++ b/test/transformers/concat_with_test.dart
@@ -1,0 +1,18 @@
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  test('rx.Observable.concatWith', () async {
+    final Observable<int> delayedStream =
+        new Observable<int>.timer(1, new Duration(milliseconds: 10));
+    final Observable<int> immediateStream = new Observable<int>.just(2);
+    final List<int> expected = <int>[1, 2];
+    int count = 0;
+
+    new Observable<int>(delayedStream)
+        .concatWith(<Observable<int>>[immediateStream])
+        .listen(expectAsync1((int result) {
+          expect(result, expected[count++]);
+        }, count: expected.length));
+  });
+}

--- a/test/transformers/merge_with_test.dart
+++ b/test/transformers/merge_with_test.dart
@@ -1,0 +1,18 @@
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  test('rx.Observable.mergeWith', () async {
+    final Observable<int> delayedStream =
+        new Observable<int>.timer(1, new Duration(milliseconds: 10));
+    final Observable<int> immediateStream = new Observable<int>.just(2);
+    final List<int> expected = <int>[2, 1];
+    int count = 0;
+
+    new Observable<int>(delayedStream)
+        .mergeWith(<Observable<int>>[immediateStream])
+        .listen(expectAsync1((int result) {
+          expect(result, expected[count++]);
+        }, count: expected.length));
+  });
+}

--- a/test/transformers/zip_with_test.dart
+++ b/test/transformers/zip_with_test.dart
@@ -1,0 +1,12 @@
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  test('rx.Observable.zipWith', () async {
+    new Observable<int>(new Observable<int>.just(1))
+        .zipWith(new Observable<int>.just(2), (int one, int two) => one + two)
+        .listen(expectAsync1((int result) {
+          expect(result, 3);
+        }, count: 1));
+  });
+}


### PR DESCRIPTION
Some more nice convenience operators. Light tests, as they are simple, logic-free wrappers around ZipStream and ConcatStream.

I've also included a couple of small cleanup / tweaks to our Readme / Examples.