### PR TITLE
rework retry

### DIFF
--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -1040,7 +1040,7 @@ class Observable<T> extends Stream<T> {
   /// Creates an Observable that will repeat the source sequence the specified
   /// number of times until it successfully terminates. If the retry count is
   /// not specified, it retries indefinitely.
-  Observable<T> retry([int count]) => transform(retryTransformer(count));
+  Observable<T> retry({int count: 0}) => transform(retryTransformer(count: count));
 
   /// Creates an Observable that will emit the latest value from the source
   /// sequence whenever the sampleStream itself emits a value.

--- a/lib/src/transformers/retry.dart
+++ b/lib/src/transformers/retry.dart
@@ -1,22 +1,49 @@
 import 'dart:async';
 
-StreamTransformer<T, T> retryTransformer<T>(int count) {
+StreamTransformer<T, T> retryTransformer<T>({int count: 0}) {
   return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
     StreamController<T> controller;
     StreamSubscription<T> subscription;
     int retryStep = 0;
 
+    // In Dart, you cannot resubscribe to a single-subscription [Stream]
+    // however the Rx retry spec stipulates that we should resubscribe
+    // onError to trigger any potential side effects
+    // This assert warns the developer to not use retry when
+    // the input [Stream] is a single-subscription
+    assert(
+        input.isBroadcast,
+        '''The provided Stream
+is not a broadcast Stream, making it impossible to
+resubscribe to it.
+
+In Rx retry, it is expected to resubscribe when an error occurs.
+
+To resolve, please ensure that the provided Stream is a broadcast
+Stream.
+
+See: http://reactivex.io/documentation/operators/retry.html''');
+
     controller = new StreamController<T>(
         sync: true,
         onListen: () {
-          subscription = input.listen((T data) {
-            controller.add(data);
-          }, onError: (dynamic e, dynamic s) {
-            if (count > 0 && count == retryStep)
-              controller.addError(new RetryError(count));
+          void subscribeNext() {
+            subscription?.cancel();
 
-            retryStep++;
-          }, onDone: controller.close, cancelOnError: cancelOnError);
+            subscription = input.listen((T data) {
+              controller.add(data);
+            }, onError: (dynamic e, dynamic s) {
+              if (count > 0 && count == retryStep) {
+                controller.addError(new RetryError(count));
+              } else {
+                subscribeNext();
+              }
+
+              retryStep++;
+            }, onDone: controller.close, cancelOnError: cancelOnError);
+          }
+
+          subscribeNext();
         },
         onPause: ([Future<dynamic> resumeSignal]) =>
             subscription.pause(resumeSignal),

--- a/test/transformers/retry_test.dart
+++ b/test/transformers/retry_test.dart
@@ -15,28 +15,42 @@ Stream<int> _getStream() {
 }
 
 void main() {
-  test('rx.Observable.retry', () async {
-    new Observable<int>(_getStream())
-        .retry(3)
-        .listen(expectAsync1((int result) {
-          expect(result, 3);
-        }, count: 1));
+  test('rx.Observable.retry.assertWhenSingleSubscription', () async {
+    try {
+      // If call contains no arguments, throw a runtime error in dev mode
+      // in order to "fail fast" and alert the developer that the operator
+      // can be used or safely removed.
+      new Observable<int>(_getStream())
+          .retry()
+          .listen(null);
+    } catch (e) {
+      await expect(e is AssertionError, isTrue);
+    }
   });
 
-  test('rx.Observable.retry.asBroadcastStream', () async {
+
+  test('rx.Observable.retry.asBroadcastStream.1', () async {
     Stream<int> stream =
-        new Observable<int>(_getStream().asBroadcastStream()).retry(3);
+        new Observable<int>(_getStream().asBroadcastStream()).retry(count: 3);
 
     // listen twice on same stream
     stream.listen((_) {});
     stream.listen((_) {});
     // code should reach here
-    expect(true, true);
+    await expect(true, true);
+  });
+
+  test('rx.Observable.retry.asBroadcastStream.2', () async {
+    new Observable<int>(_getStream().asBroadcastStream())
+        .retry(count: 3)
+        .listen(expectAsync1((int result) {
+      expect(result, 3);
+    }, count: 1));
   });
 
   test('rx.Observable.retry.error.shouldThrow', () async {
     Stream<int> observableWithError =
-        new Observable<int>(_getStream()).retry(2);
+        new Observable<int>(_getStream().asBroadcastStream()).retry(count: 2);
 
     observableWithError.listen(null, onError: (dynamic e, dynamic s) {
       expect(e is RetryError, isTrue);
@@ -45,8 +59,8 @@ void main() {
 
   test('rx.Observable.retry.pause.resume', () async {
     StreamSubscription<int> subscription;
-    subscription = new Observable<int>(_getStream())
-        .retry(3)
+    subscription = new Observable<int>(_getStream().asBroadcastStream())
+        .retry(count: 3)
         .listen(expectAsync1((int result) {
           expect(result, 3);
 


### PR DESCRIPTION
Up for discussion!

In this version, it asserts to ensure that the provided Stream is a broadcast Stream.

If it isn't, a resubscribe is impossible, making the retry implementation invalid.

See also: http://reactivex.io/documentation/operators/retry.html