### PR TITLE
Refactor tests proposal

### DIFF
--- a/test/observable/amb_test.dart
+++ b/test/observable/amb_test.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Observable.amb factory wraps AmbStream', () async {
+    final Observable<int> first =
+        new Observable<int>.timer(1, new Duration(milliseconds: 10));
+    final Observable<int> second =
+        new Observable<int>.timer(2, new Duration(milliseconds: 20));
+
+    await expect(new Observable<int>.amb(<Stream<int>>[first, second]),
+        emitsInOrder(<dynamic>[1, emitsDone]));
+  });
+}

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -1,5 +1,7 @@
 library test.rx;
 
+import 'observable/amb_test.dart' as observable_amb_test;
+
 import 'streams/amb_test.dart' as amb_test;
 import 'streams/combine_latest_test.dart' as combine_latest_test;
 import 'streams/concat_eager_test.dart' as concat_eager_test;
@@ -90,6 +92,8 @@ import 'subject/replay_subject_test.dart' as replay_subject_test;
 import 'subject/behaviour_subject_test.dart' as behaviour_subject_test;
 
 void main() {
+  observable_amb_test.main();
+
   amb_test.main();
   combine_latest_test.main();
   concat_eager_test.main();


### PR DESCRIPTION
A bit of test cleanup! We've had a lot of change in this lib and the test package itself, and this has had a really positive effect on how efficient our code can be :)

This refactor acts as an example of what I propose doing across the board to our tests, and I'll continue with this refactor if you think it's a good direction!

Addresses #34 & #35.

Changes:

  - Test Streams & StreamTransformers independently from the Observable wrapper methods. 
  - Test Streams and StreamTransformers heavily, while testing the Observable method glue code lightly
  - `group` tests together for clarity
  - Then give tests within the group more descriptive names to clarify intent
  - Use stream matchers now that they're available from the test package
  - Use our new factory methods to simplify many tests
  - Ensure our streams close
  - No longer test `asBroadcastStream`. Since we no longer accept `asBroadcastStream` as an argument, and we rely on the `.asBroadcastStream` method, we're simply testing another class and not our own.