### PR TITLE
Ensure all Streams are single-subscription

### DIFF
--- a/lib/src/streams/amb.dart
+++ b/lib/src/streams/amb.dart
@@ -1,17 +1,24 @@
 import 'dart:async';
 
 class AmbStream<T> extends Stream<T> {
-  final Iterable<Stream<T>> streams;
+  final StreamController<T> controller;
 
-  AmbStream(this.streams);
+  AmbStream(Iterable<Stream<T>> streams)
+      : controller = _buildController(streams);
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
+    return controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     final List<StreamSubscription<T>> subscriptions =
         new List<StreamSubscription<T>>(streams.length);
-    StreamController<T> controller;
     bool isDisambiguated = false;
+
+    StreamController<T> controller;
 
     controller = new StreamController<T>(
         sync: true,
@@ -44,7 +51,6 @@ class AmbStream<T> extends Stream<T> {
               return new Future<dynamic>.value();
             }).where((Future<dynamic> cancelFuture) => cancelFuture != null)));
 
-    return controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    return controller;
   }
 }

--- a/lib/src/streams/concat.dart
+++ b/lib/src/streams/concat.dart
@@ -1,13 +1,19 @@
 import 'dart:async';
 
 class ConcatStream<T> extends Stream<T> {
-  final Iterable<Stream<T>> streams;
+  final StreamController<T> controller;
 
-  ConcatStream(this.streams);
+  ConcatStream(Iterable<Stream<T>> streams)
+      : controller = _buildController(streams);
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
+    return controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     StreamController<T> controller;
     StreamSubscription<T> subscription;
 
@@ -36,7 +42,6 @@ class ConcatStream<T> extends Stream<T> {
         },
         onCancel: () => subscription.cancel());
 
-    return controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    return controller;
   }
 }

--- a/lib/src/streams/concat_eager.dart
+++ b/lib/src/streams/concat_eager.dart
@@ -1,13 +1,19 @@
 import 'dart:async';
 
 class ConcatEagerStream<T> extends Stream<T> {
-  final Iterable<Stream<T>> streams;
+  final StreamController<T> controller;
 
-  ConcatEagerStream(this.streams);
+  ConcatEagerStream(Iterable<Stream<T>> streams)
+      : controller = _buildController(streams);
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
+    return controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     final List<StreamSubscription<T>> subscriptions =
         new List<StreamSubscription<T>>(streams.length);
     final List<Completer<dynamic>> completeEvents =
@@ -34,7 +40,6 @@ class ConcatEagerStream<T> extends Stream<T> {
             .map((StreamSubscription<T> subscription) => subscription.cancel())
             .where((Future<dynamic> cancelFuture) => cancelFuture != null)));
 
-    return controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    return controller;
   }
 }

--- a/lib/src/streams/error.dart
+++ b/lib/src/streams/error.dart
@@ -11,15 +11,13 @@ import 'dart:async';
 ///     new ErrorStream(new ArgumentError());
 class ErrorStream<T> extends Stream<T> {
   final Object error;
+  StreamController<T> controller = new StreamController<T>();
 
   ErrorStream(this.error);
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    // ignore: close_sinks
-    StreamController<T> controller = new StreamController<T>();
-
     controller.addError(error);
 
     controller.close();

--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -1,13 +1,19 @@
 import 'dart:async';
 
 class MergeStream<T> extends Stream<T> {
-  final Iterable<Stream<T>> streams;
+  final StreamController<T> controller;
 
-  MergeStream(this.streams);
+  MergeStream(Iterable<Stream<T>> streams)
+      : controller = _buildController(streams);
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
+    return controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     final List<StreamSubscription<T>> subscriptions =
         new List<StreamSubscription<T>>(streams.length);
     StreamController<T> controller;
@@ -32,7 +38,6 @@ class MergeStream<T> extends Stream<T> {
             .map((StreamSubscription<T> subscription) => subscription.cancel())
             .where((Future<dynamic> cancelFuture) => cancelFuture != null)));
 
-    return controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    return controller;
   }
 }

--- a/lib/src/streams/never.dart
+++ b/lib/src/streams/never.dart
@@ -8,14 +8,14 @@ import 'dart:async';
 /// other Observables or as parameters to operators that expect other
 /// Observables as parameters.
 class NeverStream<T> extends Stream<T> {
+  // ignore: close_sinks
+  StreamController<T> controller = new StreamController<T>();
+
   NeverStream();
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    // ignore: close_sinks
-    StreamController<T> controller = new StreamController<T>();
-
     return controller.stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }

