### PR TITLE
added tests for Transformer reusability (same instance), fixed transf…

### DIFF
--- a/lib/src/transformers/buffer_with_count.dart
+++ b/lib/src/transformers/buffer_with_count.dart
@@ -2,13 +2,14 @@ import 'dart:async';
 
 class BufferWithCountStreamTransformer<T, S extends List<T>>
     implements StreamTransformer<T, S> {
-  final StreamTransformer<T, S> transformer;
+  final int count;
+  final int skip;
 
-  BufferWithCountStreamTransformer(int count, [int skip])
-      : transformer = _buildTransformer(count, skip);
+  BufferWithCountStreamTransformer(this.count, [this.skip]);
 
   @override
-  Stream<S> bind(Stream<T> stream) => transformer.bind(stream);
+  Stream<S> bind(Stream<T> stream) =>
+      _buildTransformer<T, S>(count, skip).bind(stream);
 
   static StreamTransformer<T, S> _buildTransformer<T, S extends List<T>>(
       int count,

--- a/lib/src/transformers/debounce.dart
+++ b/lib/src/transformers/debounce.dart
@@ -10,12 +10,11 @@ class DebounceStreamTransformer<T> implements StreamTransformer<T, T> {
   Stream<T> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, T> _buildTransformer<T>(Duration duration) {
-    bool _closeAfterNextEvent = false;
-    Timer _timer;
-
     return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
+      bool _closeAfterNextEvent = false;
+      Timer _timer;
       bool streamHasEvent = false;
 
       controller = new StreamController<T>(

--- a/lib/src/transformers/max.dart
+++ b/lib/src/transformers/max.dart
@@ -1,15 +1,14 @@
 import 'dart:async';
 
-class MaxStreamTransformer<T> implements StreamTransformer<T, T> {
-  final StreamTransformer<T, T> transformer;
+typedef int _MaxStreamTransformerCompare<T>(T a, T b);
 
-  MaxStreamTransformer([int compare(T a, T b), bool sync])
-      : transformer = _buildTransformer(compare);
+class MaxStreamTransformer<T> implements StreamTransformer<T, T> {
+  final _MaxStreamTransformerCompare<T> compare;
+
+  MaxStreamTransformer([this.compare]);
 
   @override
-  Stream<T> bind(Stream<T> stream) {
-    return transformer.bind(stream);
-  }
+  Stream<T> bind(Stream<T> stream) => _buildTransformer<T>(compare).bind(stream);
 
   static StreamTransformer<T, T> _buildTransformer<T>([int compare(T a, T b)]) {
     T _currentMax;

--- a/lib/src/transformers/min.dart
+++ b/lib/src/transformers/min.dart
@@ -1,13 +1,14 @@
 import 'dart:async';
 
-class MinStreamTransformer<T> implements StreamTransformer<T, T> {
-  final StreamTransformer<T, T> transformer;
+typedef int _MinStreamTransformerCompare<T>(T a, T b);
 
-  MinStreamTransformer([int compare(T a, T b)])
-      : transformer = _buildTransformer(compare);
+class MinStreamTransformer<T> implements StreamTransformer<T, T> {
+  final _MinStreamTransformerCompare<T> compare;
+
+  MinStreamTransformer([this.compare]);
 
   @override
-  Stream<T> bind(Stream<T> stream) => transformer.bind(stream);
+  Stream<T> bind(Stream<T> stream) => _buildTransformer<T>(compare).bind(stream);
 
   static StreamTransformer<T, T> _buildTransformer<T>([int compare(T a, T b)]) {
     T _currentMin;

--- a/lib/src/transformers/on_error_resume_next.dart
+++ b/lib/src/transformers/on_error_resume_next.dart
@@ -11,18 +11,17 @@ class OnErrorResumeNextStreamTransformer<T> implements StreamTransformer<T, T> {
 
   static StreamTransformer<T, T> _buildTransformer<T>(
       Stream<T> recoveryStream) {
-    StreamController<T> controller;
-    bool shouldCloseController = true;
-
-    void safeClose() {
-      if (shouldCloseController) {
-        controller.close();
-      }
-    }
-
     return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamSubscription<T> inputSubscription;
       StreamSubscription<T> recoverySubscription;
+      StreamController<T> controller;
+      bool shouldCloseController = true;
+
+      void safeClose() {
+        if (shouldCloseController) {
+          controller.close();
+        }
+      }
 
       controller = new StreamController<T>(
           sync: true,

--- a/lib/src/transformers/scan.dart
+++ b/lib/src/transformers/scan.dart
@@ -1,14 +1,17 @@
 import 'dart:async';
 
-class ScanStreamTransformer<T, S> implements StreamTransformer<T, S> {
-  final StreamTransformer<T, S> transformer;
+typedef S _ScanStreamTransformerPredicate<T, S>(
+    S accumulated, T value, int index);
 
-  ScanStreamTransformer(S predicate(S accumulated, T value, int index),
-      [S seed])
-      : transformer = _buildTransformer(predicate, seed);
+class ScanStreamTransformer<T, S> implements StreamTransformer<T, S> {
+  final _ScanStreamTransformerPredicate<T, S> predicate;
+  final S seed;
+
+  ScanStreamTransformer(this.predicate, [this.seed]);
 
   @override
-  Stream<S> bind(Stream<T> stream) => transformer.bind(stream);
+  Stream<S> bind(Stream<T> stream) =>
+      _buildTransformer<T, S>(predicate, seed).bind(stream);
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
       S predicate(S accumulated, T value, int index),

--- a/lib/src/transformers/throttle.dart
+++ b/lib/src/transformers/throttle.dart
@@ -10,12 +10,11 @@ class ThrottleStreamTransformer<T> implements StreamTransformer<T, T> {
   Stream<T> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, T> _buildTransformer<T>(Duration duration) {
-    Timer _timer;
-    bool _closeAfterNextEvent = false;
-
     return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
+      Timer _timer;
+      bool _closeAfterNextEvent = false;
 
       bool _resetTimer() {
         if (_timer != null && _timer.isActive) return false;

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -18,6 +18,7 @@ export 'package:rxdart/src/transformers/on_error_resume_next.dart';
 export 'package:rxdart/src/transformers/repeat.dart';
 export 'package:rxdart/src/transformers/sample.dart';
 export 'package:rxdart/src/transformers/scan.dart';
+export 'package:rxdart/src/transformers/skip_until.dart';
 export 'package:rxdart/src/transformers/start_with.dart';
 export 'package:rxdart/src/transformers/start_with_many.dart';
 export 'package:rxdart/src/transformers/switch_if_empty.dart';

--- a/test/transformers/buffer_with_count_test.dart
+++ b/test/transformers/buffer_with_count_test.dart
@@ -23,6 +23,38 @@ void main() {
     }, count: 2));
   });
 
+  test('rx.Observable.bufferWithCount.reusable', () async {
+    final BufferWithCountStreamTransformer<int, List<int>> transformer =
+        new BufferWithCountStreamTransformer<int, List<int>>(2);
+    const List<List<int>> expectedOutput = const <List<int>>[
+      const <int>[1, 2],
+      const <int>[3, 4]
+    ];
+    int countA = 0, countB = 0;
+
+    Stream<List<int>> streamA =
+        new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
+            .transform(transformer);
+
+    streamA.listen(expectAsync1((List<int> result) {
+      // test to see if the combined output matches
+      expect(expectedOutput[countA][0], result[0]);
+      expect(expectedOutput[countA][1], result[1]);
+      countA++;
+    }, count: 2));
+
+    Stream<List<int>> streamB =
+        new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
+            .transform(transformer);
+
+    streamB.listen(expectAsync1((List<int> result) {
+      // test to see if the combined output matches
+      expect(expectedOutput[countB][0], result[0]);
+      expect(expectedOutput[countB][1], result[1]);
+      countB++;
+    }, count: 2));
+  });
+
   test('rx.Observable.bufferWithCount.skip', () async {
     const List<List<int>> expectedOutput = const <List<int>>[
       const <int>[1, 2],

--- a/test/transformers/call_test.dart
+++ b/test/transformers/call_test.dart
@@ -51,6 +51,24 @@ void main() {
     }));
   });
 
+  test('rx.Observable.call.reusable', () async {
+    bool onDataCalled = false;
+    final CallStreamTransformer<int> transformer =
+        new CallStreamTransformer<int>(onData: (_) {
+      onDataCalled = true;
+    });
+    final Observable<int> observableA = new Observable<int>.just(1);
+    final Observable<int> observableB = new Observable<int>.just(1);
+
+    observableA.transform(transformer).listen((_) {}, onDone: expectAsync0(() {
+      expect(onDataCalled, isTrue);
+    }));
+
+    observableB.transform(transformer).listen((_) {}, onDone: expectAsync0(() {
+      expect(onDataCalled, isTrue);
+    }));
+  });
+
   test('rx.Observable.call.onDone', () async {
     final Observable<int> observable = new Observable<int>.just(1);
 

--- a/test/transformers/concat_map_test.dart
+++ b/test/transformers/concat_map_test.dart
@@ -16,6 +16,26 @@ void main() {
     }));
   });
 
+  test('rx.Observable.concatMap.reusable', () async {
+    final ConcatMapStreamTransformer<int, int> transformer = new ConcatMapStreamTransformer<int, int>(_getOtherStream);
+    const List<int> expectedOutput = const <int>[1, 1, 2, 2, 3, 3];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream()).transform(transformer).listen(
+        expectAsync1((int result) {
+          expect(result, expectedOutput[countA++]);
+        }, count: expectedOutput.length), onDone: expectAsync0(() {
+      expect(true, true);
+    }));
+
+    new Observable<int>(_getStream()).transform(transformer).listen(
+        expectAsync1((int result) {
+          expect(result, expectedOutput[countB++]);
+        }, count: expectedOutput.length), onDone: expectAsync0(() {
+      expect(true, true);
+    }));
+  });
+
   test('rx.Observable.concatMap.asBroadcastStream', () async {
     Stream<num> stream = new Observable<int>(_getStream())
         .concatMap(_getOtherStream)
@@ -29,8 +49,8 @@ void main() {
   });
 
   test('rx.Observable.concatMap.error.shouldThrow', () async {
-    Stream<num> observableWithError =
-        new Observable<num>(new ErrorStream<num>(new Exception()))
+    Stream<int> observableWithError =
+        new Observable<int>(new ErrorStream<int>(new Exception()))
             .concatMap(_getOtherStream);
 
     observableWithError.listen(null, onError: (dynamic e, dynamic s) {
@@ -55,9 +75,9 @@ void main() {
   });
 
   test('rx.Observable.concatMap.cancel', () async {
-    StreamSubscription<num> subscription;
-    Observable<num> stream =
-        new Observable<num>(_getStream()).concatMap(_getOtherStream);
+    StreamSubscription<int> subscription;
+    Observable<int> stream =
+        new Observable<int>(_getStream()).concatMap(_getOtherStream);
 
     // Cancel the subscription before any events come through
     subscription = stream.listen(
@@ -81,8 +101,8 @@ Stream<int> _getStream() {
   return new Stream<int>.fromIterable(<int>[1, 2, 3]);
 }
 
-Stream<num> _getOtherStream(num value) {
-  StreamController<num> controller = new StreamController<num>();
+Stream<int> _getOtherStream(int value) {
+  StreamController<int> controller = new StreamController<int>();
 
   new Timer(
       // Reverses the order of 1, 2, 3 to 3, 2, 1 by delaying 1, and 2 longer

--- a/test/transformers/debounce_test.dart
+++ b/test/transformers/debounce_test.dart
@@ -26,6 +26,23 @@ void main() {
         }, count: 1));
   });
 
+  test('rx.Observable.debounce.reusable', () async {
+    final DebounceStreamTransformer<int> transformer =
+        new DebounceStreamTransformer<int>(const Duration(milliseconds: 200));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(result, 4);
+        }, count: 1));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(result, 4);
+        }, count: 1));
+  });
+
   test('rx.Observable.debounce.asBroadcastStream', () async {
     Stream<int> stream = new Observable<int>(_getStream().asBroadcastStream())
         .debounce(const Duration(milliseconds: 200));

--- a/test/transformers/default_if_empty_test.dart
+++ b/test/transformers/default_if_empty_test.dart
@@ -12,6 +12,23 @@ void main() {
         }, count: 1));
   });
 
+  test('rx.Observable.defaultIfEmpty.reusable', () async {
+    final DefaultIfEmptyStreamTransformer<bool> transformer =
+        new DefaultIfEmptyStreamTransformer<bool>(true);
+
+    new Observable<bool>(new Stream<bool>.empty())
+        .transform(transformer)
+        .listen(expectAsync1((bool result) {
+          expect(result, true);
+        }, count: 1));
+
+    new Observable<bool>(new Stream<bool>.empty())
+        .transform(transformer)
+        .listen(expectAsync1((bool result) {
+          expect(result, true);
+        }, count: 1));
+  });
+
   test('rx.Observable.defaultIfEmpty.whenNotEmpty', () async {
     new Observable<bool>(
             new Stream<bool>.fromIterable(const <bool>[false, false, false]))

--- a/test/transformers/dematerialize_test.dart
+++ b/test/transformers/dematerialize_test.dart
@@ -17,6 +17,30 @@ void main() {
     }));
   });
 
+  test('rx.Observable.dematerialize.reusable', () async {
+    final DematerializeStreamTransformer<int> transformer =
+        new DematerializeStreamTransformer<int>();
+    final int expectedValue = 1;
+    final Observable<Notification<int>> observableA =
+        new Observable<int>.just(1).materialize();
+    final Observable<Notification<int>> observableB =
+        new Observable<int>.just(1).materialize();
+
+    observableA.transform(transformer).listen(expectAsync1((int value) {
+      expect(value, expectedValue);
+    }), onDone: expectAsync0(() {
+      // Should call onDone
+      expect(true, isTrue);
+    }));
+
+    observableB.transform(transformer).listen(expectAsync1((int value) {
+      expect(value, expectedValue);
+    }), onDone: expectAsync0(() {
+      // Should call onDone
+      expect(true, isTrue);
+    }));
+  });
+
   test('dematerializeTransformer.happyPath', () async {
     final int expectedValue = 1;
     final Stream<Notification<int>> stream =

--- a/test/transformers/flat_map_test.dart
+++ b/test/transformers/flat_map_test.dart
@@ -7,8 +7,8 @@ Stream<int> _getStream() {
   return new Stream<int>.fromIterable(<int>[1, 2, 3]);
 }
 
-Stream<num> _getOtherStream(num value) {
-  StreamController<num> controller = new StreamController<num>();
+Stream<int> _getOtherStream(int value) {
+  StreamController<int> controller = new StreamController<int>();
 
   new Timer(
       // Reverses the order of 1, 2, 3 to 3, 2, 1 by delaying 1, and 2 longer
@@ -33,6 +33,25 @@ void main() {
         }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.flatMap.reusable', () async {
+    final FlatMapStreamTransformer<int, int> transformer =
+        new FlatMapStreamTransformer<int, int>(_getOtherStream);
+    const List<int> expectedOutput = const <int>[3, 2, 1];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((num result) {
+          expect(result, expectedOutput[countA++]);
+        }, count: expectedOutput.length));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((num result) {
+          expect(result, expectedOutput[countB++]);
+        }, count: expectedOutput.length));
+  });
+
   test('rx.Observable.flatMap.asBroadcastStream', () async {
     Stream<num> stream = new Observable<int>(_getStream().asBroadcastStream())
         .flatMap(_getOtherStream);
@@ -45,8 +64,8 @@ void main() {
   });
 
   test('rx.Observable.flatMap.error.shouldThrow', () async {
-    Stream<num> observableWithError =
-        new Observable<num>(new ErrorStream<num>(new Exception()))
+    Stream<int> observableWithError =
+        new Observable<int>(new ErrorStream<int>(new Exception()))
             .flatMap(_getOtherStream);
 
     observableWithError.listen(null, onError: (dynamic e, dynamic s) {

--- a/test/transformers/group_by_test.dart
+++ b/test/transformers/group_by_test.dart
@@ -3,21 +3,23 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:rxdart/rxdart.dart';
 
+Stream<Map<String, int>> getStream() {
+  return new Stream<Map<String, int>>.fromIterable(<Map<String, int>>[
+    <String, int>{'name': 1, 'value': 1},
+    <String, int>{'name': 2, 'value': 2},
+    <String, int>{'name': 3, 'value': 3},
+    <String, int>{'name': 1, 'value': 4},
+    <String, int>{'name': 2, 'value': 5}
+  ]);
+}
+
 void main() {
-  const List<String> expectedResults = const <String>['1: 2', '2: 2', '3: 1'];
-  int index = 0;
-
   test('rx.Observable.groupBy', () async {
+    const List<String> expectedResults = const <String>['1: 2', '2: 2', '3: 1'];
     StreamSubscription<String> subscription;
+    int index = 0;
 
-    subscription = new Observable<Map<String, int>>(
-            new Stream<Map<String, int>>.fromIterable(<Map<String, int>>[
-      <String, int>{'name': 1, 'value': 1},
-      <String, int>{'name': 2, 'value': 2},
-      <String, int>{'name': 3, 'value': 3},
-      <String, int>{'name': 1, 'value': 4},
-      <String, int>{'name': 2, 'value': 5}
-    ]))
+    subscription = new Observable<Map<String, int>>(getStream())
         .groupBy((Map<String, int> map) => map['name'])
         .flatMap((GroupByMap<int, Map<String, int>> groupByMap) async* {
       int len = await groupByMap.stream.length;
@@ -33,5 +35,42 @@ void main() {
 
     subscription.pause();
     subscription.resume();
+  });
+
+  test('rx.Observable.groupBy.reusable', () async {
+    final GroupByStreamTransformer<Map<String, int>, int> transformer =
+        new GroupByStreamTransformer<Map<String, int>, int>(
+            (Map<String, int> map) => map['name']);
+    const List<String> expectedResults = const <String>['1: 2', '2: 2', '3: 1'];
+    StreamSubscription<String> subscriptionA, subscriptionB;
+    int indexA = 0, indexB = 0;
+
+    subscriptionA = new Observable<Map<String, int>>(getStream())
+        .transform(transformer)
+        .flatMap((GroupByMap<int, Map<String, int>> groupByMap) async* {
+      int len = await groupByMap.stream.length;
+
+      yield '${groupByMap.key}: $len';
+    }).listen(expectAsync1((String result) {
+      expect(result, expectedResults[indexA++]);
+
+      if (indexA == expectedResults.length) {
+        subscriptionA.cancel();
+      }
+    }, count: 3));
+
+    subscriptionB = new Observable<Map<String, int>>(getStream())
+        .transform(transformer)
+        .flatMap((GroupByMap<int, Map<String, int>> groupByMap) async* {
+      int len = await groupByMap.stream.length;
+
+      yield '${groupByMap.key}: $len';
+    }).listen(expectAsync1((String result) {
+      expect(result, expectedResults[indexB++]);
+
+      if (indexB == expectedResults.length) {
+        subscriptionB.cancel();
+      }
+    }, count: 3));
   });
 }

--- a/test/transformers/ignore_elements_test.dart
+++ b/test/transformers/ignore_elements_test.dart
@@ -29,6 +29,26 @@ void main() {
         }, count: 1));
   });
 
+  test('rx.Observable.ignoreElements.reusable', () async {
+    final IgnoreElementsStreamTransformer<int> transformer =
+        new IgnoreElementsStreamTransformer<int>();
+    bool hasReceivedEvent = false;
+
+    new Observable<int>(_getStream()).transform(transformer).listen((_) {
+      hasReceivedEvent = true;
+    },
+        onDone: expectAsync0(() {
+          expect(hasReceivedEvent, isFalse);
+        }, count: 1));
+
+    new Observable<int>(_getStream()).transform(transformer).listen((_) {
+      hasReceivedEvent = true;
+    },
+        onDone: expectAsync0(() {
+          expect(hasReceivedEvent, isFalse);
+        }, count: 1));
+  });
+
   test('rx.Observable.ignoreElements.asBroadcastStream', () async {
     Stream<int> stream =
         new Observable<int>(_getStream().asBroadcastStream()).ignoreElements();

--- a/test/transformers/interval_test.dart
+++ b/test/transformers/interval_test.dart
@@ -25,6 +25,36 @@ void main() {
             onDone: stopwatch.stop);
   });
 
+  test('rx.Observable.interval.reusable', () async {
+    final IntervalStreamTransformer<int> transformer =
+        new IntervalStreamTransformer<int>(const Duration(milliseconds: 1));
+    const List<int> expectedOutput = const <int>[0, 1, 2, 3, 4];
+    int countA = 0, countB = 0, lastIntervalA = -1, lastIntervalB = -1;
+    Stopwatch stopwatch = new Stopwatch()..start();
+
+    new Observable<int>(_getStream()).transform(transformer).listen(
+        expectAsync1((int result) {
+          expect(expectedOutput[countA++], result);
+
+          if (lastIntervalA != -1)
+            expect(stopwatch.elapsedMilliseconds - lastIntervalA >= 1, true);
+
+          lastIntervalA = stopwatch.elapsedMilliseconds;
+        }, count: expectedOutput.length),
+        onDone: stopwatch.stop);
+
+    new Observable<int>(_getStream()).transform(transformer).listen(
+        expectAsync1((int result) {
+          expect(expectedOutput[countB++], result);
+
+          if (lastIntervalB != -1)
+            expect(stopwatch.elapsedMilliseconds - lastIntervalB >= 1, true);
+
+          lastIntervalB = stopwatch.elapsedMilliseconds;
+        }, count: expectedOutput.length),
+        onDone: stopwatch.stop);
+  });
+
   test('rx.Observable.interval.asBroadcastStream', () async {
     Stream<int> stream = new Observable<int>(_getStream().asBroadcastStream())
         .interval(const Duration(milliseconds: 20));

--- a/test/transformers/materialize_test.dart
+++ b/test/transformers/materialize_test.dart
@@ -17,6 +17,33 @@ void main() {
     }));
   });
 
+  test('rx.Observable.materialize.reusable', () async {
+    final MaterializeStreamTransformer<int> transformer =
+        new MaterializeStreamTransformer<int>();
+    final Observable<int> observable =
+        new Observable<int>.just(1).asBroadcastStream();
+    List<Notification<int>> notificationsA = <Notification<int>>[],
+        notificationsB = <Notification<int>>[];
+
+    observable.transform(transformer).listen((Notification<int> notification) {
+      notificationsA.add(notification);
+    }, onDone: expectAsync0(() {
+      expect(notificationsA, <Notification<int>>[
+        new Notification<int>.onData(1),
+        new Notification<int>.onDone()
+      ]);
+    }));
+
+    observable.transform(transformer).listen((Notification<int> notification) {
+      notificationsB.add(notification);
+    }, onDone: expectAsync0(() {
+      expect(notificationsB, <Notification<int>>[
+        new Notification<int>.onData(1),
+        new Notification<int>.onDone()
+      ]);
+    }));
+  });
+
   test('materializeTransformer.happyPath', () async {
     final Stream<int> stream = new Stream<int>.fromIterable(<int>[1]);
     List<Notification<int>> notifications = <Notification<int>>[];

--- a/test/transformers/max_test.dart
+++ b/test/transformers/max_test.dart
@@ -41,6 +41,25 @@ void main() {
         }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.max.transformer.reusable', () async {
+    final MaxStreamTransformer<int> transformer =
+        new MaxStreamTransformer<int>((int a, int b) => 1);
+    const List<int> expectedOutput = const <int>[2, 3, 3, 5, 2, 9, 1, 2, 0];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countA++], result);
+        }, count: expectedOutput.length));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countB++], result);
+        }, count: expectedOutput.length));
+  });
+
   test('rx.Observable.min.withCompare.withoutComparable', () async {
     const List<Map<String, int>> expectedOutput = const <Map<String, int>>[
       const <String, int>{'value': 10},

--- a/test/transformers/min_test.dart
+++ b/test/transformers/min_test.dart
@@ -41,6 +41,25 @@ void main() {
         }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.min.withCompare.reusable', () async {
+    final MinStreamTransformer<int> transformer =
+        new MinStreamTransformer<int>((int a, int b) => -1);
+    const List<int> expectedOutput = const <int>[10, 3, 3, 5, 2, 9, 1, 2, 0];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countA++], result);
+        }, count: expectedOutput.length));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countB++], result);
+        }, count: expectedOutput.length));
+  });
+
   test('rx.Observable.min.withCompare.withoutComparable', () async {
     const List<Map<String, int>> expectedOutput = const <Map<String, int>>[
       const <String, int>{'value': 10},

--- a/test/transformers/on_error_resume_next_test.dart
+++ b/test/transformers/on_error_resume_next_test.dart
@@ -20,6 +20,25 @@ void main() {
         }, count: expected.length));
   });
 
