### PR TITLE
Fix   streams throw in ng2 after 0.13 update

### DIFF
--- a/lib/src/transformers/flat_map_latest.dart
+++ b/lib/src/transformers/flat_map_latest.dart
@@ -39,14 +39,9 @@ class FlatMapLatestStreamTransformer<T, S> implements StreamTransformer<T, S> {
           sync: true,
           onListen: () {
             subscription = input.listen(
-                (T value) async {
+                (T value) {
                   try {
-                    final Future<dynamic> closeFuture =
-                        otherSubscription?.cancel();
-
-                    if (closeFuture != null) {
-                      await closeFuture;
-                    }
+                    otherSubscription?.cancel();
 
                     hasMainEvent = true;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rxdart
-version: 0.13.0
+version: 0.13.1
 authors:
 - Frank Pepermans <frank@igindo.com>
 - Brian Egan <brian@brianegan.com>


### PR DESCRIPTION
Not sure why this was failing, with async on.

It may have to do with the await on cancel:
- parent stream adds event
- flat map latest receives it
- waits for the cancel of the previous subscription
- parent now closes
- flat map's onDone triggers, closing its controller
- the cancel from above is now complete, the listen function resumes
- Bad state error is now thrown (cannot add event after close)

seems plausible?