### PR TITLE
Remove all `async` methods introduced in 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.13.1
 
 * Fix error with FlatMapLatest where it was not properly cancelled in some scenarios
+* Remove additional async methods on Stream handlers unless they're shown to solve a problem
 
 ## 0.13.0
 

--- a/lib/src/streams/concat.dart
+++ b/lib/src/streams/concat.dart
@@ -47,11 +47,9 @@ class ConcatStream<T> extends Stream<T> {
           final int len = streams.length;
           int index = 0;
 
-          Future<Null> moveNext() async {
+          void moveNext() {
             Stream<T> stream = streams.elementAt(index);
-            Future<dynamic> cancelFuture = subscription?.cancel();
-
-            if (cancelFuture != null) await cancelFuture;
+            subscription?.cancel();
 
             subscription = stream.listen(controller.add,
                 onError: controller.addError, onDone: () {

--- a/lib/src/streams/retry.dart
+++ b/lib/src/streams/retry.dart
@@ -49,16 +49,13 @@ class RetryStream<T> extends Stream<T> {
   }
 
   void retry() {
-    subscription = streamFactory().listen(controller.add,
-        onError: (dynamic e, dynamic s) async {
-      Future<dynamic> cancelFuture = subscription.cancel();
-
-      if (cancelFuture != null) await cancelFuture;
+    subscription =
+        streamFactory().listen(controller.add, onError: (dynamic e, dynamic s) {
+      subscription.cancel();
 
       if (count == retryStep) {
         controller.addError(new RetryError(count));
-        Future<dynamic> cancelFuture2 = controller.close();
-        if (cancelFuture2 != null) await cancelFuture2;
+        controller.close();
       } else {
         retryStep++;
         retry();

--- a/lib/src/transformers/flat_map.dart
+++ b/lib/src/transformers/flat_map.dart
@@ -49,12 +49,12 @@ class FlatMapStreamTransformer<T, S> implements StreamTransformer<T, S> {
                     streams.add(otherStream);
 
                     otherSubscription = otherStream.listen(controller.add,
-                        onError: controller.addError, onDone: () async {
+                        onError: controller.addError, onDone: () {
                       streams.remove(otherStream);
                       subscriptions.remove(otherSubscription);
 
                       if (closeAfterNextEvent && streams.isEmpty)
-                        await controller.close();
+                        controller.close();
                     });
 
                     subscriptions.add(otherSubscription);

--- a/lib/src/transformers/on_error_resume_next.dart
+++ b/lib/src/transformers/on_error_resume_next.dart
@@ -40,17 +40,15 @@ class OnErrorResumeNextStreamTransformer<T> implements StreamTransformer<T, T> {
           sync: true,
           onListen: () {
             inputSubscription = input.listen(controller.add,
-                onError: (dynamic e, dynamic s) async {
+                onError: (dynamic e, dynamic s) {
               shouldCloseController = false;
-
-              Future<dynamic> cancelFuture = inputSubscription.cancel();
-
-              if (cancelFuture != null) await cancelFuture;
 
               recoverySubscription = recoveryStream.listen(controller.add,
                   onError: controller.addError,
                   onDone: controller.close,
                   cancelOnError: cancelOnError);
+
+              inputSubscription.cancel();
             }, onDone: safeClose, cancelOnError: cancelOnError);
           },
           onPause: ([Future<dynamic> resumeSignal]) {

--- a/test/transformers/flat_map_latest_test.dart
+++ b/test/transformers/flat_map_latest_test.dart
@@ -76,36 +76,6 @@ void main() {
     await expect(true, true);
   });
 
-
-  test('rx.Observable.flatMapLatest.error.shouldThrow12d122', () async {
-    StateError error;
-
-    try {
-      final StreamController<int> streamController =
-      new StreamController<int>(sync: true);
-      final Observable<int> observable =
-      new Observable<int>(streamController.stream).flatMapLatest((int i) =>
-      new Observable<int>.timer(1, new Duration(milliseconds: 100)));
-
-      scheduleMicrotask(() {
-        streamController.add(1);
-        streamController.add(2);
-      });
-
-      scheduleMicrotask(() {
-        streamController.close();
-      });
-
-      var listen = observable.listen(null);
-      listen.cancel();
-      await new Future.delayed(new Duration(milliseconds: 200));
-    } catch(e, s) {
-      error = e;
-    } finally {
-      await expect(error, isStateError);
-    }
-  });
-
   test('rx.Observable.flatMapLatest.error.shouldThrowA', () async {
     Stream<int> observableWithError =
         new Observable<int>(new ErrorStream<int>(new Exception()))


### PR DESCRIPTION
These async methods were shown to introduce some subtle bugs that are very hard to debug and correct. I'd say we just get rid of em unless they're shown to fix an issue