+  test('rx.Observable.onErrorResumeNext.reusable', () async {
+    final OnErrorResumeNextStreamTransformer<num> transformer =
+        new OnErrorResumeNextStreamTransformer<num>(
+            _getStream().asBroadcastStream());
+    int countA = 0, countB = 0;
+
+    observable(new ErrorStream<num>(new Exception()))
+        .transform(transformer)
+        .listen(expectAsync1((num result) {
+          expect(result, expected[countA++]);
+        }, count: expected.length));
+
+    observable(new ErrorStream<num>(new Exception()))
+        .transform(transformer)
+        .listen(expectAsync1((num result) {
+          expect(result, expected[countB++]);
+        }, count: expected.length));
+  });
+
   test('rx.Observable.onErrorResumeNext.asBroadcastStream', () async {
     Stream<num> stream = observable(new ErrorStream<num>(new Exception()))
         .onErrorResumeNext(_getStream())

--- a/test/transformers/repeat_test.dart
+++ b/test/transformers/repeat_test.dart
@@ -31,6 +31,37 @@ void main() {
         }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.repeat.reusable', () async {
+    final RepeatStreamTransformer<int> transformer = new RepeatStreamTransformer<int>(3);
+    const List<int> expectedOutput = const <int>[
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      3,
+      3,
+      3,
+      4,
+      4,
+      4
+    ];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+      expect(expectedOutput[countA++], result);
+    }, count: expectedOutput.length));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+      expect(expectedOutput[countB++], result);
+    }, count: expectedOutput.length));
+  });
+
   test('rx.Observable.repeat.asBroadcastStream', () async {
     Stream<int> stream =
         new Observable<int>(_getStream().asBroadcastStream()).repeat(3);

--- a/test/transformers/sample_test.dart
+++ b/test/transformers/sample_test.dart
@@ -6,19 +6,33 @@ import 'package:rxdart/rxdart.dart';
 Stream<int> _getStream() => new Stream<int>.periodic(
     const Duration(milliseconds: 20), (int count) => count).take(5);
 Stream<int> _getSampleStream() => new Stream<int>.periodic(
-    const Duration(milliseconds: 35), (int count) => count).take(5);
+    const Duration(milliseconds: 35), (int count) => count).take(10);
 
 void main() {
   test('rx.Observable.sample', () async {
-    Observable<int> observable =
+    final Observable<int> observable =
         new Observable<int>(_getStream()).sample(_getSampleStream());
 
     await expect(observable, emitsInOrder(const <int>[0, 2, 4]));
   });
 
+  test('rx.Observable.sample.reusable', () async {
+    final SampleStreamTransformer<int> transformer =
+        new SampleStreamTransformer<int>(
+            _getSampleStream().asBroadcastStream());
+    final Observable<int> observableA =
+        new Observable<int>(_getStream()).transform(transformer);
+    final Observable<int> observableB =
+        new Observable<int>(_getStream()).transform(transformer);
+
+    await expect(observableA, emitsInOrder(const <int>[0, 2, 4]));
+    await expect(observableB, emitsInOrder(const <int>[0, 2, 4]));
+  });
+
   test('rx.Observable.sample.onDone', () async {
-    Observable<int> observable = new Observable<int>(new Observable<int>.just(1))
-        .sample(new Observable<int>.empty());
+    Observable<int> observable =
+        new Observable<int>(new Observable<int>.just(1))
+            .sample(new Observable<int>.empty());
 
     await expect(observable, emits(1));
   });

--- a/test/transformers/scan_test.dart
+++ b/test/transformers/scan_test.dart
@@ -16,6 +16,26 @@ void main() {
         }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.scan.reusable', () async {
+    final ScanStreamTransformer<int, int> transformer =
+        new ScanStreamTransformer<int, int>((int acc, int value, int index) =>
+            ((acc == null) ? 0 : acc) + value);
+    const List<int> expectedOutput = const <int>[1, 3, 6, 10];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countA++], result);
+        }, count: expectedOutput.length));
+
+    new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+      expect(expectedOutput[countB++], result);
+    }, count: expectedOutput.length));
+  });
+
   test('rx.Observable.scan.asBroadcastStream', () async {
     Stream<int> stream = new Observable<int>(
             new Stream<int>.fromIterable(<int>[1, 2, 3, 4]).asBroadcastStream())

--- a/test/transformers/skip_until_test.dart
+++ b/test/transformers/skip_until_test.dart
@@ -17,8 +17,8 @@ Stream<int> _getStream() {
   return controller.stream;
 }
 
-Stream<num> _getOtherStream() {
-  StreamController<num> controller = new StreamController<num>();
+Stream<int> _getOtherStream() {
+  StreamController<int> controller = new StreamController<int>();
 
   new Timer(const Duration(milliseconds: 250), () {
     controller.add(1);
@@ -37,6 +37,26 @@ void main() {
         .skipUntil(_getOtherStream())
         .listen(expectAsync1((int result) {
           expect(expectedOutput[count++], result);
+        }, count: expectedOutput.length));
+  });
+
+  test('rx.Observable.skipUntil.reusable', () async {
+    final SkipUntilStreamTransformer<int, int> transformer =
+        new SkipUntilStreamTransformer<int, int>(
+            _getOtherStream().asBroadcastStream());
+    const List<int> expectedOutput = const <int>[3, 4];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countA++], result);
+        }, count: expectedOutput.length));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countB++], result);
         }, count: expectedOutput.length));
   });
 

