### PR TITLE
Ensure the Subjects create only 1 instance of the underlying stream

### DIFF
--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -230,5 +230,12 @@ void main() {
       await expect(stream, emits(1));
       await expect(stream, emits(1));
     });
+
+    test('always returns the same stream', () async {
+      // ignore: close_sinks
+      final StreamController<int> subject = new BehaviorSubject<int>();
+
+      await expect(subject.stream, equals(subject.stream));
+    });
   });
 }

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -235,5 +235,12 @@ void main() {
       await expect(stream, emitsInOrder(<int>[1, 2]));
       await expect(stream, emitsInOrder(<int>[1, 2]));
     });
+
+    test('always returns the same stream', () async {
+      // ignore: close_sinks
+      final StreamController<int> subject = new ReplaySubject<int>();
+
+      await expect(subject.stream, equals(subject.stream));
+    });
   });
 }


### PR DESCRIPTION
This prevents ng2 and other consumers from assuming streams returned from the Subject are different from each other when checking for identity or equality, when in fact they're functionally equivalent.