### PR TITLE
More docs / Remove deprecated methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ If you'd like to add a feature or fix a bug, we're more than happy to accept pul
     - Code is free of lint errors
   - Format your code with `dartfmt`
   - Write tests for all new code paths, consider using the [Stream Matchers](https://pub.dartlang.org/packages/test#stream-matchers) available from the test package.
+  - Write helpful documentation
   - If you would like to make a bigger / fundamental change to the codebase, please file a lightweight example PR / issue, or contact us in [Gitter](https://gitter.im/ReactiveX/rxdart) so we can discuss the issue.
 
 ## Advice when adding a new factory
@@ -29,6 +30,3 @@ If you'd like to add a feature or fix a bug, we're more than happy to accept pul
   - Add the new `StreamTransformer` to the exported `rx_transformers` library
   - Ensure the `StreamTransformer` can be re-used
   - Add new tests to `tests/rxdart_test.dart`
-
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to RxDart
+
+## Create a new issue
+
+The easiest way to get involved is to create a [new issue](https://github.com/ReactiveX/rxdart/issues/new) when you spot a bug, if the documentation is incomplete or out of date, or if you identify an implementation problem.
+
+## General coding guidlines
+
+If you'd like to add a feature or fix a bug, we're more than happy to accept pull requests! We only ask a few things:
+
+  - Ensure your code contains no analyzer errors, e.g.
+    - Code is strong-mode compliant
+    - Code is free of lint errors
+  - Format your code with `dartfmt`
+  - Write tests for all new code paths, consider using the [Stream Matchers](https://pub.dartlang.org/packages/test#stream-matchers) available from the test package.
+  - If you would like to make a bigger / fundamental change to the codebase, please file a lightweight example PR / issue, or contact us in [Gitter](https://gitter.im/ReactiveX/rxdart) so we can discuss the issue.
+
+## Advice when adding a new factory
+
+  - Extend from `Stream` so it can be constructed outside the scope of the Observable class
+  - Add the new `Stream` to the exported `rx_streams` library
+  - Ensure the stream properly enforces the single-subscription contract
+  - Ensure the stream closses properly
+  - Add new tests to `tests/rxdart_test.dart`
+
+## Advice when adding a new operator
+
+  - Extend from the `StreamTransformer` class so it can be used independently
+  - Add the new `StreamTransformer` to the exported `rx_transformers` library
+  - Ensure the `StreamTransformer` can be re-used
+  - Add new tests to `tests/rxdart_test.dart`
+
+
+

--- a/README.md
+++ b/README.md
@@ -40,14 +40,24 @@ void main() {
 
 ## API Overview
 
+### Objects
+
+- [Observable](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable-class.html)
+- [BehaviourSubject](https://www.dartdocs.org/documentation/rxdart/latest/rx_subjects/BehaviourSubject-class.html)
+- [ReplaySubject](https://www.dartdocs.org/documentation/rxdart/latest/rx_subjects/ReplaySubject-class.html)
+
+### Observable
+
 RxDart's Observables extend the Stream class.
 This has two major implications:  
 - All [methods defined on the Stream class](https://api.dartlang.org/stable/1.21.1/dart-async/Stream-class.html#instance-methods) exist on RxDart's Observables as well.
 - All Observables can be passed to any API that expects a Dart Stream as an input.
+- Additional important distinctions are documented as part of the [Observable class](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable-class.html)
 
-##### Note
+##### Notes
 
-The following sections link to DartDoc. While DartDoc is a bit scary looking at first, the documentation is up-to-date, readable, and contains examples. Furthermore, this documentation lives within the code, which means it can be easily read from within your favorite editor. 
+  * The Observable class is a simple wrapper for `Stream` and `StreamTransformer` classes. All underlying implementations can be used free of the Observable wrapper, and are exposed in their own libraries. They are linked to below.
+  * The following sections link to DartDoc. While DartDoc is a bit scary looking at first, the documentation is up-to-date, readable, and contains examples. Furthermore, this documentation lives within the code, which means it can be easily read from within your favorite editor. 
 
 ### Instantiation
 
@@ -61,16 +71,17 @@ var myObservable = new Observable(myStream);
 ```
 
 #### Available Factory Methods
-- [amb](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.amb.html)
-- [concat](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.concat.html)
-- [defer](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.defer.html)
-- [error](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.error.html)
+- [amb](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.amb.html) / [AmbStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/AmbStream-class.html)
+- [concat](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.concat.html) / [ConcatStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/ConcatStream-class.html)
+- [concatEager](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.concat.html) / [ConcatEagerStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/ConcatEagerStream-class.html)
+- [defer](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.defer.html) / [DeferStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/DeferStream-class.html)
+- [error](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.error.html) / [ErrorStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/ErrorStream-class.html)
 - [just](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.just.html)
-- [merge](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.merge.html)
-- [never](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.never.html)
+- [merge](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.merge.html) / [MergeStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/MergeStream-class.html)
+- [never](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.never.html) / [NeverStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/NeverStream-class.html)
 - [periodic](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.periodic.html)
-- [retry](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.retry.html)
-- [timer](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.timer.html)
+- [retry](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.retry.html) / [RetryStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/RetryStream-class.html)
+- [timer](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.timer.html) / [TimerStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/TimerStream-class.html)
 
 ###### Usage
 ```dart
@@ -78,10 +89,10 @@ var myObservable = new Observable.merge([myFirstStream, mySecondStream]);
 ```
 
 ##### Available Static Methods
-- [combineLatest](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/combineLatest2.html) (combineLatest2, combineLatest3, combineLatest4, ..., combineLatest9)
-- [range](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/range.html)
-- [tween](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/tween.html)
-- [zip](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/zip2.html) (zip2, zip3, zip4, ..., zip9)
+- [combineLatest](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/combineLatest2.html) / [CombineLatestStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/CombineLatestStream-class.html) (combineLatest2, combineLatest... combineLatest9) 
+- [range](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/range.html) / [RangeStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/RangeStream-class.html)
+- [tween](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/tween.html) / [TweenStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/TweenStream-class.html)
+- [zip](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/zip2.html) / [ZipStream](https://www.dartdocs.org/documentation/rxdart/latest/rx_streams/ZipStream-class.html) (zip2, zip3, zip4, ..., zip9)
 
 ###### Usage
 ```dart
@@ -95,33 +106,32 @@ var myObservable = Observable.combineLatest3(
 ### Transformations
     
 ##### Available Methods
-- [bufferWithCount](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/bufferWithCount.html)
-- [call](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/call.html)
-- [concatMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/concatMap.html)
+- [bufferWithCount](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/bufferWithCount.html) / [BufferWithCountStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/BufferWithCountStreamTransformer-class.html)
+- [call](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/call.html) / [CallStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/CallStreamTransformer-class.html)
+- [concatMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/concatMap.html) / [ConcatMapStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/ConcatMapStreamTransformer-class.html)
 - [concatWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/concatWith.html)
-- [debounce](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/debounce.html)
-- [dematerialize](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/dematerialize.html)
-- [flatMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/flatMap.html)
-- [flatMapLatest](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/flatMapLatest.html)
-- [groupBy](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/groupBy.html)
-- [interval](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/interval.html)  
-- [materialize](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/materialize.html)
+- [debounce](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/debounce.html) / [DebounceStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/DebounceStreamTransformer-class.html)
+- [dematerialize](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/dematerialize.html) / [DematerializeStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/DematerializeStreamTransformer-class.html)
+- [flatMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/flatMap.html) / [FlatMapStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/FlatMapStreamTransformer-class.html)
+- [flatMapLatest](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/flatMapLatest.html) / [FlatMapLatestStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/FlatMapLatestStreamTransformer-class.html)
+- [groupBy](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/groupBy.html) / [GroupByStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/GroupByStreamTransformer-class.html)
+- [interval](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/interval.html) / [IntervalStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/IntervalStreamTransformer-class.html)
+- [materialize](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/materialize.html) / [MaterializeStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/MaterializeStreamTransformer-class.html)
 - [mergeWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/mergeWith.html)
-- [max](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/max.html)
-- [min](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/min.html)
-- [pluck](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/pluck.html)  
-- [repeat](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/repeat.html)  
-- [sample](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/sample.html)  
-- [scan](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/scan.html)  
-- [skipUntil](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/skipUntil.html)
-- [startWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/startWith.html)  
-- [startWithMany](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/startWithMany.html)  
-- [takeUntil](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/takeUntil.html)  
-- [timeInterval](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/timeInterval.html)  
-- [timestamp](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/timestamp.html)
-- [throttle](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/throttle.html)
-- [windowWithCount](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/windowWithCount.html)
-- [withLatestFrom](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/withLatestFrom.html)
+- [max](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/max.html) / [MaxStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/MaxStreamTransformer-class.html)
+- [min](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/min.html) / [MinStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/MinStreamTransformer-class.html)
+- [repeat](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/repeat.html) / [RepeatStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/RepeatStreamTransformer-class.html)
+- [sample](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/sample.html) / [SampleStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/SampleStreamTransformer-class.html)
+- [scan](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/scan.html) / [ScanStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/ScanStreamTransformer-class.html)
+- [skipUntil](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/skipUntil.html) / [SkipUntilStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/SkipUntilStreamTransformer-class.html)
+- [startWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/startWith.html) / [StartWithStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/StartWithStreamTransformer-class.html)
+- [startWithMany](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/startWithMany.html) / [StartWithManyStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/StartWithManyStreamTransformer-class.html) 
+- [takeUntil](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/takeUntil.html) / [TakeUntilStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/TakeUntilStreamTransformer-class.html)
+- [timeInterval](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/timeInterval.html) / [TimeIntervalStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/TimeIntervalStreamTransformer-class.html)
+- [timestamp](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/timestamp.html) / [TimestampStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/TimestampStreamTransformer-class.html)
+- [throttle](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/throttle.html) / [ThrottleStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/ThrottleStreamTransformer-class.html)
+- [windowWithCount](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/windowWithCount.html) / [WindowWithCountStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/WindowWithCountStreamTransformer-class.html)
+- [withLatestFrom](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/withLatestFrom.html) / [WithLatestFromStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/WithLatestFromStreamTransformer-class.html)
 - [zipWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/zipWith.html)
 
 A full list of all methods and properties including those provided by the Dart Stream API (such as `first`, `asyncMap`, etc), can be seen by examining the [DartDocs](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable-class.html#instance-methods)
@@ -132,12 +142,6 @@ var myObservable = new Observable(myStream)
     .bufferWithCount(5)
     .distinct();
 ```
-
-### Objects
-
-- [Observable](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable-class.html)
-- [BehaviourSubject](https://www.dartdocs.org/documentation/rxdart/latest/rx_subjects/BehaviourSubject-class.html)
-- [ReplaySubject](https://www.dartdocs.org/documentation/rxdart/latest/rx_subjects/ReplaySubject-class.html)
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Generally speaking, creating a new Observable is either done by wrapping a Dart 
 But to better support Dart's strong mode, `combineLatest` and `zip` have been pulled apart into fixed-length constructors. 
 These methods are supplied as static methods, since Dart's factory methods don't support generic types.
 
-##### Usage
+###### Usage
 ```dart
 var myObservable = new Observable(myStream);
 ```

--- a/README.md
+++ b/README.md
@@ -45,28 +45,32 @@ This has two major implications:
 - All [methods defined on the Stream class](https://api.dartlang.org/stable/1.21.1/dart-async/Stream-class.html#instance-methods) exist on RxDart's Observables as well.
 - All Observables can be passed to any API that expects a Dart Stream as an input.
 
+##### Note
+
+The following sections link to DartDoc. While DartDoc is a bit scary looking at first, the documentation is up-to-date, readable, and contains examples. Furthermore, this documentation lives within the code, which means it can be easily read from within your favorite editor. 
+
 ### Instantiation
 
 Generally speaking, creating a new Observable is either done by wrapping a Dart Stream using the top-level constructor `new Observable()`, or by calling a factory method on the Observable class.
 But to better support Dart's strong mode, `combineLatest` and `zip` have been pulled apart into fixed-length constructors. 
 These methods are supplied as static methods, since Dart's factory methods don't support generic types.
 
-###### Usage
+##### Usage
 ```dart
 var myObservable = new Observable(myStream);
 ```
 
-##### Available Factory Methods
-- amb
-- concat
-- defer
-- error
-- just
-- merge
-- never
-- periodic
-- retry
-- timer
+#### Available Factory Methods
+- [amb](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.amb.html)
+- [concat](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.concat.html)
+- [defer](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.defer.html)
+- [error](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.error.html)
+- [just](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.just.html)
+- [merge](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.merge.html)
+- [never](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.never.html)
+- [periodic](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.periodic.html)
+- [retry](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.retry.html)
+- [timer](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.timer.html)
 
 ###### Usage
 ```dart
@@ -74,10 +78,10 @@ var myObservable = new Observable.merge([myFirstStream, mySecondStream]);
 ```
 
 ##### Available Static Methods
-- combineLatest (combineLatest2, combineLatest3, combineLatest4, ..., combineLatest9)
-- range
-- tween
-- zip (zip2, zip3, zip4, ..., zip9)
+- [combineLatest](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/combineLatest2.html) (combineLatest2, combineLatest3, combineLatest4, ..., combineLatest9)
+- [range](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/range.html)
+- [tween](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/tween.html)
+- [zip](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/zip2.html) (zip2, zip3, zip4, ..., zip9)
 
 ###### Usage
 ```dart
@@ -91,34 +95,36 @@ var myObservable = Observable.combineLatest3(
 ### Transformations
     
 ##### Available Methods
-- bufferWithCount
-- call
-- concatMap
-- concatWith
-- debounce
-- dematerialize
-- flatMapLatest
-- flatMap
-- groupBy
-- interval  
-- materialize
-- mergeWith
-- max
-- min
-- pluck  
-- repeat  
-- sample  
-- scan  
-- skipUntil
-- startWith  
-- startWithMany  
-- takeUntil  
-- timeInterval  
-- timestamp
-- throttle
-- windowWithCount
-- withLatestFrom
-- zipWith
+- [bufferWithCount](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/bufferWithCount.html)
+- [call](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/call.html)
+- [concatMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/concatMap.html)
+- [concatWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/concatWith.html)
+- [debounce](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/debounce.html)
+- [dematerialize](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/dematerialize.html)
+- [flatMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/flatMap.html)
+- [flatMapLatest](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/flatMapLatest.html)
+- [groupBy](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/groupBy.html)
+- [interval](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/interval.html)  
+- [materialize](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/materialize.html)
+- [mergeWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/mergeWith.html)
+- [max](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/max.html)
+- [min](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/min.html)
+- [pluck](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/pluck.html)  
+- [repeat](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/repeat.html)  
+- [sample](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/sample.html)  
+- [scan](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/scan.html)  
+- [skipUntil](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/skipUntil.html)
+- [startWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/startWith.html)  
+- [startWithMany](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/startWithMany.html)  
+- [takeUntil](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/takeUntil.html)  
+- [timeInterval](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/timeInterval.html)  
+- [timestamp](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/timestamp.html)
+- [throttle](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/throttle.html)
+- [windowWithCount](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/windowWithCount.html)
+- [withLatestFrom](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/withLatestFrom.html)
+- [zipWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/zipWith.html)
+
+A full list of all methods and properties including those provided by the Dart Stream API (such as `first`, `asyncMap`, etc), can be seen by examining the [DartDocs](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable-class.html#instance-methods)
 
 ###### Usage
 ```Dart
@@ -129,9 +135,9 @@ var myObservable = new Observable(myStream)
 
 ### Objects
 
-- Observable
-- BehaviourSubject
-- ReplaySubject
+- [Observable](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable-class.html)
+- [BehaviourSubject](https://www.dartdocs.org/documentation/rxdart/latest/rx_subjects/BehaviourSubject-class.html)
+- [ReplaySubject](https://www.dartdocs.org/documentation/rxdart/latest/rx_subjects/ReplaySubject-class.html)
 
 ## Examples
 
@@ -158,7 +164,7 @@ In order to run the command line example, please follow these steps:
   
 #### Install Flutter
 
-In order to run this repo, you must have Flutter installed. For help getting started with Flutter, view the online
+In order to run the flutter example, you must have Flutter installed. For installation instructions, view the online
 [documentation](http://flutter.io/).
 
 #### Run the app
@@ -169,8 +175,6 @@ In order to run this repo, you must have Flutter installed. For help getting sta
   4. Run `flutter doctor` to ensure you have all Flutter dependencies working.
   5. Run `flutter packages get`
   6. Run `flutter run`
- 
-  
 
 ## Notable References
 - [Documentation on the Dart Stream class](https://api.dartlang.org/stable/1.21.1/dart-async/Stream-class.html)

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -44,92 +44,157 @@ import 'package:rxdart/src/transformers/timestamp.dart';
 import 'package:rxdart/src/transformers/window_with_count.dart';
 import 'package:rxdart/src/transformers/with_latest_from.dart';
 
-/// Deprecated: Please use `new Observable(stream)` instead
-Observable<S> observable<S>(Stream<S> stream) => new Observable<S>(stream);
-
 class Observable<T> extends Stream<T> {
   final Stream<T> stream;
 
   Observable(this.stream);
 
-  /// Given two or more source Observables, emit all of the items from only
-  /// the first of these Observables to emit an item or notification.
+  /// Given two or more source [streams], emit all of the items from only
+  /// the first of these [streams] to emit an item or notification.
   ///
-  /// http://rxmarbles.com/#amb
+  /// [Interactive marble diagram](http://rxmarbles.com/#amb)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.amb([
+  ///       new Observable.timer(1, new Duration(days: 1)),
+  ///       new Observable.timer(2, new Duration(days: 2)),
+  ///       new Observable.timer(3, new Duration(seconds: 1))
+  ///     ]).listen(print); // prints 3
   factory Observable.amb(Iterable<Stream<T>> streams) =>
       new Observable<T>(new AmbStream<T>(streams));
 
   @override
   Future<bool> any(bool test(T element)) => stream.any(test);
 
-  /// Creates an Observable where each item is the result of passing the latest
-  /// values from each feeder stream into the predicate function.
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function whenever any of the observable sequences emits an
+  /// item.
   ///
-  /// http://rxmarbles.com/#combineLatest
-  @Deprecated(
-      'For better strong mode support, use combineLatest2, combineLatest3, ... instead')
-  factory Observable.combineLatest(
-          Iterable<Stream<dynamic>> streams, Function predicate) =>
-      new Observable<T>(new CombineLatestStream<T>(streams, predicate));
-
-  /// Creates an Observable where each item is the result of passing the latest
-  /// values from each feeder stream into the predicate function.
+  /// The Observable will not emit until all streams have emitted at least one
+  /// item.
   ///
-  /// http://rxmarbles.com/#combineLatest
+  /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.combineLatest2(
+  ///       new Observable.just(1),
+  ///       new Observable.fromIterable([0, 1, 2]),
+  ///       (a, b) => a + b)
+  ///     .listen(print); //prints 1, 2, 3
   static Observable<T> combineLatest2<A, B, T>(
-          Stream<A> streamOne, Stream<B> streamTwo, T predicate(A a, B b)) =>
+          Stream<A> streamOne, Stream<B> streamTwo, T combiner(A a, B b)) =>
       new Observable<T>(new CombineLatestStream<T>(
-          <Stream<dynamic>>[streamOne, streamTwo], predicate));
+          <Stream<dynamic>>[streamOne, streamTwo], combiner));
 
-  /// Creates an Observable where each item is the result of passing the latest
-  /// values from each feeder stream into the predicate function.
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function whenever any of the observable sequences emits an
+  /// item.
   ///
-  /// http://rxmarbles.com/#combineLatest
+  /// The Observable will not emit until all streams have emitted at least one
+  /// item.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.combineLatest3(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.fromIterable(["c", "c"]),
+  ///       (a, b, c) => a + b + c)
+  ///     .listen(print); //prints "abc", "abc"
   static Observable<T> combineLatest3<A, B, C, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
-          T predicate(A a, B b, C c)) =>
+          T combiner(A a, B b, C c)) =>
       new Observable<T>(new CombineLatestStream<T>(
-          <Stream<dynamic>>[streamOne, streamTwo, streamThree], predicate));
+          <Stream<dynamic>>[streamOne, streamTwo, streamThree], combiner));
 
-  /// Creates an Observable where each item is the result of passing the latest
-  /// values from each feeder stream into the predicate function.
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function whenever any of the observable sequences emits an
+  /// item.
   ///
-  /// http://rxmarbles.com/#combineLatest
+  /// The Observable will not emit until all streams have emitted at least one
+  /// item.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.combineLatest4(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.fromIterable(["d", "d"]),
+  ///       (a, b, c, d) => a + b + c + d)
+  ///     .listen(print); //prints "abcd", "abcd"
   static Observable<T> combineLatest4<A, B, C, D, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
           Stream<D> streamFour,
-          T predicate(A a, B b, C c, D d)) =>
+          T combiner(A a, B b, C c, D d)) =>
       new Observable<T>(new CombineLatestStream<T>(
           <Stream<dynamic>>[streamOne, streamTwo, streamThree, streamFour],
-          predicate));
+          combiner));
 
-  /// Creates an Observable where each item is the result of passing the latest
-  /// values from each feeder stream into the predicate function.
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function whenever any of the observable sequences emits an
+  /// item.
   ///
-  /// http://rxmarbles.com/#combineLatest
+  /// The Observable will not emit until all streams have emitted at least one
+  /// item.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.combineLatest5(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.fromIterable(["e", "e"]),
+  ///       (a, b, c, d, e) => a + b + c + d + e)
+  ///     .listen(print); //prints "abcde", "abcde"
   static Observable<T> combineLatest5<A, B, C, D, E, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
           Stream<D> streamFour,
           Stream<E> streamFive,
-          T predicate(A a, B b, C c, D d, E e)) =>
+          T combiner(A a, B b, C c, D d, E e)) =>
       new Observable<T>(new CombineLatestStream<T>(<Stream<dynamic>>[
         streamOne,
         streamTwo,
         streamThree,
         streamFour,
         streamFive
-      ], predicate));
+      ], combiner));
 
-  /// Creates an Observable where each item is the result of passing the latest
-  /// values from each feeder stream into the predicate function.
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function whenever any of the observable sequences emits an
+  /// item.
   ///
-  /// http://rxmarbles.com/#combineLatest
+  /// The Observable will not emit until all streams have emitted at least one
+  /// item.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.combineLatest6(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.fromIterable(["f", "f"]),
+  ///       (a, b, c, d, e, f) => a + b + c + d + e + f)
+  ///     .listen(print); //prints "abcdef", "abcdef"
   static Observable<T> combineLatest6<A, B, C, D, E, F, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
@@ -137,7 +202,7 @@ class Observable<T> extends Stream<T> {
           Stream<D> streamFour,
           Stream<E> streamFive,
           Stream<F> streamSix,
-          T predicate(A a, B b, C c, D d, E e, F f)) =>
+          T combiner(A a, B b, C c, D d, E e, F f)) =>
       new Observable<T>(new CombineLatestStream<T>(<Stream<dynamic>>[
         streamOne,
         streamTwo,
@@ -145,12 +210,29 @@ class Observable<T> extends Stream<T> {
         streamFour,
         streamFive,
         streamSix
-      ], predicate));
+      ], combiner));
 
-  /// Creates an Observable where each item is the result of passing the latest
-  /// values from each feeder stream into the predicate function.
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function whenever any of the observable sequences emits an
+  /// item.
   ///
-  /// http://rxmarbles.com/#combineLatest
+  /// The Observable will not emit until all streams have emitted at least one
+  /// item.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.combineLatest7(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.just("f"),
+  ///       new Observable.fromIterable(["g", "g"]),
+  ///       (a, b, c, d, e, f, g) => a + b + c + d + e + f + g)
+  ///     .listen(print); //prints "abcdefg", "abcdefg"
   static Observable<T> combineLatest7<A, B, C, D, E, F, G, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
@@ -159,7 +241,7 @@ class Observable<T> extends Stream<T> {
           Stream<E> streamFive,
           Stream<F> streamSix,
           Stream<G> streamSeven,
-          T predicate(A a, B b, C c, D d, E e, F f, G g)) =>
+          T combiner(A a, B b, C c, D d, E e, F f, G g)) =>
       new Observable<T>(new CombineLatestStream<T>(<Stream<dynamic>>[
         streamOne,
         streamTwo,
@@ -168,12 +250,30 @@ class Observable<T> extends Stream<T> {
         streamFive,
         streamSix,
         streamSeven
-      ], predicate));
+      ], combiner));
 
-  /// Creates an Observable where each item is the result of passing the latest
-  /// values from each feeder stream into the predicate function.
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function whenever any of the observable sequences emits an
+  /// item.
   ///
-  /// http://rxmarbles.com/#combineLatest
+  /// The Observable will not emit until all streams have emitted at least one
+  /// item.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.combineLatest8(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.just("f"),
+  ///       new Observable.just("g"),
+  ///       new Observable.fromIterable(["h", "h"]),
+  ///       (a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h)
+  ///     .listen(print); //prints "abcdefgh", "abcdefgh"
   static Observable<T> combineLatest8<A, B, C, D, E, F, G, H, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
@@ -183,7 +283,7 @@ class Observable<T> extends Stream<T> {
           Stream<F> streamSix,
           Stream<G> streamSeven,
           Stream<H> streamEight,
-          T predicate(A a, B b, C c, D d, E e, F f, G g, H h)) =>
+          T combiner(A a, B b, C c, D d, E e, F f, G g, H h)) =>
       new Observable<T>(new CombineLatestStream<T>(<Stream<dynamic>>[
         streamOne,
         streamTwo,
@@ -193,12 +293,31 @@ class Observable<T> extends Stream<T> {
         streamSix,
         streamSeven,
         streamEight
-      ], predicate));
+      ], combiner));
 
-  /// Creates an Observable where each item is the result of passing the latest
-  /// values from each feeder stream into the predicate function.
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function whenever any of the observable sequences emits an
+  /// item.
   ///
-  /// http://rxmarbles.com/#combineLatest
+  /// The Observable will not emit until all streams have emitted at least one
+  /// item.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.combineLatest9(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.just("f"),
+  ///       new Observable.just("g"),
+  ///       new Observable.just("h"),
+  ///       new Observable.fromIterable(["i", "i"]),
+  ///       (a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h + i)
+  ///     .listen(print); //prints "abcdefghi", "abcdefghi"
   static Observable<T> combineLatest9<A, B, C, D, E, F, G, H, I, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
@@ -209,7 +328,7 @@ class Observable<T> extends Stream<T> {
           Stream<G> streamSeven,
           Stream<H> streamEight,
           Stream<I> streamNine,
-          T predicate(A a, B b, C c, D d, E e, F f, G g, H h, I i)) =>
+          T combiner(A a, B b, C c, D d, E e, F f, G g, H h, I i)) =>
       new Observable<T>(new CombineLatestStream<T>(<Stream<dynamic>>[
         streamOne,
         streamTwo,
@@ -220,38 +339,64 @@ class Observable<T> extends Stream<T> {
         streamSeven,
         streamEight,
         streamNine
-      ], predicate));
+      ], combiner));
 
-  /// Concatenates all of the specified observable sequences, as long as the
-  /// previous observable sequence terminated successfully..
+  /// Concatenates all of the specified stream sequences, as long as the
+  /// previous stream sequence terminated successfully.
   ///
-  /// http://rxmarbles.com/#concat
+  /// It does this by subscribing to each stream one by one, emitting all items
+  /// and completing before subscribing to the next stream.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#concat)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.concat([
+  ///       new Observable.just(1),
+  ///       new Observable.timer(2, new Duration(days: 1)),
+  ///       new Observable.just(3)
+  ///     ])
+  ///     .listen(print); // prints 1, 2, 3
   factory Observable.concat(Iterable<Stream<T>> streams) =>
       new Observable<T>(new ConcatStream<T>(streams));
 
-  /// Concatenates all of the specified observable sequences,
-  /// a backlog is being kept for events that emit on the waiting streams.
-  /// When a previous sequence is terminated, all backlog for the next stream
-  /// is eagerly emitted at once.
+  /// Concatenates all of the specified stream sequences, as long as the
+  /// previous stream sequence terminated successfully.
   ///
+  /// In the case of concatEager, rather than subscribing to one stream after
+  /// the next, all streams are immediately subscribed to. The events are then
+  /// captured and emitted at the correct time, after the previous stream has
+  /// finished emitting items.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#concat)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.concatEager([
+  ///       new Observable.just(1),
+  ///       new Observable.timer(2, new Duration(days: 1)),
+  ///       new Observable.just(3)
+  ///     ])
+  ///     .listen(print); // prints 1, 2, 3
   factory Observable.concatEager(Iterable<Stream<T>> streams) =>
       new Observable<T>(new ConcatEagerStream<T>(streams));
 
   /// The defer factory waits until an observer subscribes to it, and then it
   /// creates an Observable with the given factory function.
   ///
-  /// It does this afresh for each subscriber, so although each subscriber may
-  /// think it is subscribing to the same Observable, in fact each subscriber
-  /// gets its own individual sequence.
-  ///
   /// In some circumstances, waiting until the last minute (that is, until
   /// subscription time) to generate the Observable can ensure that this
   /// Observable contains the freshest data.
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.defer(() => new Observable.just(1))
+  ///       .listen(print); //prints 1
   factory Observable.defer(Stream<T> streamFactory()) =>
       new Observable<T>(new DeferStream<T>(streamFactory));
 
-  /// Returns an observable sequence that terminates with an exception, then
-  /// immediately completes.
+  /// Returns an observable sequence that emits an [error], then immediately
+  /// completes.
   ///
   /// The error operator is one with very specific and limited behavior. It is
   /// mostly useful for testing purposes.
@@ -280,6 +425,11 @@ class Observable<T> extends Stream<T> {
   ///
   /// When the future completes, the stream will fire one event, either
   /// data or error, and then close with a done-event.
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromFuture(new Future.value("Hello"))
+  ///       .listen(print); // prints "Hello"
   factory Observable.fromFuture(Future<T> future) =>
       new Observable<T>((new Stream<T>.fromFuture(future)));
 
@@ -292,24 +442,45 @@ class Observable<T> extends Stream<T> {
   /// that error. No done event will be sent (iteration is not complete), but no
   /// further data events will be generated either, since iteration cannot
   /// continue.
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromIterable([1, 2]).listen(print); // prints 1, 2
   factory Observable.fromIterable(Iterable<T> data) =>
       new Observable<T>((new Stream<T>.fromIterable(data)));
 
   /// Creates an Observable that contains a single value
   ///
   /// The value is emitted when the stream receives a listener.
+  ///
+  /// ### Example
+  ///
+  ///      new Observable.just(1).listen(print); // prints 1
   factory Observable.just(T data) =>
       new Observable<T>((new Stream<T>.fromIterable(<T>[data])));
 
   /// Creates an Observable that contains no values.
   ///
   /// No items are emitted from the stream, and done is called upon listening.
-  factory Observable.empty() => observable((new Stream<T>.empty()));
-
-  /// Creates an Observable where each item is the interleaved output emitted by
-  /// the feeder streams.
   ///
-  /// http://rxmarbles.com/#merge
+  /// ### Example
+  ///
+  ///     new Observable.empty().listen(
+  ///       (_) => print("data"), onDone: () => print("done")); // prints "done"
+  factory Observable.empty() => new Observable<T>((new Stream<T>.empty()));
+
+  /// Flattens the items emitted by the given [streams] into a single Observable
+  /// sequence.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#merge)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.merge([
+  ///       new Observable.timer(1, new Duration(days: 10)),
+  ///       new Observable.just(2)
+  ///     ])
+  ///     .listen(print); // prints 2, 1
   factory Observable.merge(Iterable<Stream<T>> streams) =>
       new Observable<T>(new MergeStream<T>(streams));
 
@@ -320,6 +491,10 @@ class Observable<T> extends Stream<T> {
   /// are useful for testing purposes, and sometimes also for combining with
   /// other Observables or as parameters to operators that expect other
   /// Observables as parameters.
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.never().listen(print); // Neither prints nor terminates
   factory Observable.never() => new Observable<T>(new NeverStream<T>());
 
   /// Creates an Observable that repeatedly emits events at [period] intervals.
@@ -329,6 +504,11 @@ class Observable<T> extends Stream<T> {
   /// every event.
   ///
   /// If [computation] is omitted the event values will all be `null`.
+  ///
+  /// ### Example
+  ///
+  ///      new Observable.periodic(new Duration(seconds: 1), (i) => i).take(3)
+  ///        .listen(print); // prints 0, 1, 2
   factory Observable.periodic(Duration period,
           [T computation(int computationCount)]) =>
       new Observable<T>((new Stream<T>.periodic(period, computation)));
@@ -377,134 +557,179 @@ class Observable<T> extends Stream<T> {
 
   /// Creates an Observable that emits values starting from startValue and
   /// incrementing according to the ease type over the duration.
-  /// todo : needs more detail
+  ///
+  /// This function is generally useful for transitions, such as animating
+  /// items across a screen or muting the volume of a sound gracefully.
+  ///
+  /// ### Example
+  ///
+  ///     Observable
+  ///       .tween(0.0, 100.0, const Duration(seconds: 1), ease: Ease.IN)
+  ///       .listen((i) => view.setLeft(i)); // Imaginary API as an example
   static Observable<double> tween(
           double startValue, double changeInTime, Duration duration,
-          {int intervalMs: 20, Ease ease: Ease.LINEAR}) =>
+          {int intervalMs: 16, Ease ease: Ease.LINEAR}) =>
       new Observable<double>(new TweenStream(
           startValue, changeInTime, duration, intervalMs, ease));
 
-  /// Creates an Observable that applies a function of your choosing to the
-  /// combination of items emitted, in sequence, by two (or more) other
-  /// Observables, with the results of this function becoming the items emitted
-  /// by the returned Observable. It applies this function in strict sequence,
-  /// so the first item emitted by the new Observable will be the result of the
-  /// function applied to the first item emitted by Observable #1 and the first
-  /// item emitted by Observable #2; the second item emitted by the new
-  /// zip-Observable will be the result of the function applied to the second
-  /// item emitted by Observable #1 and the second item emitted by Observable
-  /// #2; and so forth. It will only emit as many items as the number of items
-  /// emitted by the source Observable that emits the fewest items.
+  /// Merges the specified streams into one observable sequence using the given
+  /// zipper function whenever all of the observable sequences have produced
+  /// an element at a corresponding index.
   ///
-  /// http://rxmarbles.com/#zip
-  @Deprecated('For better strong mode support, use zip2, zip3, ... instead')
-  factory Observable.zip(
-          Iterable<Stream<dynamic>> streams, Function predicate) =>
-      new Observable<T>(new ZipStream<T>(streams, predicate));
-
-  /// Creates an Observable that applies a function of your choosing to the
-  /// combination of items emitted, in sequence, by two (or more) other
-  /// Observables, with the results of this function becoming the items emitted
-  /// by the returned Observable. It applies this function in strict sequence,
-  /// so the first item emitted by the new Observable will be the result of the
-  /// function applied to the first item emitted by Observable #1 and the first
-  /// item emitted by Observable #2; the second item emitted by the new
-  /// zip-Observable will be the result of the function applied to the second
-  /// item emitted by Observable #1 and the second item emitted by Observable
-  /// #2; and so forth. It will only emit as many items as the number of items
-  /// emitted by the source Observable that emits the fewest items.
+  /// It applies this function in strict sequence, so the first item emitted by
+  /// the new Observable will be the result of the function applied to the first
+  /// item emitted by Observable #1 and the first item emitted by Observable #2;
+  /// the second item emitted by the new zip-Observable will be the result of
+  /// the function applied to the second item emitted by Observable #1 and the
+  /// second item emitted by Observable #2; and so forth. It will only emit as
+  /// many items as the number of items emitted by the source Observable that
+  /// emits the fewest items.
   ///
-  /// http://rxmarbles.com/#zip
+  /// [Interactive marble diagram](http://rxmarbles.com/#zip)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.zip2(
+  ///       new Observable.just("Hi "),
+  ///       new Observable.fromIterable(["Friend", "Dropped"]),
+  ///       (a, b) => a + b)
+  ///     .listen(print); // prints "Hi Friend"
   static Observable<T> zip2<A, B, T>(
-          Stream<A> streamOne, Stream<B> streamTwo, T predicate(A a, B b)) =>
+          Stream<A> streamOne, Stream<B> streamTwo, T zipper(A a, B b)) =>
       new Observable<T>(
-          new ZipStream<T>(<Stream<dynamic>>[streamOne, streamTwo], predicate));
+          new ZipStream<T>(<Stream<dynamic>>[streamOne, streamTwo], zipper));
 
-  /// Creates an Observable that applies a function of your choosing to the
-  /// combination of items emitted, in sequence, by two (or more) other
-  /// Observables, with the results of this function becoming the items emitted
-  /// by the returned Observable. It applies this function in strict sequence,
-  /// so the first item emitted by the new Observable will be the result of the
-  /// function applied to the first item emitted by Observable #1 and the first
-  /// item emitted by Observable #2; the second item emitted by the new
-  /// zip-Observable will be the result of the function applied to the second
-  /// item emitted by Observable #1 and the second item emitted by Observable
-  /// #2; and so forth. It will only emit as many items as the number of items
-  /// emitted by the source Observable that emits the fewest items.
+  /// Merges the specified streams into one observable sequence using the given
+  /// zipper function whenever all of the observable sequences have produced
+  /// an element at a corresponding index.
   ///
-  /// http://rxmarbles.com/#zip
+  /// It applies this function in strict sequence, so the first item emitted by
+  /// the new Observable will be the result of the function applied to the first
+  /// item emitted by Observable #1 and the first item emitted by Observable #2;
+  /// the second item emitted by the new zip-Observable will be the result of
+  /// the function applied to the second item emitted by Observable #1 and the
+  /// second item emitted by Observable #2; and so forth. It will only emit as
+  /// many items as the number of items emitted by the source Observable that
+  /// emits the fewest items.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#zip)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.zip3(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.fromIterable(["c", "dropped"]),
+  ///       (a, b, c) => a + b + c)
+  ///     .listen(print); //prints "abc"
   static Observable<T> zip3<A, B, C, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
-          T predicate(A a, B b, C c)) =>
+          T zipper(A a, B b, C c)) =>
       new Observable<T>(new ZipStream<T>(
-          <Stream<dynamic>>[streamOne, streamTwo, streamThree], predicate));
+          <Stream<dynamic>>[streamOne, streamTwo, streamThree], zipper));
 
-  /// Creates an Observable that applies a function of your choosing to the
-  /// combination of items emitted, in sequence, by two (or more) other
-  /// Observables, with the results of this function becoming the items emitted
-  /// by the returned Observable. It applies this function in strict sequence,
-  /// so the first item emitted by the new Observable will be the result of the
-  /// function applied to the first item emitted by Observable #1 and the first
-  /// item emitted by Observable #2; the second item emitted by the new
-  /// zip-Observable will be the result of the function applied to the second
-  /// item emitted by Observable #1 and the second item emitted by Observable
-  /// #2; and so forth. It will only emit as many items as the number of items
-  /// emitted by the source Observable that emits the fewest items.
+  /// Merges the specified streams into one observable sequence using the given
+  /// zipper function whenever all of the observable sequences have produced
+  /// an element at a corresponding index.
   ///
-  /// http://rxmarbles.com/#zip
+  /// It applies this function in strict sequence, so the first item emitted by
+  /// the new Observable will be the result of the function applied to the first
+  /// item emitted by Observable #1 and the first item emitted by Observable #2;
+  /// the second item emitted by the new zip-Observable will be the result of
+  /// the function applied to the second item emitted by Observable #1 and the
+  /// second item emitted by Observable #2; and so forth. It will only emit as
+  /// many items as the number of items emitted by the source Observable that
+  /// emits the fewest items.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#zip)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.zip4(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.fromIterable(["d", "dropped"]),
+  ///       (a, b, c, d) => a + b + c + d)
+  ///     .listen(print); //prints "abcd"
   static Observable<T> zip4<A, B, C, D, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
           Stream<D> streamFour,
-          T predicate(A a, B b, C c, D d)) =>
+          T zipper(A a, B b, C c, D d)) =>
       new Observable<T>(new ZipStream<T>(
           <Stream<dynamic>>[streamOne, streamTwo, streamThree, streamFour],
-          predicate));
+          zipper));
 
-  /// Creates an Observable that applies a function of your choosing to the
-  /// combination of items emitted, in sequence, by two (or more) other
-  /// Observables, with the results of this function becoming the items emitted
-  /// by the returned Observable. It applies this function in strict sequence,
-  /// so the first item emitted by the new Observable will be the result of the
-  /// function applied to the first item emitted by Observable #1 and the first
-  /// item emitted by Observable #2; the second item emitted by the new
-  /// zip-Observable will be the result of the function applied to the second
-  /// item emitted by Observable #1 and the second item emitted by Observable
-  /// #2; and so forth. It will only emit as many items as the number of items
-  /// emitted by the source Observable that emits the fewest items.
+  /// Merges the specified streams into one observable sequence using the given
+  /// zipper function whenever all of the observable sequences have produced
+  /// an element at a corresponding index.
   ///
-  /// http://rxmarbles.com/#zip
+  /// It applies this function in strict sequence, so the first item emitted by
+  /// the new Observable will be the result of the function applied to the first
+  /// item emitted by Observable #1 and the first item emitted by Observable #2;
+  /// the second item emitted by the new zip-Observable will be the result of
+  /// the function applied to the second item emitted by Observable #1 and the
+  /// second item emitted by Observable #2; and so forth. It will only emit as
+  /// many items as the number of items emitted by the source Observable that
+  /// emits the fewest items.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#zip)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.zip5(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.fromIterable(["e", "dropped"]),
+  ///       (a, b, c, d, e) => a + b + c + d + e)
+  ///     .listen(print); //prints "abcde"
   static Observable<T> zip5<A, B, C, D, E, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
           Stream<C> streamThree,
           Stream<D> streamFour,
           Stream<E> streamFive,
-          T predicate(A a, B b, C c, D d, E e)) =>
+          T zipper(A a, B b, C c, D d, E e)) =>
       new Observable<T>(new ZipStream<T>(<Stream<dynamic>>[
         streamOne,
         streamTwo,
         streamThree,
         streamFour,
         streamFive
-      ], predicate));
+      ], zipper));
 
-  /// Creates an Observable that applies a function of your choosing to the
-  /// combination of items emitted, in sequence, by two (or more) other
-  /// Observables, with the results of this function becoming the items emitted
-  /// by the returned Observable. It applies this function in strict sequence,
-  /// so the first item emitted by the new Observable will be the result of the
-  /// function applied to the first item emitted by Observable #1 and the first
-  /// item emitted by Observable #2; the second item emitted by the new
-  /// zip-Observable will be the result of the function applied to the second
-  /// item emitted by Observable #1 and the second item emitted by Observable
-  /// #2; and so forth. It will only emit as many items as the number of items
-  /// emitted by the source Observable that emits the fewest items.
+  /// Merges the specified streams into one observable sequence using the given
+  /// zipper function whenever all of the observable sequences have produced
+  /// an element at a corresponding index.
   ///
-  /// http://rxmarbles.com/#zip
+  /// It applies this function in strict sequence, so the first item emitted by
+  /// the new Observable will be the result of the function applied to the first
+  /// item emitted by Observable #1 and the first item emitted by Observable #2;
+  /// the second item emitted by the new zip-Observable will be the result of
+  /// the function applied to the second item emitted by Observable #1 and the
+  /// second item emitted by Observable #2; and so forth. It will only emit as
+  /// many items as the number of items emitted by the source Observable that
+  /// emits the fewest items.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#zip)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.zip6(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.fromIterable(["f", "dropped"]),
+  ///       (a, b, c, d, e, f) => a + b + c + d + e + f)
+  ///     .listen(print); //prints "abcdef"
   static Observable<T> zip6<A, B, C, D, E, F, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
@@ -512,7 +737,7 @@ class Observable<T> extends Stream<T> {
           Stream<D> streamFour,
           Stream<E> streamFive,
           Stream<F> streamSix,
-          T predicate(A a, B b, C c, D d, E e, F f)) =>
+          T zipper(A a, B b, C c, D d, E e, F f)) =>
       new Observable<T>(new ZipStream<T>(<Stream<dynamic>>[
         streamOne,
         streamTwo,
@@ -520,21 +745,35 @@ class Observable<T> extends Stream<T> {
         streamFour,
         streamFive,
         streamSix
-      ], predicate));
+      ], zipper));
 
-  /// Creates an Observable that applies a function of your choosing to the
-  /// combination of items emitted, in sequence, by two (or more) other
-  /// Observables, with the results of this function becoming the items emitted
-  /// by the returned Observable. It applies this function in strict sequence,
-  /// so the first item emitted by the new Observable will be the result of the
-  /// function applied to the first item emitted by Observable #1 and the first
-  /// item emitted by Observable #2; the second item emitted by the new
-  /// zip-Observable will be the result of the function applied to the second
-  /// item emitted by Observable #1 and the second item emitted by Observable
-  /// #2; and so forth. It will only emit as many items as the number of items
-  /// emitted by the source Observable that emits the fewest items.
+  /// Merges the specified streams into one observable sequence using the given
+  /// zipper function whenever all of the observable sequences have produced
+  /// an element at a corresponding index.
   ///
-  /// http://rxmarbles.com/#zip
+  /// It applies this function in strict sequence, so the first item emitted by
+  /// the new Observable will be the result of the function applied to the first
+  /// item emitted by Observable #1 and the first item emitted by Observable #2;
+  /// the second item emitted by the new zip-Observable will be the result of
+  /// the function applied to the second item emitted by Observable #1 and the
+  /// second item emitted by Observable #2; and so forth. It will only emit as
+  /// many items as the number of items emitted by the source Observable that
+  /// emits the fewest items.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#zip)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.zip7(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.just("f"),
+  ///       new Observable.fromIterable(["g", "dropped"]),
+  ///       (a, b, c, d, e, f, g) => a + b + c + d + e + f + g)
+  ///     .listen(print); //prints "abcdefg"
   static Observable<T> zip7<A, B, C, D, E, F, G, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
@@ -543,7 +782,7 @@ class Observable<T> extends Stream<T> {
           Stream<E> streamFive,
           Stream<F> streamSix,
           Stream<G> streamSeven,
-          T predicate(A a, B b, C c, D d, E e, F f, G g)) =>
+          T zipper(A a, B b, C c, D d, E e, F f, G g)) =>
       new Observable<T>(new ZipStream<T>(<Stream<dynamic>>[
         streamOne,
         streamTwo,
@@ -552,21 +791,36 @@ class Observable<T> extends Stream<T> {
         streamFive,
         streamSix,
         streamSeven
-      ], predicate));
+      ], zipper));
 
-  /// Creates an Observable that applies a function of your choosing to the
-  /// combination of items emitted, in sequence, by two (or more) other
-  /// Observables, with the results of this function becoming the items emitted
-  /// by the returned Observable. It applies this function in strict sequence,
-  /// so the first item emitted by the new Observable will be the result of the
-  /// function applied to the first item emitted by Observable #1 and the first
-  /// item emitted by Observable #2; the second item emitted by the new
-  /// zip-Observable will be the result of the function applied to the second
-  /// item emitted by Observable #1 and the second item emitted by Observable
-  /// #2; and so forth. It will only emit as many items as the number of items
-  /// emitted by the source Observable that emits the fewest items.
+  /// Merges the specified streams into one observable sequence using the given
+  /// zipper function whenever all of the observable sequences have produced
+  /// an element at a corresponding index.
   ///
-  /// http://rxmarbles.com/#zip
+  /// It applies this function in strict sequence, so the first item emitted by
+  /// the new Observable will be the result of the function applied to the first
+  /// item emitted by Observable #1 and the first item emitted by Observable #2;
+  /// the second item emitted by the new zip-Observable will be the result of
+  /// the function applied to the second item emitted by Observable #1 and the
+  /// second item emitted by Observable #2; and so forth. It will only emit as
+  /// many items as the number of items emitted by the source Observable that
+  /// emits the fewest items.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#zip)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.zip8(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.just("f"),
+  ///       new Observable.just("g"),
+  ///       new Observable.fromIterable(["h", "dropped"]),
+  ///       (a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h)
+  ///     .listen(print); //prints "abcdefgh"
   static Observable<T> zip8<A, B, C, D, E, F, G, H, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
@@ -576,7 +830,7 @@ class Observable<T> extends Stream<T> {
           Stream<F> streamSix,
           Stream<G> streamSeven,
           Stream<H> streamEight,
-          T predicate(A a, B b, C c, D d, E e, F f, G g, H h)) =>
+          T zipper(A a, B b, C c, D d, E e, F f, G g, H h)) =>
       new Observable<T>(new ZipStream<T>(<Stream<dynamic>>[
         streamOne,
         streamTwo,
@@ -586,21 +840,37 @@ class Observable<T> extends Stream<T> {
         streamSix,
         streamSeven,
         streamEight
-      ], predicate));
+      ], zipper));
 
-  /// Creates an Observable that applies a function of your choosing to the
-  /// combination of items emitted, in sequence, by two (or more) other
-  /// Observables, with the results of this function becoming the items emitted
-  /// by the returned Observable. It applies this function in strict sequence,
-  /// so the first item emitted by the new Observable will be the result of the
-  /// function applied to the first item emitted by Observable #1 and the first
-  /// item emitted by Observable #2; the second item emitted by the new
-  /// zip-Observable will be the result of the function applied to the second
-  /// item emitted by Observable #1 and the second item emitted by Observable
-  /// #2; and so forth. It will only emit as many items as the number of items
-  /// emitted by the source Observable that emits the fewest items.
+  /// Merges the specified streams into one observable sequence using the given
+  /// zipper function whenever all of the observable sequences have produced
+  /// an element at a corresponding index.
   ///
-  /// http://rxmarbles.com/#zip
+  /// It applies this function in strict sequence, so the first item emitted by
+  /// the new Observable will be the result of the function applied to the first
+  /// item emitted by Observable #1 and the first item emitted by Observable #2;
+  /// the second item emitted by the new zip-Observable will be the result of
+  /// the function applied to the second item emitted by Observable #1 and the
+  /// second item emitted by Observable #2; and so forth. It will only emit as
+  /// many items as the number of items emitted by the source Observable that
+  /// emits the fewest items.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#zip)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.zip9(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.just("f"),
+  ///       new Observable.just("g"),
+  ///       new Observable.just("h"),
+  ///       new Observable.fromIterable(["i", "dropped"]),
+  ///       (a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h + i)
+  ///     .listen(print); //prints "abcdefghi"
   static Observable<T> zip9<A, B, C, D, E, F, G, H, I, T>(
           Stream<A> streamOne,
           Stream<B> streamTwo,
@@ -611,7 +881,7 @@ class Observable<T> extends Stream<T> {
           Stream<G> streamSeven,
           Stream<H> streamEight,
           Stream<I> streamNine,
-          T predicate(A a, B b, C c, D d, E e, F f, G g, H h, I i)) =>
+          T zipper(A a, B b, C c, D d, E e, F f, G g, H h, I i)) =>
       new Observable<T>(new ZipStream<T>(<Stream<dynamic>>[
         streamOne,
         streamTwo,
@@ -622,7 +892,7 @@ class Observable<T> extends Stream<T> {
         streamSeven,
         streamEight,
         streamNine
-      ], predicate));
+      ], zipper));
 
   /// Returns a multi-subscription stream that produces the same events as this.
   ///
@@ -940,11 +1210,49 @@ class Observable<T> extends Stream<T> {
   Future<dynamic> lastWhere(bool test(T element), {Object defaultValue()}) =>
       stream.lastWhere(test, defaultValue: defaultValue);
 
+  /// Adds a subscription to this stream. Returns a [StreamSubscription] which
+  /// handles events from the stream using the provided [onData], [onError] and
+  /// [onDone] handlers.
+  ///
+  /// The handlers can be changed on the subscription, but they start out
+  /// as the provided functions.
+  ///
+  /// On each data event from this stream, the subscriber's [onData] handler
+  /// is called. If [onData] is `null`, nothing happens.
+  ///
+  /// On errors from this stream, the [onError] handler is called with the
+  /// error object and possibly a stack trace.
+  ///
+  /// The [onError] callback must be of type `void onError(error)` or
+  /// `void onError(error, StackTrace stackTrace)`. If [onError] accepts
+  /// two arguments it is called with the error object and the stack trace
+  /// (which could be `null` if the stream itself received an error without
+  /// stack trace).
+  /// Otherwise it is called with just the error object.
+  /// If [onError] is omitted, any errors on the stream are considered unhandled,
+  /// and will be passed to the current [Zone]'s error handler.
+  /// By default unhandled async errors are treated
+  /// as if they were uncaught top-level errors.
+  ///
+  /// If this stream closes and sends a done event, the [onDone] handler is
+  /// called. If [onDone] is `null`, nothing happens.
+  ///
+  /// If [cancelOnError] is true, the subscription is automatically cancelled
+  /// when the first error event is delivered. The default is `false`.
+  ///
+  /// While a subscription is paused, or when it has been cancelled,
+  /// the subscription doesn't receive events and none of the
+  /// event handler functions are called.
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.just(1).listen(print); // prints 1
   @override
   StreamSubscription<T> listen(void onData(T event),
-          {Function onError, void onDone(), bool cancelOnError}) =>
-      stream.listen(onData,
-          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+      {Function onError, void onDone(), bool cancelOnError}) {
+    return stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
 
   @override
   Future<int> get length => stream.length;

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -44,6 +44,62 @@ import 'package:rxdart/src/transformers/timestamp.dart';
 import 'package:rxdart/src/transformers/window_with_count.dart';
 import 'package:rxdart/src/transformers/with_latest_from.dart';
 
+/// A wrapper class that extends Stream. It combines all the Streams and
+/// StreamTransformers contained in this library into a fluent api.
+///
+/// ### Example
+///
+///     new Observable(new Stream.fromIterable([1]))
+///       .interval(new Duration(seconds: 1))
+///       .flatMap((i) => new Observable.just(2))
+///       .take(1)
+///       .listen(print); // prints 2
+///
+/// ### Learning RxDart
+///
+/// This library contains documentation and examples for each method. In
+/// addition, more complex examples can be found in the
+/// [RxDart github repo](https://github.com/ReactiveX/rxdart) demonstrating how
+/// to use RxDart with web, command line, and Flutter applications.
+///
+/// ### Dart Streams vs Observables
+///
+/// In order to integrate fluently with the Dart ecosystem, the Observable class
+/// extends the Dart `Stream` class. This provides several advantages:
+///
+///    - Observables work with any API that expects a Dart Stream as an input.
+///    - Inherit the many methods and properties from the core Stream API.
+///    - Ability to create Streams with language-level syntax.
+///
+/// Overall, we attempt to follow the Observable spec as closely as we can, but
+/// prioritize fitting in with the Dart ecosystem when a trade-off must be made.
+/// Therefore, there are some important differences to note between Dart's
+/// `Stream` class and standard Rx `Observable`.
+///
+/// First, Cold Observables in Dart are single-subscription. In other words,
+/// you can only listen to Observables once, unless it is a hot (aka broadcast)
+/// Stream. If you attempt to listen to a cold stream twice, a StateError will
+/// be thrown. If you need to listen to a stream multiple times, you can simply
+/// create a factory function that returns a new instance of the stream.
+///
+/// Second, many methods contained within, such as `first` and `last` do not
+/// return a `Single` nor an `Observable`, but rather must return a Dart Future.
+/// Luckily, Dart Futures are easy to work with, and easily convert back to a
+/// Stream using the `myFuture.asStream()` method if needed.
+///
+/// Third, Streams in Dart do not close by default when an error occurs. In Rx,
+/// an Error causes the Observable to terminate unless it is intercepted by
+/// an operator. Dart has mechanisms for creating streams that close when an
+/// error occurs, but the majority of Streams do not exhibit this behavior.
+///
+/// Fourth, Dart streams are asynchronous by default, whereas Observables are
+/// synchronous by default, unless you schedule work on a different Scheduler.
+/// You can create synchronous Streams with Dart, but please be aware the the
+/// default is simply different.
+///
+/// Finally, when using Dart Broadcast Streams (similar to Hot Observables),
+/// please know that `onListen` will only be called the first time the
+/// broadcast stream is listened to.
 class Observable<T> extends Stream<T> {
   final Stream<T> stream;
 

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -1078,10 +1078,10 @@ class Observable<T> extends Stream<T> {
   ///
   /// ### Example
   ///
-  ///   Observable.range(4, 1)
-  ///     .concatMap((i) =>
-  ///       new Observable.timer(i, new Duration(minutes: i))
-  ///     .listen(print); // prints 4, 3, 2, 1
+  ///     Observable.range(4, 1)
+  ///       .concatMap((i) =>
+  ///         new Observable.timer(i, new Duration(minutes: i))
+  ///       .listen(print); // prints 4, 3, 2, 1
   Observable<S> concatMap<S>(Stream<S> mapper(T value)) =>
       transform(new ConcatMapStreamTransformer<T, S>(mapper));
 
@@ -1120,7 +1120,7 @@ class Observable<T> extends Stream<T> {
   ///
   /// ### Example
   ///
-  ///   new Observable.empty().defaultIfEmpty(10).listen(print); // prints 10
+  ///     new Observable.empty().defaultIfEmpty(10).listen(print); // prints 10
   Observable<T> defaultIfEmpty(T defaultValue) =>
       transform(new DefaultIfEmptyStreamTransformer<T>(defaultValue));
 
@@ -1131,11 +1131,14 @@ class Observable<T> extends Stream<T> {
   /// events as [Notification] objects. Dematerialize simply reverses this by
   /// transforming [Notification] objects back to a normal stream of events.
   ///
-  /// Example:
+  /// ### Example
+  ///
   ///     new Observable<Notification<int>>
   ///         .fromIterable([new Notification.onData(1), new Notification.onDone()])
   ///         .dematerialize()
   ///         .listen((i) => print(i)); // Prints 1
+  ///
+  /// ### Error example
   ///
   ///     new Observable<Notification<int>>
   ///         .just(new Notification.onError(new Exception(), null))
@@ -1207,10 +1210,10 @@ class Observable<T> extends Stream<T> {
   ///
   /// ### Example
   ///
-  ///   Observable.range(4, 1)
-  ///     .flatMap((i) =>
-  ///       new Observable.timer(i, new Duration(minutes: i))
-  ///     .listen(print); // prints 1, 2, 3, 4
+  ///     Observable.range(4, 1)
+  ///       .flatMap((i) =>
+  ///         new Observable.timer(i, new Duration(minutes: i))
+  ///       .listen(print); // prints 1, 2, 3, 4
   Observable<S> flatMap<S>(Stream<S> mapper(T value)) =>
       transform(new FlatMapStreamTransformer<T, S>(mapper));
 
@@ -1226,10 +1229,10 @@ class Observable<T> extends Stream<T> {
   ///
   /// ### Example
   ///
-  ///   Observable.range(4, 1)
-  ///     .flatMapLatest((i) =>
-  ///       new Observable.timer(i, new Duration(minutes: i))
-  ///     .listen(print); // prints 1
+  ///     Observable.range(4, 1)
+  ///       .flatMapLatest((i) =>
+  ///         new Observable.timer(i, new Duration(minutes: i))
+  ///       .listen(print); // prints 1
   Observable<S> flatMapLatest<S>(Stream<S> mapper(T value)) =>
       transform(new FlatMapLatestStreamTransformer<T, S>(mapper));
 
@@ -1543,11 +1546,11 @@ class Observable<T> extends Stream<T> {
   /// ### Example
   ///
   ///     new Observable.merge([
-  ///       new Observable.just(1),
-  ///       new Observable.timer(2, new Duration(minutes: 2))
-  ///     ])
-  ///     .skipUntil(new Observable.timer(true, new Duration(minutes: 1)))
-  ///     .listen(print); // prints 2;
+  ///         new Observable.just(1),
+  ///         new Observable.timer(2, new Duration(minutes: 2))
+  ///       ])
+  ///       .skipUntil(new Observable.timer(true, new Duration(minutes: 1)))
+  ///       .listen(print); // prints 2;
   Observable<T> skipUntil<S>(Stream<S> otherStream) =>
       transform(new SkipUntilStreamTransformer<T, S>(otherStream));
 
@@ -1632,12 +1635,14 @@ class Observable<T> extends Stream<T> {
   /// Returns the values from the source observable sequence until the other
   /// observable sequence produces a value.
   ///
-  /// new Observable.merge([
-  ///     new Observable.just(1),
-  ///     new Observable.timer(2, new Duration(minutes: 1))
-  ///   ])
-  ///   .takeUntil(new Observable.timer(3, new Duration(seconds: 10)))
-  ///   .listen(print); // prints 1
+  /// ### Example
+  ///
+  ///     new Observable.merge([
+  ///         new Observable.just(1),
+  ///         new Observable.timer(2, new Duration(minutes: 1))
+  ///       ])
+  ///       .takeUntil(new Observable.timer(3, new Duration(seconds: 10)))
+  ///       .listen(print); // prints 1
   Observable<T> takeUntil<S>(Stream<S> otherStream) =>
       transform(new TakeUntilStreamTransformer<T, S>(otherStream));
 

--- a/lib/src/streams/amb.dart
+++ b/lib/src/streams/amb.dart
@@ -1,5 +1,17 @@
 import 'dart:async';
 
+/// Given two or more source streams, emit all of the items from only
+/// the first of these streams to emit an item or notification.
+///
+/// [Interactive marble diagram](http://rxmarbles.com/#amb)
+///
+/// ### Example
+///
+///     new AmbStream([
+///       new TimerStream(1, new Duration(days: 1)),
+///       new TimerStream(2, new Duration(days: 2)),
+///       new TimerStream(3, new Duration(seconds: 3))
+///     ]).listen(print); // prints 3
 class AmbStream<T> extends Stream<T> {
   final StreamController<T> controller;
 

--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -1,10 +1,27 @@
 import 'dart:async';
 
+/// Merges the given Streams into one Stream sequence by using the
+/// combiner function whenever any of the source stream sequences emits an
+/// item.
+///
+/// The Stream will not emit until all Streams have emitted at least one
+/// item.
+///
+/// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+///
+/// ### Example
+///
+///     new CombineLatestStream([
+///       new Stream.fromIterable(["a"]),
+///       new Stream.fromIterable(["b"]),
+///       new Stream.fromIterable(["c", "c"])],
+///       (a, b, c) => a + b + c)
+///     .listen(print); //prints "abc", "abc"
 class CombineLatestStream<T> extends Stream<T> {
   final StreamController<T> controller;
 
-  CombineLatestStream(Iterable<Stream<dynamic>> streams, Function predicate)
-      : controller = _buildController(streams, predicate);
+  CombineLatestStream(Iterable<Stream<dynamic>> streams, Function combiner)
+      : controller = _buildController(streams, combiner);
 
   @override
   StreamSubscription<T> listen(void onData(T event),

--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -31,7 +31,7 @@ class CombineLatestStream<T> extends Stream<T> {
   }
 
   static StreamController<T> _buildController<T>(
-      Iterable<Stream<dynamic>> streams, Function predicate) {
+      Iterable<Stream<dynamic>> streams, Function combiner) {
     final List<StreamSubscription<dynamic>> subscriptions =
         new List<StreamSubscription<dynamic>>(streams.length);
     StreamController<T> controller;
@@ -59,7 +59,7 @@ class CombineLatestStream<T> extends Stream<T> {
                         triggered.reduce((bool a, bool b) => a && b);
 
                   if (allStreamsHaveEvents)
-                    updateWithValues(predicate, values, controller);
+                    updateWithValues(combiner, values, controller);
                 },
                 onError: controller.addError,
                 onDone: () {
@@ -78,7 +78,7 @@ class CombineLatestStream<T> extends Stream<T> {
     return controller;
   }
 
-  static void updateWithValues<T>(Function predicate, Iterable<dynamic> values,
+  static void updateWithValues<T>(Function combiner, Iterable<dynamic> values,
       StreamController<T> controller) {
     try {
       final int len = values.length;
@@ -86,22 +86,22 @@ class CombineLatestStream<T> extends Stream<T> {
 
       switch (len) {
         case 2:
-          result = predicate(values.elementAt(0), values.elementAt(1));
+          result = combiner(values.elementAt(0), values.elementAt(1));
           break;
         case 3:
-          result = predicate(
+          result = combiner(
               values.elementAt(0), values.elementAt(1), values.elementAt(2));
           break;
         case 4:
-          result = predicate(values.elementAt(0), values.elementAt(1),
+          result = combiner(values.elementAt(0), values.elementAt(1),
               values.elementAt(2), values.elementAt(3));
           break;
         case 5:
-          result = predicate(values.elementAt(0), values.elementAt(1),
+          result = combiner(values.elementAt(0), values.elementAt(1),
               values.elementAt(2), values.elementAt(3), values.elementAt(4));
           break;
         case 6:
-          result = predicate(
+          result = combiner(
               values.elementAt(0),
               values.elementAt(1),
               values.elementAt(2),
@@ -110,7 +110,7 @@ class CombineLatestStream<T> extends Stream<T> {
               values.elementAt(5));
           break;
         case 7:
-          result = predicate(
+          result = combiner(
               values.elementAt(0),
               values.elementAt(1),
               values.elementAt(2),
@@ -120,7 +120,7 @@ class CombineLatestStream<T> extends Stream<T> {
               values.elementAt(6));
           break;
         case 8:
-          result = predicate(
+          result = combiner(
               values.elementAt(0),
               values.elementAt(1),
               values.elementAt(2),
@@ -131,7 +131,7 @@ class CombineLatestStream<T> extends Stream<T> {
               values.elementAt(7));
           break;
         case 9:
-          result = predicate(
+          result = combiner(
               values.elementAt(0),
               values.elementAt(1),
               values.elementAt(2),

--- a/lib/src/streams/concat.dart
+++ b/lib/src/streams/concat.dart
@@ -1,5 +1,21 @@
 import 'dart:async';
 
+/// Concatenates all of the specified stream sequences, as long as the
+/// previous stream sequence terminated successfully.
+///
+/// It does this by subscribing to each stream one by one, emitting all items
+/// and completing before subscribing to the next stream.
+///
+/// [Interactive marble diagram](http://rxmarbles.com/#concat)
+///
+/// ### Example
+///
+///     new ConcatStream([
+///       new Stream.fromIterable([1]),
+///       new TimerStream(2, new Duration(days: 1)),
+///       new Stream.fromIterable([3])
+///     ])
+///     .listen(print); // prints 1, 2, 3
 class ConcatStream<T> extends Stream<T> {
   final StreamController<T> controller;
 

--- a/lib/src/streams/concat_eager.dart
+++ b/lib/src/streams/concat_eager.dart
@@ -1,5 +1,23 @@
 import 'dart:async';
 
+/// Concatenates all of the specified stream sequences, as long as the
+/// previous stream sequence terminated successfully.
+///
+/// In the case of concatEager, rather than subscribing to one stream after
+/// the next, all streams are immediately subscribed to. The events are then
+/// captured and emitted at the correct time, after the previous stream has
+/// finished emitting items.
+///
+/// [Interactive marble diagram](http://rxmarbles.com/#concat)
+///
+/// ### Example
+///
+///     new ConcatEagerStream([
+///       new Stream.fromIterable([1]),
+///       new TimerStream(2, new Duration(days: 1)),
+///       new Stream.fromIterable([3])
+///     ])
+///     .listen(print); // prints 1, 2, 3
 class ConcatEagerStream<T> extends Stream<T> {
   final StreamController<T> controller;
 

--- a/lib/src/streams/defer.dart
+++ b/lib/src/streams/defer.dart
@@ -2,6 +2,16 @@ import 'dart:async';
 
 import 'package:rxdart/src/streams/utils.dart';
 
+/// The defer factory waits until an observer subscribes to it, and then it
+/// creates an Observable with the given factory function.
+///
+/// In some circumstances, waiting until the last minute (that is, until
+/// subscription time) to generate the Observable can ensure that this
+/// Observable contains the freshest data.
+///
+/// ### Example
+///
+///     new DeferStream(() => new Observable.just(1)).listen(print); //prints 1
 class DeferStream<T> extends Stream<T> {
   final StreamFactory<T> streamFactory;
   bool _isUsed = false;

--- a/lib/src/streams/error.dart
+++ b/lib/src/streams/error.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-/// Returns an observable sequence that terminates with an exception, then
-/// immediately completes.
+/// Returns an observable sequence that emits an [error], then immediately
+/// completes.
 ///
 /// The error operator is one with very specific and limited behavior. It is
 /// mostly useful for testing purposes.

--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -1,5 +1,17 @@
 import 'dart:async';
 
+/// Flattens the items emitted by the given streams into a single Observable
+/// sequence.
+///
+/// [Interactive marble diagram](http://rxmarbles.com/#merge)
+///
+/// ### Example
+///
+///     new MergeStream([
+///       new TimerStream(1, new Duration(days: 10)),
+///       new Stream.fromIterable([2])
+///     ])
+///     .listen(print); // prints 2, 1
 class MergeStream<T> extends Stream<T> {
   final StreamController<T> controller;
 

--- a/lib/src/streams/never.dart
+++ b/lib/src/streams/never.dart
@@ -7,6 +7,10 @@ import 'dart:async';
 /// are useful for testing purposes, and sometimes also for combining with
 /// other Observables or as parameters to operators that expect other
 /// Observables as parameters.
+///
+/// ### Example
+///
+///     new NeverStream().listen(print); // Neither prints nor terminates
 class NeverStream<T> extends Stream<T> {
   // ignore: close_sinks
   StreamController<T> controller = new StreamController<T>();

--- a/lib/src/streams/tween.dart
+++ b/lib/src/streams/tween.dart
@@ -1,5 +1,15 @@
 import 'dart:async';
 
+/// Creates a Stream that emits values starting from startValue and
+/// incrementing according to the ease type over the duration.
+///
+/// This function is generally useful for transitions, such as animating
+/// items across a screen or muting the volume of a sound gracefully.
+///
+/// ### Example
+///
+///     new TweenStream(0.0, 100.0, const Duration(seconds: 1), ease: Ease.IN)
+///       .listen((i) => view.setLeft(i)); // Imaginary API as an example
 class TweenStream extends Stream<double> {
   final StreamController<double> controller;
 

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -35,7 +35,7 @@ class ZipStream<T> extends Stream<T> {
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   static StreamController<T> _buildController<T>(
-      Iterable<Stream<dynamic>> streams, Function predicate) {
+      Iterable<Stream<dynamic>> streams, Function zipper) {
     StreamController<T> controller;
     final List<bool> pausedStates =
         new List<bool>.generate(streams.length, (_) => false, growable: false);
@@ -58,7 +58,7 @@ class ZipStream<T> extends Stream<T> {
             if (subscriptions[index] != null) subscriptions[index].pause();
 
             if (_areAllPaused(pausedStates)) {
-              updateWithValues(predicate, values, controller);
+              updateWithValues(zipper, values, controller);
 
               _resumeAll(subscriptions, pausedStates);
             }
@@ -90,7 +90,7 @@ class ZipStream<T> extends Stream<T> {
     return controller;
   }
 
-  static void updateWithValues<T>(Function predicate, Iterable<dynamic> values,
+  static void updateWithValues<T>(Function zipper, Iterable<dynamic> values,
       StreamController<T> controller) {
     try {
       final int len = values.length;
@@ -98,22 +98,22 @@ class ZipStream<T> extends Stream<T> {
 
       switch (len) {
         case 2:
-          result = predicate(values.elementAt(0), values.elementAt(1));
+          result = zipper(values.elementAt(0), values.elementAt(1));
           break;
         case 3:
-          result = predicate(
+          result = zipper(
               values.elementAt(0), values.elementAt(1), values.elementAt(2));
           break;
         case 4:
-          result = predicate(values.elementAt(0), values.elementAt(1),
+          result = zipper(values.elementAt(0), values.elementAt(1),
               values.elementAt(2), values.elementAt(3));
           break;
         case 5:
-          result = predicate(values.elementAt(0), values.elementAt(1),
+          result = zipper(values.elementAt(0), values.elementAt(1),
               values.elementAt(2), values.elementAt(3), values.elementAt(4));
           break;
         case 6:
-          result = predicate(
+          result = zipper(
               values.elementAt(0),
               values.elementAt(1),
               values.elementAt(2),
@@ -122,7 +122,7 @@ class ZipStream<T> extends Stream<T> {
               values.elementAt(5));
           break;
         case 7:
-          result = predicate(
+          result = zipper(
               values.elementAt(0),
               values.elementAt(1),
               values.elementAt(2),
@@ -132,7 +132,7 @@ class ZipStream<T> extends Stream<T> {
               values.elementAt(6));
           break;
         case 8:
-          result = predicate(
+          result = zipper(
               values.elementAt(0),
               values.elementAt(1),
               values.elementAt(2),
@@ -143,7 +143,7 @@ class ZipStream<T> extends Stream<T> {
               values.elementAt(7));
           break;
         case 9:
-          result = predicate(
+          result = zipper(
               values.elementAt(0),
               values.elementAt(1),
               values.elementAt(2),

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -1,10 +1,28 @@
 import 'dart:async';
 
+/// Merges the specified streams into one observable sequence using the given
+/// combiner function whenever all of the observable sequences have produced
+/// an element at a corresponding index.
+///
+/// It applies this function in strict sequence, so the first item emitted by
+/// the new Observable will be the result of the function applied to the first
+/// item emitted by Observable #1 and the first item emitted by Observable #2;
+/// the second item emitted by the new zip-Observable will be the result of
+/// the function applied to the second item emitted by Observable #1 and the
+/// second item emitted by Observable #2; and so forth. It will only emit as
+/// many items as the number of items emitted by the source Observable that
+/// emits the fewest items.
+///
+/// [Interactive marble diagram](http://rxmarbles.com/#zip)
+///
+/// ### Example
+///
+///     new ZipStream()
 class ZipStream<T> extends Stream<T> {
   final StreamController<T> controller;
 
-  ZipStream(Iterable<Stream<dynamic>> streams, Function predicate)
-      : controller = _buildController(streams, predicate);
+  ZipStream(Iterable<Stream<dynamic>> streams, Function zipper)
+      : controller = _buildController(streams, zipper);
 
   @override
   StreamSubscription<T> listen(void onData(T event),

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -17,7 +17,11 @@ import 'dart:async';
 ///
 /// ### Example
 ///
-///     new ZipStream()
+///     new ZipStream([
+///         new Stream.fromIterable([1]),
+///         new Stream.fromIterable([2, 3])
+///       ], (a, b) => a + b)
+///       .listen(print); // prints 3
 class ZipStream<T> extends Stream<T> {
   final StreamController<T> controller;
 

--- a/lib/src/transformers/buffer_with_count.dart
+++ b/lib/src/transformers/buffer_with_count.dart
@@ -1,5 +1,22 @@
 import 'dart:async';
 
+/// Creates an Observable where each item is a list containing the items
+/// from the source sequence, in batches of count.
+///
+/// If skip is provided, each group will start where the previous group
+/// ended minus the skip value.
+///
+/// ### Example
+///
+///     new Stream.fromIterable([1, 2, 3, 4])
+///       .transform(new BufferWithCountStreamTransformer(2))
+///       .listen(print); // prints [1, 2], [3, 4]
+///
+/// ### Example with skip
+///
+///     new Stream.fromIterable([1, 2, 3, 4])
+///       .transform(new BufferWithCountStreamTransformer(2, 1))
+///       .listen(print); // prints [1, 2], [2, 3], [3, 4], [4]
 class BufferWithCountStreamTransformer<T, S extends List<T>>
     implements StreamTransformer<T, S> {
   final int count;

--- a/lib/src/transformers/call.dart
+++ b/lib/src/transformers/call.dart
@@ -142,8 +142,11 @@ class CallStreamTransformer<T> implements StreamTransformer<T, T> {
   }
 }
 
+/// The type of event
 enum Kind { OnData, OnDone, OnError }
 
+/// A class that encapsulates the [Kind] of event, value of the event in case of
+/// onData, or the Error in the case of onError.
 class Notification<T> {
   final Kind kind;
   final T value;

--- a/lib/src/transformers/concat_map.dart
+++ b/lib/src/transformers/concat_map.dart
@@ -11,11 +11,11 @@ import 'dart:async';
 ///
 /// ### Example
 ///
-///   new Stream.fromIterable([4, 3, 2, 1])
-///     .transform(new ConcatMapStreamTransformer((i) =>
-///       new Stream.fromFuture(
-///         new Future.delayed(new Duration(minutes: i), () => i))
-///     .listen(print); // prints 4, 3, 2, 1
+///     new Stream.fromIterable([4, 3, 2, 1])
+///       .transform(new ConcatMapStreamTransformer((i) =>
+///         new Stream.fromFuture(
+///           new Future.delayed(new Duration(minutes: i), () => i))
+///       .listen(print); // prints 4, 3, 2, 1
 class ConcatMapStreamTransformer<T, S> implements StreamTransformer<T, S> {
   final StreamTransformer<T, S> transformer;
 
@@ -26,7 +26,7 @@ class ConcatMapStreamTransformer<T, S> implements StreamTransformer<T, S> {
   Stream<S> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
-      Stream<S> predicate(T value)) {
+      Stream<S> mapper(T value)) {
     return new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
       final List<Stream<S>> streams = <Stream<S>>[];
       final List<bool> completionStatuses = <bool>[];
@@ -67,7 +67,7 @@ class ConcatMapStreamTransformer<T, S> implements StreamTransformer<T, S> {
           onListen: () {
             subscription = input.listen(
                 (T value) {
-                  streams.add(predicate(value));
+                  streams.add(mapper(value));
                   completionStatuses.add(false);
 
                   moveNext();

--- a/lib/src/transformers/concat_map.dart
+++ b/lib/src/transformers/concat_map.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-/// Maps each emitted item to a new [Stream] using the given predicate, then
+/// Maps each emitted item to a new [Stream] using the given mapper, then
 /// subscribes to each new stream one after the next until all values are
 /// emitted.
 ///
@@ -8,11 +8,19 @@ import 'dart:async';
 /// all items from the created stream will be emitted before moving to the
 /// next created stream. This process continues until all created streams have
 /// completed.
+///
+/// ### Example
+///
+///   new Stream.fromIterable([4, 3, 2, 1])
+///     .transform(new ConcatMapStreamTransformer((i) =>
+///       new Stream.fromFuture(
+///         new Future.delayed(new Duration(minutes: i), () => i))
+///     .listen(print); // prints 4, 3, 2, 1
 class ConcatMapStreamTransformer<T, S> implements StreamTransformer<T, S> {
   final StreamTransformer<T, S> transformer;
 
-  ConcatMapStreamTransformer(Stream<S> predicate(T value))
-      : transformer = _buildTransformer(predicate);
+  ConcatMapStreamTransformer(Stream<S> mapper(T value))
+      : transformer = _buildTransformer(mapper);
 
   @override
   Stream<S> bind(Stream<T> stream) => transformer.bind(stream);

--- a/lib/src/transformers/debounce.dart
+++ b/lib/src/transformers/debounce.dart
@@ -1,5 +1,19 @@
 import 'dart:async';
 
+/// Transforms a Stream so that will only emit items from the source sequence
+/// if a particular time span has passed without the source sequence emitting
+/// another item.
+///
+/// The Debounce Transformer filters out items emitted by the source Observable
+/// that are rapidly followed by another emitted item.
+///
+/// [Interactive marble diagram](http://rxmarbles.com/#debounce)
+///
+/// ### Example
+///
+///     new Stream.fromIterable([1, 2, 3, 4])
+///       .transform(new DebounceStreamTransformer(new Duration(seconds: 1)))
+///       .listen(print); // prints 4
 class DebounceStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/default_if_empty.dart
+++ b/lib/src/transformers/default_if_empty.dart
@@ -1,5 +1,13 @@
 import 'dart:async';
 
+/// Emit items from the source Stream, or a single default item if the source
+/// Stream emits nothing.
+///
+/// ### Example
+///
+///   new Stream.empty()
+///     .transform(new DefaultIfEmptyStreamTransformer(10))
+///     .listen(print); // prints 10
 class DefaultIfEmptyStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/default_if_empty.dart
+++ b/lib/src/transformers/default_if_empty.dart
@@ -5,9 +5,9 @@ import 'dart:async';
 ///
 /// ### Example
 ///
-///   new Stream.empty()
-///     .transform(new DefaultIfEmptyStreamTransformer(10))
-///     .listen(print); // prints 10
+///     new Stream.empty()
+///       .transform(new DefaultIfEmptyStreamTransformer(10))
+///       .listen(print); // prints 10
 class DefaultIfEmptyStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/dematerialize.dart
+++ b/lib/src/transformers/dematerialize.dart
@@ -9,11 +9,14 @@ import 'package:rxdart/src/transformers/call.dart';
 /// events as [Notification] objects. Dematerialize simply reverses this by
 /// transforming [Notification] objects back to a normal stream of events.
 ///
-/// Example:
+/// ### Example
+///
 ///     new Stream<Notification<int>>
 ///         .fromIterable([new Notification.onData(1), new Notification.onDone()])
 ///         .transform(dematerializeTransformer())
 ///         .listen((i) => print(i)); // Prints 1
+///
+/// ### Error example
 ///
 ///     new Stream<Notification<int>>
 ///         .fromIterable([new Notification.onError(new Exception(), null)])

--- a/lib/src/transformers/flat_map.dart
+++ b/lib/src/transformers/flat_map.dart
@@ -10,22 +10,22 @@ import 'dart:async';
 ///
 /// ### Example
 ///
-///   new Stream.fromIterable([4, 3, 2, 1])
-///     .transform(new FlatMapStreamTransformer((i) =>
-///       new Stream.fromFuture(
-///         new Future.delayed(new Duration(minutes: i), () => i))
-///     .listen(print); // prints 1, 2, 3, 4
+///       new Stream.fromIterable([4, 3, 2, 1])
+///         .transform(new FlatMapStreamTransformer((i) =>
+///           new Stream.fromFuture(
+///             new Future.delayed(new Duration(minutes: i), () => i))
+///         .listen(print); // prints 1, 2, 3, 4
 class FlatMapStreamTransformer<T, S> implements StreamTransformer<T, S> {
   final StreamTransformer<T, S> transformer;
 
-  FlatMapStreamTransformer(Stream<S> predicate(T value))
-      : transformer = _buildTransformer(predicate);
+  FlatMapStreamTransformer(Stream<S> mapper(T value))
+      : transformer = _buildTransformer(mapper);
 
   @override
   Stream<S> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
-      Stream<S> predicate(T value)) {
+      Stream<S> mapper(T value)) {
     return new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
       final List<Stream<S>> streams = <Stream<S>>[];
       final List<StreamSubscription<S>> subscriptions =
@@ -41,7 +41,7 @@ class FlatMapStreamTransformer<T, S> implements StreamTransformer<T, S> {
           onListen: () {
             subscription = input.listen(
                 (T value) {
-                  Stream<S> otherStream = predicate(value);
+                  Stream<S> otherStream = mapper(value);
 
                   hasMainEvent = true;
 

--- a/lib/src/transformers/flat_map.dart
+++ b/lib/src/transformers/flat_map.dart
@@ -1,5 +1,20 @@
 import 'dart:async';
 
+/// Converts each emitted item into a new Stream using the given mapper
+/// function. The newly created Stream will be be listened to and begin
+/// emitting items downstream.
+///
+/// The items emitted by each of the new Streams are emitted downstream in the
+/// same order they arrive. In other words, the sequences are merged
+/// together.
+///
+/// ### Example
+///
+///   new Stream.fromIterable([4, 3, 2, 1])
+///     .transform(new FlatMapStreamTransformer((i) =>
+///       new Stream.fromFuture(
+///         new Future.delayed(new Duration(minutes: i), () => i))
+///     .listen(print); // prints 1, 2, 3, 4
 class FlatMapStreamTransformer<T, S> implements StreamTransformer<T, S> {
   final StreamTransformer<T, S> transformer;
 

--- a/lib/src/transformers/flat_map_latest.dart
+++ b/lib/src/transformers/flat_map_latest.dart
@@ -1,5 +1,22 @@
 import 'dart:async';
 
+/// Converts each emitted item into a new Stream using the given mapper
+/// function. The newly created Stream will be be listened to and begin
+/// emitting items, and any previously created Stream will stop emitting.
+///
+/// The flatMapLatest operator is similar to the flatMap and concatMap
+/// methods, but it only emits items from the most recently created Stream.
+///
+/// This can be useful when you only want the very latest state from
+/// asynchronous APIs, for example.
+///
+/// ### Example
+///
+///   new Stream.fromIterable([4, 3, 2, 1])
+///     .transform(new FlatMapLatestStreamTransformer((i) =>
+///       new Stream.fromFuture(
+///         new Future.delayed(new Duration(minutes: i), () => i))
+///     .listen(print); // prints 1
 class FlatMapLatestStreamTransformer<T, S> implements StreamTransformer<T, S> {
   final StreamTransformer<T, S> transformer;
 

--- a/lib/src/transformers/flat_map_latest.dart
+++ b/lib/src/transformers/flat_map_latest.dart
@@ -12,22 +12,22 @@ import 'dart:async';
 ///
 /// ### Example
 ///
-///   new Stream.fromIterable([4, 3, 2, 1])
-///     .transform(new FlatMapLatestStreamTransformer((i) =>
-///       new Stream.fromFuture(
-///         new Future.delayed(new Duration(minutes: i), () => i))
-///     .listen(print); // prints 1
+///     new Stream.fromIterable([4, 3, 2, 1])
+///       .transform(new FlatMapLatestStreamTransformer((i) =>
+///         new Stream.fromFuture(
+///           new Future.delayed(new Duration(minutes: i), () => i))
+///       .listen(print); // prints 1
 class FlatMapLatestStreamTransformer<T, S> implements StreamTransformer<T, S> {
   final StreamTransformer<T, S> transformer;
 
-  FlatMapLatestStreamTransformer(Stream<S> predicate(T value))
-      : transformer = _buildTransformer(predicate);
+  FlatMapLatestStreamTransformer(Stream<S> mapper(T value))
+      : transformer = _buildTransformer(mapper);
 
   @override
   Stream<S> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
-      Stream<S> predicate(T value)) {
+      Stream<S> mapper(T value)) {
     return new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
       StreamController<S> controller;
       StreamSubscription<T> subscription;
@@ -44,7 +44,7 @@ class FlatMapLatestStreamTransformer<T, S> implements StreamTransformer<T, S> {
 
                   hasMainEvent = true;
 
-                  otherSubscription = predicate(value).listen(controller.add,
+                  otherSubscription = mapper(value).listen(controller.add,
                       onError: controller.addError, onDone: () {
                     rightClosed = true;
 

--- a/lib/src/transformers/group_by.dart
+++ b/lib/src/transformers/group_by.dart
@@ -1,5 +1,12 @@
 import 'dart:async';
 
+/// The GroupBy operator divides a Stream that emits items into a Stream that
+/// emits Stream, each one of which emits some subset of the items from the
+/// original source Stream.
+///
+///  Which items end up on which Stream is typically decided by a
+///  discriminating function that evaluates each item and assigns it a
+///  key. All items with the same key are emitted by the same Observable.
 class GroupByStreamTransformer<T, S>
     implements StreamTransformer<T, GroupByMap<S, T>> {
   final StreamTransformer<T, GroupByMap<S, T>> transformer;

--- a/lib/src/transformers/ignore_elements.dart
+++ b/lib/src/transformers/ignore_elements.dart
@@ -5,11 +5,11 @@ import 'dart:async';
 ///
 /// ### Example
 ///
-///    new MergeStream([
-///      new Stream.fromIterable([1]),
-///      new ErrorStream(new Exception())
-///    ])
-///    .listen(print, onError: print); // prints Exception
+///     new MergeStream([
+///       new Stream.fromIterable([1]),
+///       new ErrorStream(new Exception())
+///     ])
+///     .listen(print, onError: print); // prints Exception
 class IgnoreElementsStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/ignore_elements.dart
+++ b/lib/src/transformers/ignore_elements.dart
@@ -1,5 +1,15 @@
 import 'dart:async';
 
+/// Creates an Observable where all emitted items are ignored, only the
+/// error / completed notifications are passed
+///
+/// ### Example
+///
+///    new MergeStream([
+///      new Stream.fromIterable([1]),
+///      new ErrorStream(new Exception())
+///    ])
+///    .listen(print, onError: print); // prints Exception
 class IgnoreElementsStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/interval.dart
+++ b/lib/src/transformers/interval.dart
@@ -1,5 +1,13 @@
 import 'dart:async';
 
+/// Creates a Stream that emits each item in the Stream after a given
+/// duration.
+///
+/// ### Example
+///
+///     new Stream.fromIterable([1, 2, 3])
+///       .transform(new IntervalStreamTransformer(seconds: 1))
+///       .listen((i) => print("$i sec"); // prints 1 sec, 2 sec, 3 sec
 class IntervalStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/materialize.dart
+++ b/lib/src/transformers/materialize.dart
@@ -9,7 +9,8 @@ import 'package:rxdart/src/transformers/call.dart';
 /// OnError), and the item or error that was emitted. In the case of onDone,
 /// no data is emitted as part of the [Notification].
 ///
-/// Example:
+/// ### Example
+///
 ///     new Stream<int>.fromIterable([1])
 ///         .transform(materializeTransformer())
 ///         .listen((i) => print(i)); // Prints onData & onDone Notification

--- a/lib/src/transformers/of_type.dart
+++ b/lib/src/transformers/of_type.dart
@@ -1,5 +1,33 @@
 import 'dart:async';
 
+/// Filters a sequence so that only events of a given type pass
+///
+/// In order to capture the Type correctly, it needs to be wrapped
+/// in a [TypeToken] as the generic parameter.
+///
+/// Given the way Dart generics work, one cannot simply use the `is T` / `as T`
+/// checks and castings within `OfTypeObservable` itself. Therefore, the
+/// [TypeToken] class was introduced to capture the type of class you'd
+/// like `ofType` to filter down to.
+///
+/// ### Examples
+///
+///     new Stream.fromIterable([1, "hi"])
+///       .ofType(new TypeToken<String>)
+///       .listen(print); // prints "hi"
+///
+/// As a shortcut, you can use some pre-defined constants to write the above
+/// in the following way:
+///
+///     new Stream.fromIterable([1, "hi"])
+///       .transform(new OfTypeStreamTransformer(kString))
+///       .listen(print); // prints "hi"
+///
+/// If you'd like to create your own shortcuts like the example above,
+/// simply create a constant:
+///
+///     const TypeToken<Map<Int, String>> kMapIntString =
+///       const TypeToken<Map<Int, String>>();
 class OfTypeStreamTransformer<T, S> implements StreamTransformer<T, S> {
   final StreamTransformer<T, S> transformer;
 
@@ -44,26 +72,11 @@ class OfTypeStreamTransformer<T, S> implements StreamTransformer<T, S> {
 /// was introduced to capture the type of class you'd like `ofType` to filter
 /// down to.
 ///
-/// Example:
+/// ### Example
 ///
-/// ```dart
-/// myObservable.ofType(const TypeToken<num>);
-/// ```
-///
-/// As a shortcut, you can use the pre-defined constants to write the above in
-/// the following way:
-///
-/// ```dart
-/// myObservable.ofType(kNum);
-/// ```
-///
-/// If you'd like to create your own shortcuts like the example above,
-/// simply create a constant:
-///
-/// ```dart
-/// const TypeToken<Map<Int, String>> kMapIntString =
-///   const TypeToken<Map<Int, String>>();
-/// ```
+/// new Stream.fromIterable([1, "hi"])
+///   .ofType(new TypeToken<String>)
+///   .listen(print); // prints "hi"
 class TypeToken<S> {
   const TypeToken();
 

--- a/lib/src/transformers/of_type.dart
+++ b/lib/src/transformers/of_type.dart
@@ -74,9 +74,9 @@ class OfTypeStreamTransformer<T, S> implements StreamTransformer<T, S> {
 ///
 /// ### Example
 ///
-/// new Stream.fromIterable([1, "hi"])
-///   .ofType(new TypeToken<String>)
-///   .listen(print); // prints "hi"
+///     new Stream.fromIterable([1, "hi"])
+///       .ofType(new TypeToken<String>)
+///       .listen(print); // prints "hi"
 class TypeToken<S> {
   const TypeToken();
 

--- a/lib/src/transformers/on_error_resume_next.dart
+++ b/lib/src/transformers/on_error_resume_next.dart
@@ -1,5 +1,18 @@
 import 'dart:async';
 
+/// Intercepts error events and switches to the given recovery stream in
+/// that case
+///
+/// The OnErrorResumeNextStreamTransformer intercepts an onError notification from
+/// the source Stream. Instead of passing the error through to any
+/// listeners, it replaces it with another Stream of items.
+///
+/// ### Example
+///
+///     new ErrorStream(new Exception())
+///       .transform(new OnErrorResumeNextStreamTransformer(
+///         new Observable.fromIterable([1, 2, 3])))
+///       .listen(print); // prints 1, 2, 3
 class OnErrorResumeNextStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/repeat.dart
+++ b/lib/src/transformers/repeat.dart
@@ -1,5 +1,13 @@
 import 'dart:async';
 
+/// A StreamTransformer that repeats the source's elements the specified
+/// number of times.
+///
+/// ### Example
+///
+///     new Stream.fromIterable([1])
+///       .transform(new RepeatStreamTransformer(3))
+///       .listen(print); // prints 1, 1, 1
 class RepeatStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/sample.dart
+++ b/lib/src/transformers/sample.dart
@@ -1,5 +1,15 @@
 import 'dart:async';
 
+/// A StreamTransformer that, when the specified sample stream emits
+/// an item or completes, emits the most recently emitted item (if any)
+/// emitted by the source stream since the previous emission from
+/// the sample stream.
+///
+/// ### Example
+///
+///     new Stream.fromIterable([1, 2, 3])
+///       .transform(new SampleStreamTransformer(new TimerStream(1, new Duration(seconds: 1)))
+///       .listen(print); // prints 3
 class SampleStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/scan.dart
+++ b/lib/src/transformers/scan.dart
@@ -1,17 +1,23 @@
 import 'dart:async';
 
-typedef S _ScanStreamTransformerPredicate<T, S>(
-    S accumulated, T value, int index);
-
+/// Applies an accumulator function over an observable sequence and returns
+/// each intermediate result. The optional seed value is used as the initial
+/// accumulator value.
+///
+/// ### Example
+///
+///     new Stream.fromIterable([1, 2, 3])
+///        .transform(new ScanStreamTransformer((acc, curr, i) => acc + curr, 0))
+///        .listen(print); // prints 1, 3, 6
 class ScanStreamTransformer<T, S> implements StreamTransformer<T, S> {
-  final _ScanStreamTransformerPredicate<T, S> predicate;
+  final _ScanStreamTransformerAccumulator<T, S> accumulator;
   final S seed;
 
-  ScanStreamTransformer(this.predicate, [this.seed]);
+  ScanStreamTransformer(this.accumulator, [this.seed]);
 
   @override
   Stream<S> bind(Stream<T> stream) =>
-      _buildTransformer<T, S>(predicate, seed).bind(stream);
+      _buildTransformer<T, S>(accumulator, seed).bind(stream);
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
       S predicate(S accumulated, T value, int index),
@@ -27,3 +33,6 @@ class ScanStreamTransformer<T, S> implements StreamTransformer<T, S> {
     });
   }
 }
+
+typedef S _ScanStreamTransformerAccumulator<T, S>(
+    S accumulated, T value, int index);

--- a/lib/src/transformers/scan.dart
+++ b/lib/src/transformers/scan.dart
@@ -20,14 +20,14 @@ class ScanStreamTransformer<T, S> implements StreamTransformer<T, S> {
       _buildTransformer<T, S>(accumulator, seed).bind(stream);
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
-      S predicate(S accumulated, T value, int index),
+      S accumulator(S accumulated, T value, int index),
       [S seed]) {
     int index = 0;
     S acc = seed;
 
     return new StreamTransformer<T, S>.fromHandlers(
         handleData: (T data, EventSink<S> sink) {
-      acc = predicate(acc, data, index++);
+      acc = accumulator(acc, data, index++);
 
       sink.add(acc);
     });

--- a/lib/src/transformers/skip_until.dart
+++ b/lib/src/transformers/skip_until.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 /// Starts emitting items only after the given stream emits an item.
 ///
-/// Example:
+/// ### Example
 ///
 ///     new MergeStream([
 ///       new Observable.just(1),

--- a/lib/src/transformers/start_with.dart
+++ b/lib/src/transformers/start_with.dart
@@ -1,5 +1,12 @@
 import 'dart:async';
 
+/// Prepends a value to the source Stream.
+///
+/// ### Example
+///
+///     new Stream.fromIterable([2])
+///       .transform(new StartWithStreamTransformer(1))
+///       .listen(print); // prints 1, 2
 class StartWithStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/start_with_many.dart
+++ b/lib/src/transformers/start_with_many.dart
@@ -1,5 +1,12 @@
 import 'dart:async';
 
+/// Prepends a sequence of values to the source Stream.
+///
+/// ### Example
+///
+///     new Stream.fromIterable([3])
+///       .transform(new StartWithManyStreamTransformer([1, 2]))
+///       .listen(print); // prints 1, 2, 3
 class StartWithManyStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/switch_if_empty.dart
+++ b/lib/src/transformers/switch_if_empty.dart
@@ -1,5 +1,29 @@
 import 'dart:async';
 
+/// When the original observable emits no items, this operator subscribes to
+/// the given fallback stream and emits items from that observable instead.
+///
+/// This can be particularly useful when consuming data from multiple sources.
+/// For example, when using the Repository Pattern. Assuming you have some
+/// data you need to load, you might want to start with the fastest access
+/// point and keep falling back to the slowest point. For example, first query
+/// an in-memory database, then a database on the file system, then a network
+/// call if the data isn't on the local machine.
+///
+/// This can be achieved quite simply with switchIfEmpty!
+///
+/// ### Example
+///
+///     // Let's pretend we have some Data sources that complete without emitting
+///     // any items if they don't contain the data we're looking for
+///     Stream<Data> memory;
+///     Stream<Data> disk;
+///     Stream<Data> network;
+///
+///     // Start with memory, fallback to disk, then fallback to network.
+///     // Simple as that!
+///     Stream<Data> getThatData =
+///         memory.switchIfEmpty(disk).switchIfEmpty(network);
 class SwitchIfEmptyStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/take_until.dart
+++ b/lib/src/transformers/take_until.dart
@@ -3,13 +3,15 @@ import 'dart:async';
 /// Returns the values from the source observable sequence until the other
 /// stream sequence produces a value.
 ///
-/// new MergeStream([
-///     new Stream.fromIterable([1]),
-///     new TimerStream(2, new Duration(minutes: 1))
-///   ])
-///   .transform(new TakeUntilStreamTransformer(
-///     new TimerStream(3, new Duration(seconds: 10))))
-///   .listen(print); // prints 1
+/// ### Example
+///
+///     new MergeStream([
+///         new Stream.fromIterable([1]),
+///         new TimerStream(2, new Duration(minutes: 1))
+///       ])
+///       .transform(new TakeUntilStreamTransformer(
+///         new TimerStream(3, new Duration(seconds: 10))))
+///       .listen(print); // prints 1
 class TakeUntilStreamTransformer<T, S> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/take_until.dart
+++ b/lib/src/transformers/take_until.dart
@@ -1,5 +1,15 @@
 import 'dart:async';
 
+/// Returns the values from the source observable sequence until the other
+/// stream sequence produces a value.
+///
+/// new MergeStream([
+///     new Stream.fromIterable([1]),
+///     new TimerStream(2, new Duration(minutes: 1))
+///   ])
+///   .transform(new TakeUntilStreamTransformer(
+///     new TimerStream(3, new Duration(seconds: 10))))
+///   .listen(print); // prints 1
 class TakeUntilStreamTransformer<T, S> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/throttle.dart
+++ b/lib/src/transformers/throttle.dart
@@ -1,5 +1,13 @@
 import 'dart:async';
 
+/// A StreamTransformer that emits only the first item emitted by the source
+/// Stream during sequential time windows of a specified duration.
+///
+/// ### Example
+///
+///     new Stream.fromIterable([1, 2, 3])
+///       .transform(new ThrottleStreamTransformer(new Duration(seconds: 1)))
+///       .listen(print); // prints 1
 class ThrottleStreamTransformer<T> implements StreamTransformer<T, T> {
   final StreamTransformer<T, T> transformer;
 

--- a/lib/src/transformers/time_interval.dart
+++ b/lib/src/transformers/time_interval.dart
@@ -1,5 +1,14 @@
 import 'dart:async';
 
+/// Records the time interval between consecutive values in an observable
+/// sequence.
+///
+/// ### Example
+///
+///     new Stream.fromIterable([1])
+///       .transform(new IntervalStreamTransformer(new Duration(seconds: 1)))
+///       .transform(new TimeIntervalStreamTransformer())
+///       .listen(print); // prints TimeInterval{interval: 0:00:01, value: 1}
 class TimeIntervalStreamTransformer<T, S extends TimeInterval<T>>
     implements StreamTransformer<T, S> {
   final StreamTransformer<T, S> transformer;
@@ -27,7 +36,8 @@ class TimeIntervalStreamTransformer<T, S extends TimeInterval<T>>
 
                   stopwatch.stop();
 
-                  controller.add(new TimeInterval<T>(value, ems));
+                  controller.add(new TimeInterval<T>(
+                      value, new Duration(microseconds: ems)));
 
                   stopwatch = new Stopwatch()..start();
                 },
@@ -49,7 +59,7 @@ class TimeIntervalStreamTransformer<T, S extends TimeInterval<T>>
 }
 
 class TimeInterval<T> {
-  final int interval;
+  final Duration interval;
   final T value;
 
   TimeInterval(this.value, this.interval);

--- a/lib/src/transformers/window_with_count.dart
+++ b/lib/src/transformers/window_with_count.dart
@@ -2,6 +2,18 @@ import 'dart:async';
 
 import 'package:rxdart/src/transformers/buffer_with_count.dart';
 
+/// Creates an Observable where each item is a Stream containing the items
+/// from the source sequence, in batches of count.
+///
+/// If skip is provided, each group will start where the previous group
+/// ended minus the skip value.
+///
+/// ### Example
+///
+///     new RangeStream(1, 4)
+///      .transform(new WindowWithCountStreamTransformer(3))
+///      .transform(new FlatMapStreamTransformer((i) => i))
+///      .listen(expectAsync1(print, count: 4)); // prints 1, 2, 3, 4
 class WindowWithCountStreamTransformer<T, S extends Stream<T>>
     implements StreamTransformer<T, S> {
   final StreamTransformer<T, S> transformer;

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -1,5 +1,19 @@
 import 'dart:async';
 
+/// A StreamTransformer that emits when the source stream emits, combining
+/// the latest values from the two streams using the provided function.
+///
+/// If the latestFromStream has not emitted any values, this stream will not
+/// emit either.
+///
+/// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
+///
+/// ### Example
+///
+///     new Stream.fromIterable([1, 2]).transform(
+///       new WithLatestFromStreamTransformer(
+///         new Stream.fromIterable([2, 3]), (a, b) => a + b)
+///       .listen(print); // prints 4 (due to the async nature of streams)
 class WithLatestFromStreamTransformer<T, S, R> implements StreamTransformer<T, R> {
   final StreamTransformer<T, R> transformer;
 

--- a/lib/streams.dart
+++ b/lib/streams.dart
@@ -9,6 +9,7 @@ export 'package:rxdart/src/streams/error.dart';
 export 'package:rxdart/src/streams/merge.dart';
 export 'package:rxdart/src/streams/never.dart';
 export 'package:rxdart/src/streams/range.dart';
+export 'package:rxdart/src/streams/retry.dart';
 export 'package:rxdart/src/streams/timer.dart';
 export 'package:rxdart/src/streams/tween.dart';
 export 'package:rxdart/src/streams/zip.dart';

--- a/test/transformers/buffer_with_count_test.dart
+++ b/test/transformers/buffer_with_count_test.dart
@@ -11,9 +11,7 @@ void main() {
     ];
     int count = 0;
 
-    Stream<List<int>> stream =
-        new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
-            .bufferWithCount(2);
+    Stream<List<int>> stream = Observable.range(1, 4).bufferWithCount(2);
 
     stream.listen(expectAsync1((List<int> result) {
       // test to see if the combined output matches
@@ -64,9 +62,7 @@ void main() {
     ];
     int count = 0;
 
-    Stream<List<int>> stream =
-        new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
-            .bufferWithCount(2, 1);
+    Stream<List<int>> stream = Observable.range(1, 4).bufferWithCount(2, 1);
 
     stream.listen(expectAsync1((List<int> result) {
       // test to see if the combined output matches

--- a/test/transformers/on_error_resume_next_test.dart
+++ b/test/transformers/on_error_resume_next_test.dart
@@ -13,7 +13,7 @@ void main() {
   test('rx.Observable.onErrorResumeNext', () async {
     int count = 0;
 
-    observable(new ErrorStream<num>(new Exception()))
+    new Observable<num>(new ErrorStream<num>(new Exception()))
         .onErrorResumeNext(_getStream())
         .listen(expectAsync1((num result) {
           expect(result, expected[count++]);
@@ -26,13 +26,13 @@ void main() {
             _getStream().asBroadcastStream());
     int countA = 0, countB = 0;
 
-    observable(new ErrorStream<num>(new Exception()))
+    new Observable<num>(new ErrorStream<num>(new Exception()))
         .transform(transformer)
         .listen(expectAsync1((num result) {
           expect(result, expected[countA++]);
         }, count: expected.length));
 
-    observable(new ErrorStream<num>(new Exception()))
+    new Observable<num>(new ErrorStream<num>(new Exception()))
         .transform(transformer)
         .listen(expectAsync1((num result) {
           expect(result, expected[countB++]);
@@ -40,7 +40,7 @@ void main() {
   });
 
   test('rx.Observable.onErrorResumeNext.asBroadcastStream', () async {
-    Stream<num> stream = observable(new ErrorStream<num>(new Exception()))
+    Stream<num> stream = new Observable<num>(new ErrorStream<num>(new Exception()))
         .onErrorResumeNext(_getStream())
         .asBroadcastStream();
     int countA = 0;
@@ -58,7 +58,7 @@ void main() {
 
   test('rx.Observable.onErrorResumeNext.error.shouldThrow', () async {
     Stream<num> observableWithError =
-        observable(new ErrorStream<num>(new Exception()))
+        new Observable<num>(new ErrorStream<num>(new Exception()))
             .onErrorResumeNext(new ErrorStream<num>(new Exception()));
 
     observableWithError.listen((_) {},
@@ -71,7 +71,7 @@ void main() {
     StreamSubscription<num> subscription;
     int count = 0;
 
-    subscription = observable(new ErrorStream<num>(new Exception()))
+    subscription = new Observable<num>(new ErrorStream<num>(new Exception()))
         .onErrorResumeNext(_getStream())
         .listen(expectAsync1((num result) {
           expect(result, expected[count++]);
@@ -88,7 +88,7 @@ void main() {
   test('rx.Observable.onErrorResumeNext.close', () async {
     int count = 0;
 
-    observable(new ErrorStream<num>(new Exception()))
+    new Observable<num>(new ErrorStream<num>(new Exception()))
         .onErrorResumeNext(_getStream())
         .listen(
             expectAsync1((num result) {

--- a/test/transformers/on_error_return_test.dart
+++ b/test/transformers/on_error_return_test.dart
@@ -7,7 +7,7 @@ void main() {
   const num expected = 0;
 
   test('rx.Observable.onErrorReturn', () async {
-    observable(new ErrorStream<num>(new Exception()))
+    new Observable<num>(new ErrorStream<num>(new Exception()))
         .onErrorReturn(0)
         .listen(expectAsync1((num result) {
       expect(result, expected);
@@ -15,7 +15,7 @@ void main() {
   });
 
   test('rx.Observable.onErrorReturn.asBroadcastStream', () async {
-    Stream<num> stream = observable(new ErrorStream<num>(new Exception()))
+    Stream<num> stream = new Observable<num>(new ErrorStream<num>(new Exception()))
         .onErrorReturn(0)
         .asBroadcastStream();
 
@@ -33,7 +33,7 @@ void main() {
   test('rx.Observable.onErrorReturn.pause.resume', () async {
     StreamSubscription<num> subscription;
 
-    subscription = observable(new ErrorStream<num>(new Exception()))
+    subscription = new Observable<num>(new ErrorStream<num>(new Exception()))
         .onErrorReturn(0)
         .listen(expectAsync1((num result) {
       expect(result, expected);

--- a/test/transformers/time_interval_test.dart
+++ b/test/transformers/time_interval_test.dart
@@ -16,7 +16,7 @@ void main() {
         .listen(expectAsync1((TimeInterval<int> result) {
           expect(expectedOutput[count++], result.value);
 
-          expect(result.interval >= 1000 /* microseconds! */, true);
+          expect(result.interval.inMicroseconds >= 1000 /* microseconds! */, true);
         }, count: expectedOutput.length));
   });
 
@@ -32,7 +32,7 @@ void main() {
         .listen(expectAsync1((TimeInterval<int> result) {
           expect(expectedOutput[countA++], result.value);
 
-          expect(result.interval >= 1000 /* microseconds! */, true);
+          expect(result.interval.inMicroseconds >= 1000 /* microseconds! */, true);
         }, count: expectedOutput.length));
 
     new Observable<int>(_getStream())
@@ -41,7 +41,7 @@ void main() {
         .listen(expectAsync1((TimeInterval<int> result) {
           expect(expectedOutput[countB++], result.value);
 
-          expect(result.interval >= 1000 /* microseconds! */, true);
+          expect(result.interval.inMicroseconds >= 1000 /* microseconds! */, true);
         }, count: expectedOutput.length));
   });
 

--- a/test/transformers/window_with_count_test.dart
+++ b/test/transformers/window_with_count_test.dart
@@ -12,8 +12,7 @@ void main() {
     int count = 0;
 
     Stream<Stream<int>> stream =
-        new Observable<int>(new Stream<int>.fromIterable(<int>[1, 2, 3, 4]))
-            .windowWithCount(2);
+        new Observable<int>.fromIterable(<int>[1, 2, 3, 4]).windowWithCount(2);
 
     stream.listen(expectAsync1((Stream<int> result) {
       // test to see if the combined output matches


### PR DESCRIPTION
Adds a ton of documentation throughout the library, especially targeting Observable, Stream, and StreamTransformer classes, including examples. 

Documentation for the Subjects still needs work.

In addition, I chose to remove the deprecated methods at this point: the `observable` constructor, `combineLatest`, and `zip`.

Hoping this starts to bring Observables close to a stable status for a 1.0 release.

Fixes #71, Fixes #38, Fixes #22, Fixes #21