--- a/test/transformers/start_with_many_test.dart
+++ b/test/transformers/start_with_many_test.dart
@@ -17,6 +17,25 @@ void main() {
     }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.startWithMany.reusable', () async {
+    final StartWithManyStreamTransformer<int> transformer =
+        new StartWithManyStreamTransformer<int>(const <int>[5, 6]);
+    const List<int> expectedOutput = const <int>[5, 6, 1, 2, 3, 4];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countA++], result);
+        }, count: expectedOutput.length));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countB++], result);
+        }, count: expectedOutput.length));
+  });
+
   test('rx.Observable.startWithMany.asBroadcastStream', () async {
     Stream<int> stream = new Observable<int>(_getStream().asBroadcastStream())
         .startWithMany(const <int>[5, 6]);

--- a/test/transformers/start_with_test.dart
+++ b/test/transformers/start_with_test.dart
@@ -18,6 +18,25 @@ void main() {
         }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.startWith.reusable', () async {
+    final StartWithStreamTransformer<int> transformer =
+        new StartWithStreamTransformer<int>(5);
+    const List<int> expectedOutput = const <int>[5, 1, 2, 3, 4];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countA++], result);
+        }, count: expectedOutput.length));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countB++], result);
+        }, count: expectedOutput.length));
+  });
+
   test('rx.Observable.startWith.asBroadcastStream', () async {
     Stream<int> stream =
         new Observable<int>(_getStream().asBroadcastStream()).startWith(5);

--- a/test/transformers/switch_if_empty_test.dart
+++ b/test/transformers/switch_if_empty_test.dart
@@ -12,6 +12,24 @@ void main() {
         }, count: 1));
   });
 
