### PR TITLE
Implement exhaustMap from rxjs

### DIFF
--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -1280,6 +1280,22 @@ class Observable<T> extends Stream<T> {
   AsObservableFuture<bool> every(bool test(T element)) =>
       new AsObservableFuture<bool>(stream.every(test));
 
+  /// Converts items from the source stream into a new Stream using a given
+  /// mapper. It ignores all items from the source stream until the new stream
+  /// completes.
+  ///
+  /// Useful when you have a noisy source Stream and only want to respond once
+  /// the previous async operation is finished.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.range(0, 2).interval(new Duration(milliseconds: 50))
+  ///       .exhaustMap((i) =>
+  ///         new Observable.timer(i, new Duration(milliseconds: 75)))
+  ///       .listen(print); // prints 0, 2
+  Observable<S> exhaustMap<S>(Stream<S> mapper(T value)) =>
+      transform(new ExhaustMapStreamTransformer<T, S>(mapper));
+
   /// Creates an Observable from this stream that converts each element into
   /// zero or more events.
   ///

--- a/lib/src/transformers/exhaust_map.dart
+++ b/lib/src/transformers/exhaust_map.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+/// Converts items from the source stream into a new Stream using a given
+/// mapper. It ignores all items from the source stream until the new stream
+/// completes.
+///
+/// Useful when you have a noisy source Stream and only want to respond once
+/// the previous async operation is finished.
+///
+/// ### Example
+///     // Emits 0, 1, 2
+///     new Stream.periodic(new Duration(milliseconds: 200), (i) => i).take(3)
+///       .transform(new ExhaustMapStreamTransformer(
+///         // Emits the value it's given after 200ms
+///         (i) => new Observable.timer(i, new Duration(milliseconds: 200)),
+///       ))
+///     .listen(print); // prints 0, 2
+class ExhaustMapStreamTransformer<T, S> implements StreamTransformer<T, S> {
+  final StreamTransformer<T, S> transformer;
+
+  ExhaustMapStreamTransformer(Stream<S> mapper(T value))
+      : transformer = _buildTransformer(mapper);
+
+  @override
+  Stream<S> bind(Stream<T> stream) => transformer.bind(stream);
+
+  static StreamTransformer<T, S> _buildTransformer<T, S>(
+      Stream<S> mapper(T value)) {
+    return new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
+      StreamController<S> controller;
+      StreamSubscription<T> inputSubscription;
+      StreamSubscription<S> outputSubscription;
+      bool inputClosed = false;
+      bool outputIsEmitting = false;
+
+      controller = new StreamController<S>(
+        sync: true,
+        onListen: () {
+          inputSubscription = input.listen(
+            (T value) {
+              try {
+                if (!outputIsEmitting) {
+                  outputIsEmitting = true;
+                  outputSubscription = mapper(value).listen(
+                    controller.add,
+                    onError: controller.addError,
+                    onDone: () {
+                      outputIsEmitting = false;
+                      if (inputClosed) controller.close();
+                    },
+                  );
+                }
+              } catch (e, s) {
+                controller.addError(e, s);
+              }
+            },
+            onError: controller.addError,
+            onDone: () {
+              inputClosed = true;
+              if (!outputIsEmitting) controller.close();
+            },
+            cancelOnError: cancelOnError,
+          );
+        },
+        onPause: ([Future<dynamic> resumeSignal]) {
+          inputSubscription.pause(resumeSignal);
+          outputSubscription?.pause(resumeSignal);
+        },
+        onResume: () {
+          inputSubscription.resume();
+          outputSubscription?.resume();
+        },
+        onCancel: () async {
+          await inputSubscription.cancel();
+          if (outputIsEmitting) await outputSubscription.cancel();
+        },
+      );
+
+      return controller.stream.listen(null);
+    });
+  }
+}

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -7,6 +7,7 @@ export 'package:rxdart/src/transformers/default_if_empty.dart';
 export 'package:rxdart/src/transformers/dematerialize.dart';
 export 'package:rxdart/src/transformers/distinct_unique.dart';
 export 'package:rxdart/src/transformers/do.dart';
+export 'package:rxdart/src/transformers/exhaust_map.dart';
 export 'package:rxdart/src/transformers/flat_map.dart';
 export 'package:rxdart/src/transformers/flat_map_latest.dart';
 export 'package:rxdart/src/transformers/ignore_elements.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -39,6 +39,7 @@ import 'transformers/do_test.dart' as do_test;
 import 'transformers/drain_test.dart' as drain_test;
 import 'transformers/element_at_test.dart' as element_at_test;
 import 'transformers/every_test.dart' as every_test;
