### PR TITLE
Add `Cast` operator and transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ var myObservable = Observable.combineLatest3(
 ##### Available Methods
 - [bufferWithCount](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/bufferWithCount.html) / [BufferWithCountStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/BufferWithCountStreamTransformer-class.html)
 - [call](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/call.html) / [CallStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/CallStreamTransformer-class.html)
+- [cast](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/cast.html) / [CastStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/CastStreamTransformer-class.html)
 - [concatMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/concatMap.html) / [ConcatMapStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/ConcatMapStreamTransformer-class.html)
 - [concatWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/concatWith.html)
 - [debounce](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/debounce.html) / [DebounceStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx_transformers/DebounceStreamTransformer-class.html)

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -14,6 +14,7 @@ import 'package:rxdart/src/streams/timer.dart';
 import 'package:rxdart/src/streams/tween.dart';
 import 'package:rxdart/src/streams/zip.dart';
 
+import 'package:rxdart/src/transformers/cast.dart';
 import 'package:rxdart/src/utils/as_observable_future.dart';
 import 'package:rxdart/src/transformers/buffer_with_count.dart';
 import 'package:rxdart/src/transformers/call.dart';
@@ -44,6 +45,7 @@ import 'package:rxdart/src/transformers/time_interval.dart';
 import 'package:rxdart/src/transformers/timestamp.dart';
 import 'package:rxdart/src/transformers/window_with_count.dart';
 import 'package:rxdart/src/transformers/with_latest_from.dart';
+import 'package:rxdart/src/utils/type_token.dart';
 
 /// A wrapper class that extends Stream. It combines all the Streams and
 /// StreamTransformers contained in this library into a fluent api.
@@ -62,6 +64,17 @@ import 'package:rxdart/src/transformers/with_latest_from.dart';
 /// addition, more complex examples can be found in the
 /// [RxDart github repo](https://github.com/ReactiveX/rxdart) demonstrating how
 /// to use RxDart with web, command line, and Flutter applications.
+///
+/// #### Additional Resources
+///
+/// In addition to the RxDart documentation and examples, you can find many
+/// more articles on Dart Streams that teach the fundamentals upon which
+/// RxDart is built.
+///
+///   - [Asynchronous Programming: Streams](https://www.dartlang.org/tutorials/language/streams)
+///   - [Single-Subscription vs. Broadcast Streams](https://www.dartlang.org/articles/libraries/broadcast-streams)
+///   - [Creating Streams in Dart](https://www.dartlang.org/articles/libraries/creating-streams)
+///   - [Testing Streams: Stream Matchers](https://pub.dartlang.org/packages/test#stream-matchers)
 ///
 /// ### Dart Streams vs Observables
 ///
@@ -1068,6 +1081,44 @@ class Observable<T> extends Stream<T> {
           onListen: onListen,
           onPause: onPause,
           onResume: onResume));
+
+  /// Casts a sequence of items to a given type.
+  ///
+  /// This operator is often useful when going from a generic to a more
+  /// specific type.
+  ///
+  /// In order to capture the Type correctly, it needs to be wrapped
+  /// in a [TypeToken] as the generic parameter.
+  ///
+  /// Given the way Dart generics work, one cannot simply use `as T`
+  /// checks and castings within `CastStreamTransformer` itself. Therefore, the
+  /// [TypeToken] class was introduced to capture the type of class you'd
+  /// like `cast` to convert to.
+  ///
+  /// ### Examples
+  ///
+  ///     // A Stream of num, but we know the data is an int
+  ///     new Stream<num>.fromIterable(<int>[1, 2, 3])
+  ///       .cast(new TypeToken<int>) // So we can call `isEven`
+  ///       .map((i) => i.isEven)
+  ///       .listen(print); // prints "false", "true", "false"
+  ///
+  /// As a shortcut, you can use some pre-defined constants to write the above
+  /// in the following way:
+  ///
+  ///     // A Stream of num, but we know the data is an int
+  ///     new Stream<num>.fromIterable(<int>[1, 2, 3])
+  ///       .cast(kInt) // Use the `kInt` constant as a shortcut
+  ///       .map((i) => i.isEven)
+  ///       .listen(print); // prints "false", "true", "false"
+  ///
+  /// If you'd like to create your own shortcuts like the example above,
+  /// simply create a constant:
+  ///
+  ///     const TypeToken<Map<Int, String>> kMapIntString =
+  ///       const TypeToken<Map<Int, String>>();
+  Observable<S> cast<S>(TypeToken<S> typeToken) =>
+      transform(new CastStreamTransformer<T, S>(typeToken));
 
   /// Maps each emitted item to a new [Stream] using the given mapper, then
   /// subscribes to each new stream one after the next until all values are