+  test('rx.Observable.switchIfEmpty.reusable', () async {
+    final SwitchIfEmptyStreamTransformer<bool> transformer =
+        new SwitchIfEmptyStreamTransformer<bool>(
+            new Observable<bool>.just(true).asBroadcastStream());
+
+    new Observable<bool>(new Stream<bool>.empty())
+        .transform(transformer)
+        .listen(expectAsync1((bool result) {
+          expect(result, true);
+        }, count: 1));
+
+    new Observable<bool>(new Stream<bool>.empty())
+        .transform(transformer)
+        .listen(expectAsync1((bool result) {
+          expect(result, true);
+        }, count: 1));
+  });
+
   test('rx.Observable.switchIfEmpty.whenNotEmpty', () async {
     new Observable<bool>.just(false)
         .switchIfEmpty(new Observable<bool>.just(true))

--- a/test/transformers/take_until_test.dart
+++ b/test/transformers/take_until_test.dart
@@ -17,8 +17,8 @@ Stream<int> _getStream() {
   return controller.stream;
 }
 
-Stream<num> _getOtherStream() {
-  StreamController<num> controller = new StreamController<num>();
+Stream<int> _getOtherStream() {
+  StreamController<int> controller = new StreamController<int>();
 
   new Timer(const Duration(milliseconds: 250), () {
     controller.add(1);
@@ -37,6 +37,26 @@ void main() {
         .takeUntil(_getOtherStream())
         .listen(expectAsync1((int result) {
           expect(expectedOutput[count++], result);
+        }, count: expectedOutput.length));
+  });
+
+  test('rx.Observable.takeUntil.reusable', () async {
+    final TakeUntilStreamTransformer<int, int> transformer =
+        new TakeUntilStreamTransformer<int, int>(
+            _getOtherStream().asBroadcastStream());
+    const List<int> expectedOutput = const <int>[1, 2];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countA++], result);
+        }, count: expectedOutput.length));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(expectedOutput[countB++], result);
         }, count: expectedOutput.length));
   });
 

