### PR TITLE
Debounce Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ script:
   - pub run test test/rxdart_test.dart
   - pub get --packages-dir
   - pub global activate coverage
-  - dart --observe=8111 test/rxdart_test.dart &
-  - sleep 30
-  - pub global run coverage:collect_coverage --port=8111 -o coverage.json --resume-isolates
+  - pub global run coverage:collect_coverage --port=8111 -o coverage.json --resume-isolates --wait-paused &
+  - dart --observe=8111 test/rxdart_test.dart
   - pub global run coverage:format_coverage --package-root=packages --report-on lib --in coverage.json --out lcov.info --lcov
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/lib/src/transformers/debounce.dart
+++ b/lib/src/transformers/debounce.dart
@@ -52,9 +52,15 @@ class DebounceStreamTransformer<T> implements StreamTransformer<T, T> {
                 onDone: () {
                   _cancelTimerIfActive(timer);
 
-                  if (lastEvent != null) controller.add(lastEvent);
+                  if (lastEvent != null) {
+                    scheduleMicrotask(() {
+                      controller.add(lastEvent);
 
-                  controller.close();
+                      controller.close();
+                    });
+                  } else {
+                    controller.close();
+                  }
                 },
                 cancelOnError: cancelOnError);
           },

--- a/lib/src/transformers/debounce.dart
+++ b/lib/src/transformers/debounce.dart
@@ -25,26 +25,24 @@ class DebounceStreamTransformer<T> implements StreamTransformer<T, T> {
 
   static StreamTransformer<T, T> _buildTransformer<T>(Duration duration) {
     return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+      T lastEvent;
       StreamController<T> controller;
       StreamSubscription<T> subscription;
-      bool _closeAfterNextEvent = false;
-      Timer _timer;
-      bool streamHasEvent = false;
+      Timer timer;
 
       controller = new StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input.listen(
                 (T value) {
-                  streamHasEvent = true;
+                  lastEvent = value;
 
                   try {
-                    if (_timer != null && _timer.isActive) _timer.cancel();
+                    _cancelTimerIfActive(timer);
 
-                    _timer = new Timer(duration, () {
-                      controller.add(value);
-
-                      if (_closeAfterNextEvent) controller.close();
+                    timer = new Timer(duration, () {
+                      controller.add(lastEvent);
+                      lastEvent = null;
                     });
                   } catch (e, s) {
                     controller.addError(e, s);
@@ -52,19 +50,30 @@ class DebounceStreamTransformer<T> implements StreamTransformer<T, T> {
                 },
                 onError: controller.addError,
                 onDone: () {
-                  if (!streamHasEvent)
-                    controller.close();
-                  else
-                    _closeAfterNextEvent = true;
+                  _cancelTimerIfActive(timer);
+
+                  if (lastEvent != null) controller.add(lastEvent);
+
+                  controller.close();
                 },
                 cancelOnError: cancelOnError);
           },
           onPause: ([Future<dynamic> resumeSignal]) =>
               subscription.pause(resumeSignal),
           onResume: () => subscription.resume(),
-          onCancel: () => subscription.cancel());
+          onCancel: () {
+            _cancelTimerIfActive(timer);
+
+            return subscription.cancel();
+          });
 
       return controller.stream.listen(null);
     });
+  }
+
+  static void _cancelTimerIfActive(Timer _timer) {
+    if (_timer != null && _timer.isActive) {
+      _timer.cancel();
+    }
   }
 }


### PR DESCRIPTION
Ensure debounce cancels any timers and emits the last item immediately after the source stream terminates.

Aims to solve #110 