--- a/lib/src/utils/type_token.dart
+++ b/lib/src/utils/type_token.dart
@@ -1,0 +1,42 @@
+/// A class that captures the Type to filter down to using `ofType` or `cast`.
+///
+/// Given the way Dart generics work, one cannot simply use the `is T` / `as T`
+/// checks and castings within an ofTypeObservable itself. Therefore, this class
+/// was introduced to capture the type of class you'd like `ofType` to filter
+/// down to, or `cast` to cast to.
+///
+/// ### Example
+///
+///     new Stream.fromIterable([1, "hi"])
+///       .ofType(new TypeToken<String>)
+///       .listen(print); // prints "hi"
+class TypeToken<S> {
+  const TypeToken();
+
+  bool isType(dynamic other) {
+    return other is S;
+  }
+
+  S toType(dynamic other) {
+    // ignore: avoid_as
+    return other as S;
+  }
+}
+
+/// Filter the observable to only Booleans
+const TypeToken<bool> kBool = const TypeToken<bool>();
+
+/// Filter the observable to only Doubles
+const TypeToken<double> kDouble = const TypeToken<double>();
+
+/// Filter the observable to only Integers
+const TypeToken<int> kInt = const TypeToken<int>();
+
+/// Filter the observable to only Numbers
+const TypeToken<num> kNum = const TypeToken<num>();
+
+/// Filter the observable to only Strings
+const TypeToken<String> kString = const TypeToken<String>();
+
+/// Filter the observable to only Symbols
+const TypeToken<Symbol> kSymbol = const TypeToken<Symbol>();

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -1,6 +1,8 @@
 library rx_transformers;
 
 export 'package:rxdart/src/transformers/buffer_with_count.dart';
+export 'package:rxdart/src/transformers/call.dart';
+export 'package:rxdart/src/transformers/cast.dart';
 export 'package:rxdart/src/transformers/concat_map.dart';
 export 'package:rxdart/src/transformers/debounce.dart';
 export 'package:rxdart/src/transformers/default_if_empty.dart';
@@ -23,9 +25,9 @@ export 'package:rxdart/src/transformers/start_with.dart';
 export 'package:rxdart/src/transformers/start_with_many.dart';
 export 'package:rxdart/src/transformers/switch_if_empty.dart';
 export 'package:rxdart/src/transformers/take_until.dart';
-export 'package:rxdart/src/transformers/call.dart';
 export 'package:rxdart/src/transformers/throttle.dart';
 export 'package:rxdart/src/transformers/time_interval.dart';
 export 'package:rxdart/src/transformers/timestamp.dart';
 export 'package:rxdart/src/transformers/window_with_count.dart';
 export 'package:rxdart/src/transformers/with_latest_from.dart';
+export 'package:rxdart/src/utils/type_token.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -27,6 +27,7 @@ import 'transformers/async_expand_test.dart' as async_expand_test;
 import 'transformers/async_map_test.dart' as async_map_test;
 import 'transformers/buffer_with_count_test.dart' as buffer_with_count_test;
 import 'transformers/call_test.dart' as call_test;
+import 'transformers/cast_test.dart' as cast_test;
 import 'transformers/concat_map_test.dart' as concat_map_test;
 import 'transformers/concat_with_test.dart' as concat_with_test;
 import 'transformers/contains_test.dart' as contains_test;
@@ -118,6 +119,7 @@ void main() {
   async_map_test.main();
   buffer_with_count_test.main();
   call_test.main();
+  cast_test.main();
   concat_map_test.main();
   concat_with_test.main();
   contains_test.main();

--- a/test/transformers/cast_test.dart
+++ b/test/transformers/cast_test.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:rxdart/src/transformers/cast.dart';
+import 'package:rxdart/src/utils/type_token.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Rx.Observable.cast', () async {
+    final Observable<num> observable =
+        new Observable<num>.fromIterable(<int>[1, 2, 3]);
+
+    await expect(observable.cast(kInt).map((int i) => i.isEven),
+        emitsInOrder(<dynamic>[false, true, false, emitsDone]));
+  });
+
+  group('CastStreamTransformer', () {
+    test('casts all items to a specific type', () async {
+      final Stream<num> stream = new Stream<num>.fromIterable(<int>[1, 2, 3]);
+
+      await expect(
+          stream
+              .transform(
+                  new CastStreamTransformer<num, int>(new TypeToken<int>()))
+              .map((int i) => i.isEven),
+          emitsInOrder(<dynamic>[false, true, false, emitsDone]));
+    });
+
+    test('emits an error if the cast is invalid', () async {
+      final Stream<num> stream = new Stream<num>.fromIterable(<num>[1.2, 2]);
+
+      await expect(
+          stream.transform(
+              new CastStreamTransformer<num, int>(new TypeToken<int>())),
+          emitsInOrder(<dynamic>[
+            emitsError(new isInstanceOf<CastError>()),
+            2,
+            emitsDone
+          ]));
+    });
+
+    test('supports pause and resume', () async {
+      StreamSubscription<int> subscription;
+      Stream<int> stream = new Stream<num>.fromIterable(<int>[1])
+          .transform(new CastStreamTransformer<num, int>(kInt));
+
+      subscription = stream.listen(expectAsync1((int value) {
+        expect(value, 1);
+
+        subscription.cancel();
+      }, count: 1));
+
+      subscription.pause();
+      subscription.resume();
+    });
+  });
+}

--- a/test/transformers/of_type_test.dart
+++ b/test/transformers/of_type_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/type_token.dart';
 import 'package:test/test.dart';
 import 'package:rxdart/rxdart.dart';
 


### PR DESCRIPTION
Adds the `cast` operator found in RxJava & RxNET. I'd seen it used a few times in the past few weeks at work, useful in certain scenarios, and thought it would be good to add to this lib.

http://reactivex.io/documentation/operators/map.html

Changes:

  - Move TypeToken into it's own file for import into both OfType and Cast
  - Add cast + docs + tests
 