--- a/test/transformers/throttle_test.dart
+++ b/test/transformers/throttle_test.dart
@@ -29,6 +29,25 @@ void main() {
         }, count: 2));
   });
 
+  test('rx.Observable.throttle.reusable', () async {
+    final ThrottleStreamTransformer<int> transformer =
+        new ThrottleStreamTransformer<int>(const Duration(milliseconds: 250));
+    const List<int> expectedOutput = const <int>[1, 4];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(result, expectedOutput[countA++]);
+        }, count: 2));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .listen(expectAsync1((int result) {
+          expect(result, expectedOutput[countB++]);
+        }, count: 2));
+  });
+
   test('rx.Observable.throttle.asBroadcastStream', () async {
     Stream<int> stream = new Observable<int>(_getStream().asBroadcastStream())
         .throttle(const Duration(milliseconds: 200));

--- a/test/transformers/time_interval_test.dart
+++ b/test/transformers/time_interval_test.dart
@@ -20,6 +20,31 @@ void main() {
         }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.timeInterval.reusable', () async {
+    final TimeIntervalStreamTransformer<int, TimeInterval<int>> transformer =
+        new TimeIntervalStreamTransformer<int, TimeInterval<int>>();
+    const List<int> expectedOutput = const <int>[0, 1, 2];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .interval(const Duration(milliseconds: 1))
+        .transform(transformer)
+        .listen(expectAsync1((TimeInterval<int> result) {
+          expect(expectedOutput[countA++], result.value);
+
+          expect(result.interval >= 1000 /* microseconds! */, true);
+        }, count: expectedOutput.length));
+
+    new Observable<int>(_getStream())
+        .interval(const Duration(milliseconds: 1))
+        .transform(transformer)
+        .listen(expectAsync1((TimeInterval<int> result) {
+          expect(expectedOutput[countB++], result.value);
+
+          expect(result.interval >= 1000 /* microseconds! */, true);
+        }, count: expectedOutput.length));
+  });
+
   test('rx.Observable.timeInterval.asBroadcastStream', () async {
     Stream<TimeInterval<int>> stream =
         new Observable<int>(_getStream().asBroadcastStream())

--- a/test/transformers/timestamp_test.dart
+++ b/test/transformers/timestamp_test.dart
@@ -15,6 +15,25 @@ void main() {
         }, count: expected.length));
   });
 