--- a/lib/src/streams/timer.dart
+++ b/lib/src/streams/timer.dart
@@ -9,20 +9,21 @@ import 'dart:async';
 class TimerStream<T> extends Stream<T> {
   final T value;
   final Duration duration;
+  final StreamController<T> controller = new StreamController<T>();
 
   TimerStream(this.value, this.duration);
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    StreamController<T> controller = new StreamController<T>();
+    StreamSubscription<T> subscription = controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
     new Timer(duration, () {
       controller.add(value);
       controller.close();
     });
 
-    return controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    return subscription;
   }
 }

--- a/test/streams/amb_test.dart
+++ b/test/streams/amb_test.dart
@@ -29,6 +29,15 @@ void main() {
     }, count: 3));
   });
 
+  test('rx.Observable.amb.single.subscription', () async {
+    final Stream<num> first = getDelayedStream(50, 1);
+
+    Observable<num> observable = new Observable<num>.amb(<Stream<num>>[first]);
+
+    observable.listen((_) {});
+    await expect(() => observable.listen((_) {}), throwsA(isStateError));
+  });
+
   test('rx.Observable.amb.asBroadcastStream', () async {
     final Stream<num> first = getDelayedStream(50, 1);
     final Stream<num> second = getDelayedStream(60, 2);

--- a/test/streams/combine_latest_test.dart
+++ b/test/streams/combine_latest_test.dart
@@ -35,6 +35,16 @@ void main() {
     }, count: 3));
   });
 
