### PR TITLE
`asObservable()` Future

### DIFF
--- a/lib/src/as_observable_future.dart
+++ b/lib/src/as_observable_future.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+
+/// A future that can be converted directly to an Observable using
+/// the `asObservable` method.
+///
+/// This class simply wraps a normal Future, providing one additional method
+/// for more fluent interoperability with the Observable class.
+///
+/// Example:
+///
+///   new Observable.fromIterable([1, 2, 3]).last.asObservable(); // .flatMap...
+class AsObservableFuture<T> implements Future<T> {
+  final Future<T> wrapped;
+
+  AsObservableFuture(this.wrapped);
+
+  Observable<T> asObservable() => new Observable<T>.fromFuture(wrapped);
+
+  @override
+  Stream<T> asStream() => wrapped.asStream();
+
+  @override
+  Future<T> catchError(Function onError, {bool test(Object error)}) =>
+      wrapped.catchError(onError, test: test);
+
+  @override
+  Future<S> then<S>(FutureOr<S> onValue(T value), {Function onError}) => wrapped
+      .then(onValue, onError: onError);
+
+  @override
+  Future<T> timeout(Duration timeLimit, {onTimeout()}) =>
+      wrapped.timeout(timeLimit, onTimeout: onTimeout);
+
+  @override
+  Future<T> whenComplete(action()) => wrapped.whenComplete(action);
+}

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -14,7 +14,7 @@ import 'package:rxdart/src/streams/timer.dart';
 import 'package:rxdart/src/streams/tween.dart';
 import 'package:rxdart/src/streams/zip.dart';
 
-import 'package:rxdart/src/as_observable_future.dart';
+import 'package:rxdart/src/utils/as_observable_future.dart';
 import 'package:rxdart/src/transformers/buffer_with_count.dart';
 import 'package:rxdart/src/transformers/call.dart';
 import 'package:rxdart/src/transformers/concat_map.dart';

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -14,6 +14,7 @@ import 'package:rxdart/src/streams/timer.dart';
 import 'package:rxdart/src/streams/tween.dart';
 import 'package:rxdart/src/streams/zip.dart';
 
+import 'package:rxdart/src/as_observable_future.dart';
 import 'package:rxdart/src/transformers/buffer_with_count.dart';
 import 'package:rxdart/src/transformers/call.dart';
 import 'package:rxdart/src/transformers/concat_map.dart';