+  test('Rx.Observable.timestamp.reusable', () async {
+    final TimestampStreamTransformer<int> transformer =
+        new TimestampStreamTransformer<int>();
+    final List<int> expected = <int>[1, 2, 3];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3]))
+        .transform(transformer)
+        .listen(expectAsync1((Timestamped<int> result) {
+          expect(result.value, expected[countA++]);
+        }, count: expected.length));
+
+    new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3]))
+        .transform(transformer)
+        .listen(expectAsync1((Timestamped<int> result) {
+          expect(result.value, expected[countB++]);
+        }, count: expected.length));
+  });
+
   test('timestampTransformer', () async {
     final List<int> expected = <int>[1, 2, 3];
     int count = 0;
@@ -41,7 +60,8 @@ void main() {
 
   test('timestampTransformer.error.shouldThrow', () async {
     Stream<Timestamped<int>> streamWithError =
-        new ErrorStream<int>(new Exception()).transform(new TimestampStreamTransformer<int>());
+        new ErrorStream<int>(new Exception())
+            .transform(new TimestampStreamTransformer<int>());
 
     streamWithError.listen(null, onError: (dynamic e, dynamic s) {
       expect(e, isException);

--- a/test/transformers/window_with_count_test.dart
+++ b/test/transformers/window_with_count_test.dart
@@ -26,6 +26,44 @@ void main() {
     }, count: 2));
   });
 
+  test('rx.Observable.windowWithCount.reusable', () async {
+    final WindowWithCountStreamTransformer<int, Stream<int>> transformer =
+        new WindowWithCountStreamTransformer<int, Stream<int>>(2);
+    const List<List<int>> expectedOutput = const <List<int>>[
+      const <int>[1, 2],
+      const <int>[3, 4]
+    ];
+    int countA = 0, countB = 0;
+
+    Stream<Stream<int>> streamA =
+        new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
+            .transform(transformer);
+
+    streamA.listen(expectAsync1((Stream<int> result) {
+      // test to see if the combined output matches
+      List<int> expected = expectedOutput[countA++];
+      int innerCount = 0;
+
+      result.listen(expectAsync1((int value) {
+        expect(expected[innerCount++], value);
+      }, count: expected.length));
+    }, count: 2));
+
+    Stream<Stream<int>> streamB =
+        new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
+            .transform(transformer);
+
+    streamB.listen(expectAsync1((Stream<int> result) {
+      // test to see if the combined output matches
+      List<int> expected = expectedOutput[countB++];
+      int innerCount = 0;
+
+      result.listen(expectAsync1((int value) {
+        expect(expected[innerCount++], value);
+      }, count: expected.length));
+    }, count: 2));
+  });
+
   test('rx.Observable.windowWithCount.skip', () async {
     const List<List<int>> expectedOutput = const <List<int>>[
       const <int>[1, 2],

--- a/test/transformers/with_latest_from_test.dart
+++ b/test/transformers/with_latest_from_test.dart
@@ -29,6 +29,35 @@ void main() {
         }, count: expectedOutput.length));
   });
 
+  test('rx.Observable.withLatestFrom.reusable', () async {
+    final WithLatestFromStreamTransformer<int, int, Pair> transformer =
+        new WithLatestFromStreamTransformer<int, int, Pair>(
+            _getLatestFromStream().asBroadcastStream(),
+            (int first, int second) => new Pair(first, second));
+    const List<Pair> expectedOutput = const <Pair>[
+      const Pair(2, 0),
+      const Pair(3, 0),
+      const Pair(4, 1),
+      const Pair(5, 1),
+      const Pair(6, 2)
+    ];
+    int countA = 0, countB = 0;
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .take(5)
+        .listen(expectAsync1((Pair result) {
+          expect(result, expectedOutput[countA++]);
+        }, count: expectedOutput.length));
+
+    new Observable<int>(_getStream())
+        .transform(transformer)
+        .take(5)
+        .listen(expectAsync1((Pair result) {
+          expect(result, expectedOutput[countB++]);
+        }, count: expectedOutput.length));
+  });
+
   test('rx.Observable.withLatestFrom.asBroadcastStream', () async {
     Stream<int> stream = new Observable<int>(_getStream().asBroadcastStream())
         .withLatestFrom(_getLatestFromStream().asBroadcastStream(),


### PR DESCRIPTION
Added tests for operators using `Transformers`

fixed some transformers,
those that use `fromHandlers `and store values need to be factory created on `bind`

in other cases, when just returning a new `StreamTransformer`, all values needed to be moved within that `StreamTransformer `body, some were sitting above being part of the `Transformer `class scope