+  test('rx.Observable.combineLatest3.single.subscription', () async {
+    Stream<String> observable = Observable.combineLatest3(
+        streamA, streamB, streamC, (int a_value, int b_value, bool c_value) {
+      return '$a_value $b_value $c_value';
+    });
+
+    observable.listen((_) {});
+    await expect(() => observable.listen((_) {}), throwsA(isStateError));
+  });
+
   test('rx.Observable.combineLatest2', () async {
     final List<List<int>> expected = <List<int>>[
       <int>[1, 2],

--- a/test/streams/concat_eager_test.dart
+++ b/test/streams/concat_eager_test.dart
@@ -31,6 +31,13 @@ void main() {
     }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.concatEager.single.subscription', () async {
+    Stream<num> observable = new Observable<num>.concatEager(_getStreams());
+
+    observable.listen((_) {});
+    await expect(() => observable.listen((_) {}), throwsA(isStateError));
+  });
+
   test('rx.Observable.concatEager.withEmptyStream', () async {
     const List<num> expectedOutput = const <num>[0, 1, 2, 3, 4, 5];
     int count = 0;

--- a/test/streams/concat_test.dart
+++ b/test/streams/concat_test.dart
@@ -31,6 +31,13 @@ void main() {
     }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.concatEager.single.subscription', () async {
+    Stream<num> observable = new Observable<num>.concat(_getStreams());
+
+    observable.listen((_) {});
+    await expect(() => observable.listen((_) {}), throwsA(isStateError));
+  });
+
   test('rx.Observable.concat.withEmptyStream', () async {
     const List<num> expectedOutput = const <num>[0, 1, 2, 3, 4, 5];
     int count = 0;

--- a/test/streams/error_test.dart
+++ b/test/streams/error_test.dart
@@ -6,36 +6,35 @@ import 'package:rxdart/rxdart.dart';
 
 void main() {
   test('ErrorStream', () async {
-    bool onDataCalled = false;
     Stream<int> stream = new ErrorStream<int>(new Exception());
 
-    stream.listen(
-        expectAsync1((int actual) {
-          onDataCalled = true;
-        }, count: 0),
-        onError: expectAsync2((dynamic e, dynamic s) {
-          expect(e, isException);
-        }, count: 1),
-        onDone: expectAsync0(() {
-          expect(true, true);
-          expect(onDataCalled, isFalse);
-        }, count: 1));
+    await expect(
+        stream,
+        emitsInOrder(<Matcher>[
+          neverEmits(anything),
+          emitsError(isException),
+          emitsDone
+        ]));
+  });
+
+  test('ErrorStream.single.subscription', () async {
+    Stream<int> stream = new ErrorStream<int>(new Exception());
+
+    stream.listen((_) {}, onError: (dynamic e, dynamic s) {});
+    await expect(
+        () => stream.listen((_) {}, onError: (dynamic e, dynamic s) {}),
+        throwsA(isStateError));
   });
 
   test('rx.Observable.error', () async {
-    bool onDataCalled = false;
     Observable<int> observable = new Observable<int>.error(new Exception());
 
-    observable.listen(
-        expectAsync1((int actual) {
-          onDataCalled = true;
-        }, count: 0),
-        onError: expectAsync2((dynamic e, dynamic s) {
-          expect(e, isException);
-        }, count: 1),
-        onDone: expectAsync0(() {
-          expect(true, true);
-          expect(onDataCalled, isFalse);
-        }, count: 1));
+    await expect(
+        observable,
+        emitsInOrder(<Matcher>[
+          neverEmits(anything),
+          emitsError(isException),
+          emitsDone
+        ]));
   });
 }

--- a/test/streams/merge_test.dart
+++ b/test/streams/merge_test.dart
@@ -13,15 +13,16 @@ List<Stream<num>> _getStreams() {
 
 void main() {
   test('rx.Observable.merge', () async {
-    const List<num> expectedOutput = const <num>[1, 2, 3, 4, 0, 1, 2];
-    int count = 0;
-
     Stream<num> observable = new Observable<num>.merge(_getStreams());
 
-    observable.listen(expectAsync1((num result) {
-      // test to see if the combined output matches
-      expect(result, expectedOutput[count++]);
-    }, count: expectedOutput.length));
+    await expect(observable, emitsInOrder(<num>[1, 2, 3, 4, 0, 1, 2]));
+  });
+
+  test('rx.Observable.merge.single.subscription', () async {
+    Stream<num> observable = new Observable<num>.merge(_getStreams());
+
+    observable.listen((_) {});
+    await expect(() => observable.listen((_) {}), throwsA(isStateError));
   });
 
   test('rx.Observable.merge.asBroadcastStream', () async {

--- a/test/streams/never_test.dart
+++ b/test/streams/never_test.dart
@@ -34,6 +34,13 @@ void main() {
     await expect(onErrorCalled, isFalse);
   });
 
+  test('NeverStream.single.subscription', () async {
+    final NeverStream<int> stream = new NeverStream<int>();
+
+    stream.listen((_) {});
+    await expect(() => stream.listen((_) {}), throwsA(isStateError));
+  });
+
   test('rx.Observable.never', () async {
     bool onDataCalled = false;
     bool onDoneCalled = false;

--- a/test/streams/range_test.dart
+++ b/test/streams/range_test.dart
@@ -15,6 +15,13 @@ void main() {
     }, count: expected.length));
   });
 
+  test('RangeStream.single.subscription', () async {
+    final RangeStream stream = new RangeStream(1, 5);
+
+    stream.listen((_) {});
+    await expect(() => stream.listen((_) {}), throwsA(isStateError));
+  });
+
   test('RangeStream.single', () async {
     Stream<int> stream = new RangeStream(1, 1);
 

--- a/test/streams/timer_test.dart
+++ b/test/streams/timer_test.dart
@@ -10,11 +10,15 @@ void main() {
     Stream<int> stream =
         new TimerStream<int>(value, new Duration(milliseconds: 1));
 
-    stream.listen(expectAsync1((int actual) {
-      expect(actual, value);
-    }), onDone: expectAsync0(() {
-      expect(true, isTrue);
-    }));
+    await expect(stream, emitsInOrder(<dynamic>[value, emitsDone]));
+  });
+
+  test('TimerStream.single.subscription', () async {
+    Stream<int> stream =
+    new TimerStream<int>(1, new Duration(milliseconds: 1));
+
+    stream.listen((_) {});
+    await expect(() => stream.listen((_) {}), throwsA(isStateError));
   });
 
   test('TimerStream.pause.resume', () async {

--- a/test/streams/tween_test.dart
+++ b/test/streams/tween_test.dart
@@ -131,6 +131,14 @@ void main() {
         }, count: expectedValues.length));
   });
 
+  test('rx.Observable.tween.single.subscription', () async {
+    Observable<double> observable = Observable
+        .tween(0.0, 100.0, const Duration(seconds: 2), intervalMs: 20);
+
+    observable.listen((_) {});
+    await expect(() => observable.listen((_) {}), throwsA(isStateError));
+  });
+
   test('rx.Observable.tween.asBroadcast', () async {
     Observable<double> observable = Observable
         .tween(0.0, 100.0, const Duration(seconds: 2), intervalMs: 20)

--- a/test/streams/zip_test.dart
+++ b/test/streams/zip_test.dart
@@ -244,6 +244,14 @@ void main() {
     }));
   });
 
+  test('rx.Observable.zip.single.subscription', () async {
+    Observable<int> observable = Observable.zip2(new Observable<int>.just(1),
+        new Observable<int>.just(1), (int a, int b) => a + b);
+
+    observable.listen((_) {});
+    await expect(() => observable.listen((_) {}), throwsA(isStateError));
+  });
+
   test('rx.Observable.zip.asBroadcastStream', () async {
     StreamController<bool> testStream = new StreamController<bool>()
       ..add(true)


### PR DESCRIPTION
### Problem

Our streams were not properly enforcing the single-subscription contract.

Many of our streams were "safe" from this bug due to the fact that they wrapped streams that threw a single-subscription error, but our streams did not explicitly fail on re-subscribe.

### Solution

Instead of re-creating the controller in `onListen` every time, therefore creating a fresh stream on every listen, we simply need to build the controller only once up front. That way, when the controller's stream is listened to a second time, it will be the same `stream` as the first attempt, and throw the appropriate error.

Please check it out and let me know whatcha think @frankpepermans  and @lestathc