### PR TITLE
fixes an RTE when the returned cancel is Null instead of Future

### DIFF
--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -167,9 +167,10 @@ class DoStreamTransformer<T> implements StreamTransformer<T, T> {
             }
           }
         }
-        return subscriptions[input]
-            .cancel()
-            .whenComplete(() => subscriptions.remove(input));
+        Future<dynamic> cancelFuture =
+            subscriptions[input].cancel() ?? new Future<dynamic>.value();
+
+        return cancelFuture.whenComplete(() => subscriptions.remove(input));
       };
 
       if (input.isBroadcast) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rxdart
-version: 0.14.0
+version: 0.14.0+1
 authors:
 - Frank Pepermans <frank@igindo.com>
 - Brian Egan <brian@brianegan.com>


### PR DESCRIPTION
Calling cancel() threw an RTE sometimes, since the cancel() method can return Null instead of Future