@@ -60,7 +61,8 @@ class Observable<T> extends Stream<T> {
       new Observable<T>(new AmbStream<T>(streams));
 
   @override
-  Future<bool> any(bool test(T element)) => stream.any(test);
+  AsObservableFuture<bool> any(bool test(T element)) =>
+      new AsObservableFuture<bool>(stream.any(test));
 
   /// Creates an Observable where each item is the result of passing the latest
   /// values from each feeder stream into the predicate function.
@@ -754,7 +756,8 @@ class Observable<T> extends Stream<T> {
       new ConcatStream<T>(<Stream<T>>[stream]..addAll(other)));
 
   @override
-  Future<bool> contains(Object needle) => stream.contains(needle);
+  AsObservableFuture<bool> contains(Object needle) =>
+      new AsObservableFuture<bool>(stream.contains(needle));
 
   /// Creates an Observable that will only emit items from the source sequence
   /// if a particular time span has passed without the source sequence emitting
@@ -817,13 +820,16 @@ class Observable<T> extends Stream<T> {
       new Observable<T>(stream.distinct(equals));
 
   @override
-  Future<S> drain<S>([S futureValue]) => stream.drain(futureValue);
+  AsObservableFuture<S> drain<S>([S futureValue]) =>
+      new AsObservableFuture<S>(stream.drain(futureValue));
 
   @override
-  Future<T> elementAt(int index) => stream.elementAt(index);
+  AsObservableFuture<T> elementAt(int index) =>
+      new AsObservableFuture<T>(stream.elementAt(index));
 
   @override
-  Future<bool> every(bool test(T element)) => stream.every(test);
+  AsObservableFuture<bool> every(bool test(T element)) =>
+      new AsObservableFuture<bool>(stream.every(test));
 
   /// Creates an Observable from this stream that converts each element into
   /// zero or more events.
@@ -839,11 +845,13 @@ class Observable<T> extends Stream<T> {
       new Observable<S>(stream.expand(convert));
 
   @override
-  Future<T> get first => stream.first;
+  AsObservableFuture<T> get first => new AsObservableFuture<T>(stream.first);
 
   @override
-  Future<dynamic> firstWhere(bool test(T element), {Object defaultValue()}) =>
-      stream.firstWhere(test, defaultValue: defaultValue);
+  AsObservableFuture<dynamic> firstWhere(bool test(T element),
+          {Object defaultValue()}) =>
+      new AsObservableFuture<dynamic>(
+          stream.firstWhere(test, defaultValue: defaultValue));
 
   /// Creates an Observable by applying the predicate to each item emitted by
   /// the original Observable, where that function is itself an Observable that
@@ -867,11 +875,13 @@ class Observable<T> extends Stream<T> {
       transform(new FlatMapLatestStreamTransformer<T, S>(predicate));
 
   @override
-  Future<S> fold<S>(S initialValue, S combine(S previous, T element)) => stream
-      .fold(initialValue, combine);
+  AsObservableFuture<S> fold<S>(
+          S initialValue, S combine(S previous, T element)) =>
+      new AsObservableFuture<S>(stream.fold(initialValue, combine));
 
   @override
-  Future<dynamic> forEach(void action(T element)) => stream.forEach(action);
+  AsObservableFuture<dynamic> forEach(void action(T element)) =>
+      new AsObservableFuture<dynamic>(stream.forEach(action));
 
   /// The GroupBy operator divides an Observable that emits items into an
   /// Observable that emits Observables, each one of which emits some subset
@@ -928,17 +938,21 @@ class Observable<T> extends Stream<T> {
   }
 
   @override
-  Future<bool> get isEmpty => stream.isEmpty;
+  AsObservableFuture<bool> get isEmpty =>
+      new AsObservableFuture<bool>(stream.isEmpty);
 
   @override
-  Future<String> join([String separator = ""]) => stream.join(separator);
+  AsObservableFuture<String> join([String separator = ""]) =>
+      new AsObservableFuture<String>(stream.join(separator));
 
   @override
-  Future<T> get last => stream.last;
+  AsObservableFuture<T> get last => new AsObservableFuture<T>(stream.last);
 
   @override
-  Future<dynamic> lastWhere(bool test(T element), {Object defaultValue()}) =>
-      stream.lastWhere(test, defaultValue: defaultValue);
+  AsObservableFuture<dynamic> lastWhere(bool test(T element),
+          {Object defaultValue()}) =>
+      new AsObservableFuture<dynamic>(
+          stream.lastWhere(test, defaultValue: defaultValue));
 
   @override
   StreamSubscription<T> listen(void onData(T event),
@@ -947,7 +961,8 @@ class Observable<T> extends Stream<T> {
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   @override
-  Future<int> get length => stream.length;
+  AsObservableFuture<int> get length =>
+      new AsObservableFuture<int>(stream.length);
 
   /// Maps values from a source sequence through a function and emits the
   /// returned values.
@@ -1051,11 +1066,12 @@ class Observable<T> extends Stream<T> {
           new Observable<T>.just(returnValue)));
 
   @override
-  Future<dynamic> pipe(StreamConsumer<T> streamConsumer) =>
-      stream.pipe(streamConsumer);
+  AsObservableFuture<dynamic> pipe(StreamConsumer<T> streamConsumer) =>
+      new AsObservableFuture<dynamic>(stream.pipe(streamConsumer));
 
   @override
-  Future<T> reduce(T combine(T previous, T element)) => stream.reduce(combine);
+  AsObservableFuture<T> reduce(T combine(T previous, T element)) =>
+      new AsObservableFuture<T>(stream.reduce(combine));
 
   /// Creates an Observable that repeats the source's elements the specified
   /// number of times.
@@ -1077,10 +1093,11 @@ class Observable<T> extends Stream<T> {
       transform(new ScanStreamTransformer<T, S>(predicate, seed));
 
   @override
-  Future<T> get single => stream.single;
+  AsObservableFuture<T> get single => new AsObservableFuture<T>(stream.single);
 
   @override
-  Future<T> singleWhere(bool test(T element)) => stream.singleWhere(test);
+  AsObservableFuture<T> singleWhere(bool test(T element)) =>
+      new AsObservableFuture<T>(stream.singleWhere(test));
 
   /// Skips the first count data events from this stream.
   ///
@@ -1235,10 +1252,12 @@ class Observable<T> extends Stream<T> {
       new Observable<S>(super.transform(streamTransformer));
 
   @override
-  Future<List<T>> toList() => stream.toList();
+  AsObservableFuture<List<T>> toList() =>
+      new AsObservableFuture<List<T>>(stream.toList());
 
   @override
-  Future<Set<T>> toSet() => stream.toSet();
+  AsObservableFuture<Set<T>> toSet() =>
+      new AsObservableFuture<Set<T>>(stream.toSet());
 
   /// Filters the elements of an observable sequence based on the test.
   @override

--- a/lib/src/utils/as_observable_future.dart
+++ b/lib/src/utils/as_observable_future.dart
@@ -10,13 +10,18 @@ import 'package:rxdart/rxdart.dart';
 ///
 /// Example:
 ///
-///   new Observable.fromIterable([1, 2, 3]).last.asObservable(); // .flatMap...
+///   new Observable.fromIterable(["hello", "friends"])
+///       .join(" ") // Returns an AsObservableFuture
+///       .asObservable() // Fluently convert the Future back to an Observable
+///       .flatMap((message) => new Observable.just(message.length)); // Use the operators you need
 class AsObservableFuture<T> implements Future<T> {
   final Future<T> wrapped;
 
   AsObservableFuture(this.wrapped);
 
-  Observable<T> asObservable() => new Observable<T>.fromFuture(wrapped);
+  Observable<T> asObservable() {
+    return new Observable<T>.fromFuture(wrapped);
+  }
 
   @override
   Stream<T> asStream() => wrapped.asStream();

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -89,6 +89,8 @@ import 'transformers/zip_with_test.dart' as zip_with_test;
 import 'subject/replay_subject_test.dart' as replay_subject_test;
 import 'subject/behaviour_subject_test.dart' as behaviour_subject_test;
 
+import 'utils/as_observable_future_test.dart' as as_observable_future_test;
+
 void main() {
   amb_test.main();
   combine_latest_test.main();
@@ -179,4 +181,6 @@ void main() {
 
   behaviour_subject_test.main();
   replay_subject_test.main();
+
+  as_observable_future_test.main();
 }

--- a/test/transformers/first_test.dart
+++ b/test/transformers/first_test.dart
@@ -8,12 +8,5 @@ void main() {
 
     await expect(actual, 1);
   });
-
-  test('rx.Observable.first.asObservable', () async {
-    final Observable<int> observable =
-        new Observable<int>.fromIterable(<int>[1, 2, 3]).first.asObservable();
-
-    await expect(observable, emits(1));
-  });
 }
 

--- a/test/transformers/first_test.dart
+++ b/test/transformers/first_test.dart
@@ -8,4 +8,12 @@ void main() {
 
     await expect(actual, 1);
   });
+
+  test('rx.Observable.first.asObservable', () async {
+    final Observable<int> observable =
+        new Observable<int>.fromIterable(<int>[1, 2, 3]).first.asObservable();
+
+    await expect(observable, emits(1));
+  });
 }
+

--- a/test/utils/as_observable_future_test.dart
+++ b/test/utils/as_observable_future_test.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+import 'package:rxdart/src/utils/as_observable_future.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('AsObservableFuture.asObservable', () async {
+    AsObservableFuture<int> future =
+        new AsObservableFuture<int>(new Future<int>.value(1));
+
+    await expect(future.asObservable(), emits(1));
+  });
+
+  test('AsObservableFuture.asStream', () async {
+    AsObservableFuture<int> future =
+        new AsObservableFuture<int>(new Future<int>.value(1));
+
+    await expect(future.asStream(), emits(1));
+  });
+
+  test('AsObservableFuture.catchError', () async {
+    bool catchErrorCalled = false;
+
+    await new AsObservableFuture<int>(new Future<int>.error(new Exception()))
+        .catchError((dynamic e, dynamic s) {
+      catchErrorCalled = true;
+    });
+
+    await expect(catchErrorCalled, isTrue);
+  });
+
+  test('AsObservableFuture.then', () async {
+    bool thenCalled = false;
+
+    await new AsObservableFuture<int>(new Future<int>.value(1)).then((int i) {
+      thenCalled = true;
+    });
+
+    await expect(thenCalled, isTrue);
+  });
+
+  test('AsObservableFuture.timeout', () async {
+    await new AsObservableFuture<int>(new Future<int>.delayed(new Duration(minutes: 1))).timeout(new Duration(milliseconds: 1), onTimeout: () {
+      // should execute
+      expect(true, isTrue);
+    });
+  });
+
+  test('AsObservableFuture.whenComplete', () async {
+    await new AsObservableFuture<int>(new Future<int>.value(1)).whenComplete(() {
+      expect(true, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Re-opening with tests + docs.

One thing that is admittedly awkward about the Observable vs Stream divide (as noted in #68) is that `first`, `last`, and several other methods currently return a plain `Future`, which is incompatible with Observable, and requires an smelly wrapper. `Futures` in Dart can be easily converted to `Streams`, much like `Single` from `RxJava2` can be easily converted back to a normal `Observable` using the method `toObservable`. But that's not the case in RxDart! For example:

```
new Stream.fromIterable([1, 2, 3]).last.asStream().listen(print); // prints 3
```

But: what if RxDart Observables had the same thing!?

```
new Observable.fromIterable([1, 2, 3]).last.asObservable().listen(print); // prints 3
```

Well that's what I've done. Any methods that returned a plain ol' `Future` now return a new, beefy `Future` called `AsObservableFuture` that adds one extra method: `asObservable`.

This means any method that returns a `Future` from the `Observable` class can now be transparently converted back to an observable using `asObservable`.

Note: after testing this idea against the alternative: `firstAsObservable` style methods, it became clear that the extended promise approach was the right way to go. For example, methods such as `join` become awkward. E.g 
```
new Observable.fromIterable(["hi", "there"]).join(" ").asObservable();
``` 

reads more fluently than 

```
new Observable.fromIterable(["hi", "there"]).joinAsObservable(" ");
```