### PR TITLE
Retry factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ var myObservable = new Observable(myStream);
 - merge
 - never
 - periodic
+- retry
 - timer
 
 ###### Usage
@@ -106,7 +107,6 @@ var myObservable = Observable.combineLatest3(
 - min
 - pluck  
 - repeat  
-- retry  
 - sample  
 - scan  
 - skipUntil

--- a/lib/src/streams/defer.dart
+++ b/lib/src/streams/defer.dart
@@ -1,15 +1,17 @@
 import 'dart:async';
 
-class DeferStream<T> extends Stream<T> {
-  final StreamProvider<T> streamProvider;
+import 'package:rxdart/src/streams/utils.dart';
 
-  DeferStream(this.streamProvider);
+class DeferStream<T> extends Stream<T> {
+  final StreamFactory<T> streamFactory;
+
+  DeferStream(this.streamFactory);
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
     StreamController<T> controller;
-    Stream<T> stream = streamProvider();
+    Stream<T> stream = streamFactory();
     bool hasListened = false;
 
     controller = new StreamController<T>(onListen: () {
@@ -23,5 +25,3 @@ class DeferStream<T> extends Stream<T> {
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 }
-
-typedef Stream<T> StreamProvider<T>();

--- a/lib/src/streams/defer.dart
+++ b/lib/src/streams/defer.dart
@@ -4,24 +4,17 @@ import 'package:rxdart/src/streams/utils.dart';
 
 class DeferStream<T> extends Stream<T> {
   final StreamFactory<T> streamFactory;
+  bool _isUsed = false;
 
   DeferStream(this.streamFactory);
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    StreamController<T> controller;
-    Stream<T> stream = streamFactory();
-    bool hasListened = false;
+    if (_isUsed) throw new StateError("Stream has already been listened to.");
+    _isUsed = true;
 
-    controller = new StreamController<T>(onListen: () {
-      if (!hasListened) {
-        stream.listen(controller.add,
-            onError: controller.addError, onDone: controller.close);
-      }
-    });
-
-    return controller.stream.listen(onData,
+    return streamFactory().listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 }

--- a/lib/src/streams/retry.dart
+++ b/lib/src/streams/retry.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:rxdart/src/streams/utils.dart';
+
+/// Creates a Stream that will recreate and re-listen to the source
+/// Stream the specified number of times until the Stream terminates
+/// successfully.
+///
+/// If the retry count is not specified, it retries indefinitely. If the retry
+/// count is met, but the Stream has not terminated successfully, a
+/// `RetryError` will be thrown.
+///
+/// ### Example
+///
+///     new RetryStream(() { new Stream.fromIterable([1]); })
+///         .listen((i) => print(i)); // Prints 1
+///
+///     new RetryStream(() {
+///          new Stream.fromIterable([1])
+///             .concatWith([new ErrorStream(new Error())]);
+///        }, 1)
+///        .listen(print, onError: (e, s) => print(e)); // Prints 1, 1, RetryError
+class RetryStream<T> extends Stream<T> {
+  final StreamFactory<T> streamFactory;
+  int count;
+  int retryStep = 0;
+  bool shouldClose = false;
+  StreamController<T> controller;
+  StreamSubscription<T> subscription;
+
+  RetryStream(this.streamFactory, [this.count]);
+
+  @override
+  StreamSubscription<T> listen(void onData(T event),
+      {Function onError, void onDone(), bool cancelOnError}) {
+    controller = new StreamController<T>(
+        sync: true,
+        onListen: retry,
+        onPause: ([Future<dynamic> resumeSignal]) =>
+            subscription.pause(resumeSignal),
+        onResume: () => subscription.resume(),
+        onCancel: () => subscription.cancel());
+
+    return controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  void retry() {
+    bool errorOccurred = false;
+
+    subscription = streamFactory().listen((T data) {
+      controller.add(data);
+    }, onError: (dynamic e, dynamic s) {
+      errorOccurred = true;
+
+      if (count == retryStep) {
+        controller.addError(new RetryError(count));
+      } else {
+        subscription.cancel();
+        retryStep++;
+        retry();
+      }
+    }, onDone: () {
+      if (!errorOccurred) {
+        controller.close();
+      }
+    }, cancelOnError: false);
+  }
+}
+
+class RetryError extends Error {
+  final String message;
+
+  RetryError(int count)
+      : message = 'Received an error after attempting $count retries';
+
+  @override
+  String toString() => message;
+}

--- a/lib/src/streams/retry.dart
+++ b/lib/src/streams/retry.dart
@@ -46,25 +46,19 @@ class RetryStream<T> extends Stream<T> {
   }
 
   void retry() {
-    bool errorOccurred = false;
-
     subscription = streamFactory().listen((T data) {
       controller.add(data);
     }, onError: (dynamic e, dynamic s) {
-      errorOccurred = true;
+      subscription.cancel();
 
       if (count == retryStep) {
         controller.addError(new RetryError(count));
+        controller.close();
       } else {
-        subscription.cancel();
         retryStep++;
         retry();
       }
-    }, onDone: () {
-      if (!errorOccurred) {
-        controller.close();
-      }
-    }, cancelOnError: false);
+    }, onDone: controller.close, cancelOnError: false);
   }
 }
 

--- a/lib/src/streams/retry.dart
+++ b/lib/src/streams/retry.dart
@@ -24,15 +24,18 @@ class RetryStream<T> extends Stream<T> {
   final StreamFactory<T> streamFactory;
   int count;
   int retryStep = 0;
-  bool shouldClose = false;
   StreamController<T> controller;
   StreamSubscription<T> subscription;
+  bool _isUsed = false;
 
   RetryStream(this.streamFactory, [this.count]);
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
+    if (_isUsed) throw new StateError("Stream has already been listened to.");
+    _isUsed = true;
+
     controller = new StreamController<T>(
         sync: true,
         onListen: retry,

--- a/lib/src/streams/utils.dart
+++ b/lib/src/streams/utils.dart
@@ -1,0 +1,3 @@
+import 'dart:async';
+
+typedef Stream<T> StreamFactory<T>();

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -15,6 +15,7 @@ import 'streams/merge_test.dart' as merge_test;
 import 'streams/never_test.dart' as never_test;
 import 'streams/periodic_test.dart' as periodic_test;
 import 'streams/range_test.dart' as range_test;
+import 'streams/retry_test.dart' as retry_test;
 import 'streams/stream_test.dart' as stream_test;
 import 'streams/timer_test.dart' as timer_test;
 import 'streams/tween_test.dart' as tween_test;
@@ -104,6 +105,7 @@ void main() {
   never_test.main();
   periodic_test.main();
   range_test.main();
+  retry_test.main();
   stream_test.main();
   zip_test.main();
 

--- a/test/streams/defer_test.dart
+++ b/test/streams/defer_test.dart
@@ -28,6 +28,17 @@ void main() {
     }, count: 1));
   });
 
+  test('rx.Observable.defer.single.subscription', () async {
+    Stream<int> observable = _getDeferStream();
+
+    try {
+      observable.listen((_) {});
+      observable.listen((_) {});
+    } catch (e) {
+      await expect(e, isStateError);
+    }
+  });
+
   test('rx.Observable.defer.error.shouldThrow', () async {
     Stream<int> observableWithError =
         new Observable<int>.defer(() => _getErroneousStream());

--- a/test/streams/retry_test.dart
+++ b/test/streams/retry_test.dart
@@ -39,6 +39,19 @@ void main() {
         emitsInOrder(<dynamic>[1, 1, 1, 2, emitsDone]));
   });
 
+  test('RetryStream.single.subscription', () async {
+    int retries = 3;
+
+    Stream<int> stream = new RetryStream<int>(_getRetryStream(retries), retries);
+
+    try {
+      stream.listen((_) {});
+      stream.listen((_) {});
+    } catch(e) {
+      await expect(e, isStateError);
+    }
+  });
+
   test('RetryStream.asBroadcastStream', () async {
     int retries = 3;
 
@@ -84,7 +97,7 @@ StreamFactory<int> _getRetryStream(int failCount) {
   return () {
     if (count < failCount) {
       count++;
-      return new Observable<int>.error(new Error());
+      return new ErrorStream<int>(new Error());
     } else {
       return new Observable<int>.just(1);
     }
@@ -101,7 +114,7 @@ StreamFactory<int> _getStreamWithExtras(int failCount) {
       // Emit first item
       return new Observable<int>.just(1)
           // Emit the error
-          .concatWith(<Stream<int>>[new Observable<int>.error(new Error())])
+          .concatWith(<Stream<int>>[new ErrorStream<int>(new Error())])
           // Emit an extra item, testing that it is not included
           .concatWith(<Stream<int>>[new Observable<int>.just(1)]);
     } else {

--- a/test/streams/retry_test.dart
+++ b/test/streams/retry_test.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:rxdart/src/streams/retry.dart';
+import 'package:rxdart/src/streams/utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('rx.Observable.retry', () async {
+    final int retries = 3;
+
+    await expect(
+        new Observable<int>.retry(_getRetryStream(retries), retries), emits(1));
+  });
+
+  test('RetryStream', () async {
+    final int retries = 3;
+
+    await expect(
+        new RetryStream<int>(_getRetryStream(retries), retries), emits(1));
+  });
+
+  test('RetryStream.onDone', () async {
+    final int retries = 3;
+
+    await expect(new RetryStream<int>(_getRetryStream(retries), retries),
+        emitsInOrder(<Matcher>[equals(1), emitsDone]));
+  });
+
+  test('RetryStream.infinite.retries', () async {
+    await expect(new RetryStream<int>(_getRetryStream(1000)), emits(1));
+  });
+
+  test('RetryStream.emits.original.items', () async {
+    final int retries = 3;
+
+    await expect(new RetryStream<int>(_getStreamWithExtras(retries), retries),
+        emitsInOrder(<int>[1, 1, 1, 2]));
+  });
+
+  test('RetryStream.asBroadcastStream', () async {
+    int retries = 3;
+
+    Stream<int> stream = new RetryStream<int>(_getRetryStream(retries), retries)
+        .asBroadcastStream();
+
+    // listen twice on same stream
+    stream.listen((_) {});
+    stream.listen((_) {});
+    // code should reach here
+    await expect(stream.isBroadcast, isTrue);
+  });
+
+  test('RetryStream.error.shouldThrow', () async {
+    Stream<int> observableWithError =
+        new RetryStream<int>(_getRetryStream(3), 2);
+
+    observableWithError.listen(null, onError: (dynamic e, dynamic s) {
+      expect(e is RetryError, isTrue);
+    });
+  });
+
+  test('RetryStream.pause.resume', () async {
+    StreamSubscription<int> subscription;
+    int retries = 3;
+
+    subscription = new RetryStream<int>(_getRetryStream(retries), retries)
+        .listen(expectAsync1((int result) {
+      expect(result, 1);
+
+      subscription.cancel();
+    }));
+
+    subscription.pause();
+    subscription.resume();
+  });
+}
+
+StreamFactory<int> _getRetryStream(int failCount) {
+  int count = 0;
+
+  return () {
+    if (count < failCount) {
+      count++;
+      return new Observable<int>.error(new Error());
+    } else {
+      return new Observable<int>.just(1);
+    }
+  };
+}
+
+StreamFactory<int> _getStreamWithExtras(int failCount) {
+  int count = 0;
+
+  return () {
+    if (count < failCount) {
+      count++;
+
+      // Emit first item
+      return new Observable<int>.just(1)
+          // Emit the error
+          .concatWith(<Stream<int>>[new Observable<int>.error(new Error())])
+          // Emit an extra item, testing that it is not included
+          .concatWith(<Stream<int>>[new Observable<int>.just(1)]);
+    } else {
+      return new Observable<int>.just(2);
+    }
+  };
+}

--- a/test/streams/retry_test.dart
+++ b/test/streams/retry_test.dart
@@ -9,33 +9,34 @@ void main() {
   test('rx.Observable.retry', () async {
     final int retries = 3;
 
-    await expect(
-        new Observable<int>.retry(_getRetryStream(retries), retries), emits(1));
+    await expect(new Observable<int>.retry(_getRetryStream(retries), retries),
+        emitsInOrder(<dynamic>[1, emitsDone]));
   });
 
   test('RetryStream', () async {
     final int retries = 3;
 
-    await expect(
-        new RetryStream<int>(_getRetryStream(retries), retries), emits(1));
+    await expect(new RetryStream<int>(_getRetryStream(retries), retries),
+        emitsInOrder(<dynamic>[1, emitsDone]));
   });
 
   test('RetryStream.onDone', () async {
     final int retries = 3;
 
     await expect(new RetryStream<int>(_getRetryStream(retries), retries),
-        emitsInOrder(<Matcher>[equals(1), emitsDone]));
+        emitsInOrder(<dynamic>[1, emitsDone]));
   });
 
   test('RetryStream.infinite.retries', () async {
-    await expect(new RetryStream<int>(_getRetryStream(1000)), emits(1));
+    await expect(new RetryStream<int>(_getRetryStream(1000)),
+        emitsInOrder(<dynamic>[1, emitsDone]));
   });
 
   test('RetryStream.emits.original.items', () async {
     final int retries = 3;
 
     await expect(new RetryStream<int>(_getStreamWithExtras(retries), retries),
-        emitsInOrder(<int>[1, 1, 1, 2]));
+        emitsInOrder(<dynamic>[1, 1, 1, 2, emitsDone]));
   });
 
   test('RetryStream.asBroadcastStream', () async {
@@ -55,9 +56,10 @@ void main() {
     Stream<int> observableWithError =
         new RetryStream<int>(_getRetryStream(3), 2);
 
-    observableWithError.listen(null, onError: (dynamic e, dynamic s) {
-      expect(e is RetryError, isTrue);
-    });
+    await expect(
+        observableWithError,
+        emitsInOrder(
+            <Matcher>[emitsError(new isInstanceOf<RetryError>()), emitsDone]));
   });
 
   test('RetryStream.pause.resume', () async {


### PR DESCRIPTION
Fixes #69 

This is another attempt to fix retry. It is a Stream / Observable factory method that takes in a `streamFactory` and `count`. It then builds a stream from the factory, listens, and rebuilds / relistens the stream if an error occurrs.

I've tried to pay careful attention to the implementation, but as always, I'm sure I missed something :)

@frankpepermans  & @lestathc -- please have a look and let me know what you think!

-- 

p.s. the last version of this pr got closed due to a falty rebase, and I had to reopen another PR.