+import 'transformers/exhaust_map_test.dart' as exhaust_map_test;
 import 'transformers/expand_test.dart' as expand_test;
 import 'transformers/first_test.dart' as first_test;
 import 'transformers/first_where_test.dart' as first_where_test;
@@ -135,6 +136,7 @@ void main() {
   drain_test.main();
   element_at_test.main();
   every_test.main();
+  exhaust_map_test.main();
   expand_test.main();
   first_test.main();
   first_where_test.main();

--- a/test/transformers/exhaust_map_test.dart
+++ b/test/transformers/exhaust_map_test.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:rxdart/src/transformers/exhaust_map.dart';
+import 'package:test/test.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  group('ExhaustMap', () {
+    test('does not create a new Stream while emitting', () async {
+      int calls = 0;
+      final Observable<int> observable =
+          Observable.range(0, 9).exhaustMap((int i) {
+        calls++;
+        return new Observable<int>.timer(i, new Duration(milliseconds: 100));
+      });
+
+      await expect(observable, emitsInOrder(<dynamic>[0, emitsDone]));
+      await expect(calls, 1);
+    });
+
+    test('starts emitting again after previous Stream is complete', () async {
+      int calls = 0;
+      final Observable<int> observable = Observable
+          .range(0, 9)
+          .interval(new Duration(milliseconds: 20))
+          .exhaustMap((int i) {
+        calls++;
+        return new Observable<int>.timer(i, new Duration(milliseconds: 100));
+      });
+
+      await expect(observable, emitsInOrder(<dynamic>[0, 5, emitsDone]));
+      await expect(calls, 2);
+    });
+
+    test('is reusable', () async {
+      final ExhaustMapStreamTransformer<int, int> transformer =
+          new ExhaustMapStreamTransformer<int, int>((int i) =>
+              new Observable<int>.timer(i, new Duration(milliseconds: 100)));
+
+      await expect(
+        Observable.range(0, 9).transform(transformer),
+        emitsInOrder(<dynamic>[0, emitsDone]),
+      );
+
+      await expect(
+        Observable.range(0, 9).transform(transformer),
+        emitsInOrder(<dynamic>[0, emitsDone]),
+      );
+    });
+
+    test('works as a broadcast stream', () async {
+      Stream<num> stream = Observable
+          .range(0, 9)
+          .asBroadcastStream()
+          .exhaustMap((int i) =>
+              new Observable<int>.timer(i, new Duration(milliseconds: 100)));
+
+      await expect(() {
+        stream.listen((_) {});
+        stream.listen((_) {});
+      }, returnsNormally);
+    });
+
+    test('should emit errors from source', () async {
+      Stream<int> observableWithError = new Observable<int>(
+              new ErrorStream<int>(new Exception()))
+          .exhaustMap((int i) =>
+              new Observable<int>.timer(i, new Duration(milliseconds: 100)));
+
+      await expect(observableWithError, emitsError(isException));
+    });
+
+    test('should emit errors from mapped stream', () async {
+      Stream<int> observableWithError = new Observable<int>.just(1).exhaustMap(
+          (_) => new ErrorStream<int>(new Exception('Catch me if you can!')));
+
+      await expect(observableWithError, emitsError(isException));
+    });
+
+    test('should emit errors thrown in the mapper', () async {
+      Stream<int> observableWithError =
+          new Observable<int>.just(1).exhaustMap((_) {
+        throw new Exception('oh noes!');
+      });
+
+      await expect(observableWithError, emitsError(isException));
+    });
+
+    test('can be paused and resumed', () async {
+      StreamSubscription<int> subscription;
+      Observable<int> stream = Observable.range(0, 9).exhaustMap((int i) =>
+          new Observable<int>.timer(i, new Duration(milliseconds: 20)));
+
+      subscription = stream.listen(expectAsync1((int value) {
+        expect(value, 0);
+        subscription.cancel();
+      }, count: 1));
+
+      subscription.pause();
+      subscription.resume();
+    });
+  });
+}


### PR DESCRIPTION
ExhaustMap is like FlatMap, but will not produce a Streams if the
previously created Stream is still emitting items.

Useful for infinite scroll situations.