### PR TITLE
Allow defer & subject streams to be listened to multiple times

### DIFF
--- a/example/flutter/github_search/lib/github_search_api.dart
+++ b/example/flutter/github_search/lib/github_search_api.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:flutter/http.dart';
+import 'package:http/http.dart';
 import 'package:rxdart/rxdart.dart';
 
 class GithubApi {

--- a/example/flutter/github_search/lib/github_search_widget.dart
+++ b/example/flutter/github_search/lib/github_search_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/http.dart';
+import 'package:http/http.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_stream_friends/flutter_stream_friends.dart';
 import 'package:github_search/github_search_api.dart';

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -460,12 +460,15 @@ class Observable<T> extends Stream<T> {
   /// subscription time) to generate the Observable can ensure that this
   /// Observable contains the freshest data.
   ///
+  /// By default, DeferStreams are single-subscription. However, it's possible
+  /// to make them reusable.
+  ///
   /// ### Example
   ///
   ///     new Observable.defer(() => new Observable.just(1))
   ///       .listen(print); //prints 1
-  factory Observable.defer(Stream<T> streamFactory()) =>
-      new Observable<T>(new DeferStream<T>(streamFactory));
+  factory Observable.defer(Stream<T> streamFactory(), {bool reusable: false}) =>
+      new Observable<T>(new DeferStream<T>(streamFactory, reusable: reusable));
 
   /// Returns an observable sequence that emits an [error], then immediately
   /// completes.

--- a/lib/src/streams/defer.dart
+++ b/lib/src/streams/defer.dart
@@ -9,26 +9,24 @@ import 'package:rxdart/src/streams/utils.dart';
 /// subscription time) to generate the Observable can ensure that this
 /// Observable contains the freshest data.
 ///
-/// By default, DeferStream is single-subscription as it cannot guarantee the
-/// source streams will be broadcast streams. If, however, you are certain the
-/// source streams are broadcast stream, you can allow the DeferStream to be
-/// subscribed to multiple times.
+/// By default, DeferStreams are single-subscription. However, it's possible
+/// to make them reusable.
 ///
 /// ### Example
 ///
 ///     new DeferStream(() => new Observable.just(1)).listen(print); //prints 1
 class DeferStream<T> extends Stream<T> {
   final StreamFactory<T> _streamFactory;
-  final bool _isBroadcastStream;
+  final bool _isReusable;
   bool _isUsed = false;
 
-  DeferStream(this._streamFactory, {bool broadcast: false})
-      : _isBroadcastStream = broadcast;
+  DeferStream(this._streamFactory, {bool reusable: false})
+      : _isReusable = reusable;
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    if (_isUsed && !_isBroadcastStream)
+    if (_isUsed && !_isReusable)
       throw new StateError("Stream has already been listened to.");
     _isUsed = true;
 

--- a/lib/src/streams/defer.dart
+++ b/lib/src/streams/defer.dart
@@ -9,22 +9,30 @@ import 'package:rxdart/src/streams/utils.dart';
 /// subscription time) to generate the Observable can ensure that this
 /// Observable contains the freshest data.
 ///
+/// By default, DeferStream is single-subscription as it cannot guarantee the
+/// source streams will be broadcast streams. If, however, you are certain the
+/// source streams are broadcast stream, you can allow the DeferStream to be
+/// subscribed to multiple times.
+///
 /// ### Example
 ///
 ///     new DeferStream(() => new Observable.just(1)).listen(print); //prints 1
 class DeferStream<T> extends Stream<T> {
-  final StreamFactory<T> streamFactory;
+  final StreamFactory<T> _streamFactory;
+  final bool _isBroadcastStream;
   bool _isUsed = false;
 
-  DeferStream(this.streamFactory);
+  DeferStream(this._streamFactory, {bool broadcast: false})
+      : _isBroadcastStream = broadcast;
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    if (_isUsed) throw new StateError("Stream has already been listened to.");
+    if (_isUsed && !_isBroadcastStream)
+      throw new StateError("Stream has already been listened to.");
     _isUsed = true;
 
-    return streamFactory().listen(onData,
+    return _streamFactory().listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 }

--- a/lib/src/subject/behavior_subject.dart
+++ b/lib/src/subject/behavior_subject.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 import 'package:rxdart/src/observable.dart';
-import 'package:rxdart/src/streams/defer.dart';
-import 'package:rxdart/src/transformers/start_with.dart';
 
 /// A special StreamController that captures the latest item that has been
 /// added to the controller, and emits that as the first item to any new
@@ -47,12 +45,11 @@ class BehaviorSubject<T> implements StreamController<T> {
         _latestValue = seedValue;
 
   @override
-  Observable<T> get stream => _latestValue == null
-      ? new Observable<T>(_controller.stream)
-      : new Observable<T>(new DeferStream<T>(
-          () => _controller.stream
-              .transform(new StartWithStreamTransformer<T>(_latestValue)),
-          broadcast: true));
+  Observable<T> get stream => new Observable<T>.defer(
+      () => _latestValue == null
+          ? _controller.stream
+          : new Observable<T>(_controller.stream).startWith(_latestValue),
+      reusable: true);
 
   @override
   StreamSink<T> get sink => _controller.sink;

--- a/lib/src/subject/replay_subject.dart
+++ b/lib/src/subject/replay_subject.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:rxdart/src/observable.dart';
+import 'package:rxdart/src/streams/defer.dart';
 
 /// A special StreamController that captures all of the items that have been
 /// added to the controller, and emits those as the first items to any new
@@ -17,10 +18,6 @@ import 'package:rxdart/src/observable.dart';
 /// ReplaySubject is, by default, a broadcast (aka hot) controller, in order
 /// to fulfill the Rx Subject contract. This means the Subject's `stream` can
 /// be listened to multiple times.
-///
-/// As a Dart quirk, in order to listen to the stream multiple times while
-/// getting the recorded items, always use the `mySubject.stream` getter. The
-/// returned Stream is an `Observable`.
 ///
 /// ### Example
 ///
@@ -56,9 +53,10 @@ class ReplaySubject<T> implements StreamController<T> {
             onListen: onListen, onCancel: onCancel, sync: sync);
 
   @override
-  Observable<T> get stream =>
-      new Observable<T>.defer(() => new Observable<T>(_controller.stream)
-          .startWithMany(_queue.toList(growable: false)));
+  Observable<T> get stream => new Observable<T>(new DeferStream<T>(
+      () => new Observable<T>(_controller.stream)
+          .startWithMany(_queue.toList(growable: false)),
+      broadcast: true));
 
   @override
   StreamSink<T> get sink => _controller.sink;

--- a/lib/src/subject/replay_subject.dart
+++ b/lib/src/subject/replay_subject.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:rxdart/src/observable.dart';
-import 'package:rxdart/src/streams/defer.dart';
 
 /// A special StreamController that captures all of the items that have been
 /// added to the controller, and emits those as the first items to any new
@@ -53,10 +52,10 @@ class ReplaySubject<T> implements StreamController<T> {
             onListen: onListen, onCancel: onCancel, sync: sync);
 
   @override
-  Observable<T> get stream => new Observable<T>(new DeferStream<T>(
+  Observable<T> get stream => new Observable<T>.defer(
       () => new Observable<T>(_controller.stream)
           .startWithMany(_queue.toList(growable: false)),
-      broadcast: true));
+      reusable: true);
 
   @override
   StreamSink<T> get sink => _controller.sink;

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -220,5 +220,15 @@ void main() {
 
       await expect(subject.done, completes);
     });
+
+    test('can be listened to multiple times', () async {
+      // ignore: close_sinks
+      final StreamController<int> subject =
+          new BehaviorSubject<int>(seedValue: 1);
+      final Stream<int> stream = subject.stream;
+
+      await expect(stream, emits(1));
+      await expect(stream, emits(1));
+    });
   });
 }

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -223,5 +223,17 @@ void main() {
 
       await expect(subject.done, completes);
     });
+
+    test('can be listened to multiple times', () async {
+      // ignore: close_sinks
+      final StreamController<int> subject = new ReplaySubject<int>();
+      final Stream<int> stream = subject.stream;
+
+      subject.add(1);
+      subject.add(2);
+
+      await expect(stream, emitsInOrder(<int>[1, 2]));
+      await expect(stream, emitsInOrder(<int>[1, 2]));
+    });
   });
 }


### PR DESCRIPTION
Discussed on Gitter -- a current limitation of the Subject streams, having used DeferStreams, was that they could not be listened to multiple times properly, the way a broadcast stream should support.

This fixes that!

Proposal: extend DeferStream with an extra `reusable` option that can be used when the consumer is certain they're working with factory function that produces reusable streams, such as our subjects with broadcast streams.

Then, use this new capability in both subjects.