### PR TITLE
Modifies the sink getter on Subject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ packages
 .idea/
 web/experimental
 doc
+.dart_tool/
 
 # Or the files created by dart2js.
 *.dart.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.2
+
+* Fix added events to `sink` are not processed correctly by `Subjects`.
+
 ## 0.16.1
 
 * Fix `dematerialize` method for Dart 2.

--- a/example/example.dart
+++ b/example/example.dart
@@ -24,14 +24,14 @@ void main(List<String> arguments) {
   const seed = const IndexedPair(1, 1, 0);
 
   Observable
-  // amount of numbers to compute
+      // amount of numbers to compute
       .range(1, n)
-  // accumulator: computes a new accumulated
-  // value each time a [Stream] event occurs
-  // in this case, the accumulated value is always
-  // the latest Fibonacci number
+      // accumulator: computes a new accumulated
+      // value each time a [Stream] event occurs
+      // in this case, the accumulated value is always
+      // the latest Fibonacci number
       .scan((IndexedPair seq, _, __) => new IndexedPair.next(seq), seed)
-  // finally, print the output
+      // finally, print the output
       .listen(print, onDone: () => print('done!'));
 }
 

--- a/example/flutter/github_search/lib/github_search_api.dart
+++ b/example/flutter/github_search/lib/github_search_api.dart
@@ -12,8 +12,7 @@ class GithubApi {
     Client client,
     Map<String, SearchResult> cache,
     this.baseUrl = "https://api.github.com/search/repositories?q=",
-  })
-      : this.client = client ?? new Client(),
+  })  : this.client = client ?? new Client(),
         this.cache = cache ?? <String, SearchResult>{};
 
   /// Search Github for repositories using the given term

--- a/example/flutter/github_search/lib/github_search_widget.dart
+++ b/example/flutter/github_search/lib/github_search_widget.dart
@@ -83,8 +83,7 @@ class SearchView extends StatelessWidget {
     Key key,
     @required this.model,
     @required this.onTextChanged,
-  })
-      : super(key: key);
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/web/dragdrop/dragdrop.dart
+++ b/example/web/dragdrop/dragdrop.dart
@@ -10,26 +10,21 @@ void main() {
   final mouseDown = new Observable<MouseEvent>(document.onMouseDown);
 
   mouseDown
-    // Use map() to calculate the left and top properties on mouseDown
-    .map((event) => new Point<num>(
-      event.client.x - dragTarget.offset.left,
-      event.client.y - dragTarget.offset.top
-    ))
-    // Use flatMapLatest() to get the mouse position on each mouseMove
-    .flatMapLatest((startPosition) {
-
-      return mouseMove
+      // Use map() to calculate the left and top properties on mouseDown
+      .map((event) => new Point<num>(event.client.x - dragTarget.offset.left,
+          event.client.y - dragTarget.offset.top))
+      // Use flatMapLatest() to get the mouse position on each mouseMove
+      .flatMapLatest((startPosition) {
+    return mouseMove
         // Use map() to calculate the left and top properties on each mouseMove
         .map((event) => new Point<num>(
-          event.client.x - startPosition.x,
-          event.client.y - startPosition.y
-        ))
+            event.client.x - startPosition.x, event.client.y - startPosition.y))
         // Use takeUntil() to stop calculations when a mouseUp occurs
         .takeUntil(mouseUp);
-    })
-    // Use listen() to update the position of the dragTarget
-    .listen((position) {
-      dragTarget.style.left = '${position.x}px';
-      dragTarget.style.top = '${position.y}px';
-    });
+  })
+      // Use listen() to update the position of the dragTarget
+      .listen((position) {
+    dragTarget.style.left = '${position.x}px';
+    dragTarget.style.top = '${position.y}px';
+  });
 }

--- a/example/web/konami/konamicode.dart
+++ b/example/web/konami/konamicode.dart
@@ -23,12 +23,13 @@ void main() {
   final keyUp = new Observable<KeyboardEvent>(document.onKeyUp);
 
   keyUp
-    // Use map() to get the keyCode
-    .map((event) => event.keyCode)
-    // Use bufferWithCount() to remember the last 10 keyCodes
-    .bufferWithCount(10, 1)
-    // Use where() to check for matching values
-    .where((lastTenKeyCodes) => const IterableEquality<int>().equals(lastTenKeyCodes, konamiKeyCodes))
-    // Use listen() to display the result
-    .listen((_) => result.innerHtml = 'KONAMI!');
+      // Use map() to get the keyCode
+      .map((event) => event.keyCode)
+      // Use bufferWithCount() to remember the last 10 keyCodes
+      .bufferWithCount(10, 1)
+      // Use where() to check for matching values
+      .where((lastTenKeyCodes) =>
+          const IterableEquality<int>().equals(lastTenKeyCodes, konamiKeyCodes))
+      // Use listen() to display the result
+      .listen((_) => result.innerHtml = 'KONAMI!');
 }

--- a/lib/src/subjects/subject.dart
+++ b/lib/src/subjects/subject.dart
@@ -22,7 +22,7 @@ abstract class Subject<T> implements StreamController<T> {
   Observable<T> get stream => observable;
 
   @override
-  StreamSink<T> get sink => controller.sink;
+  StreamSink<T> get sink => new _StreamSinkWrapper<T>(this);
 
   @override
   ControllerCallback get onListen => controller.onListen;
@@ -135,4 +135,28 @@ abstract class Subject<T> implements StreamController<T> {
 
     return controller.close();
   }
+}
+
+class _StreamSinkWrapper<T> implements StreamSink<T> {
+  final StreamController<T> _target;
+  _StreamSinkWrapper(this._target);
+
+  @override
+  void add(T data) {
+    _target.add(data);
+  }
+
+  @override
+  void addError(Object error, [StackTrace stackTrace]) {
+    _target.addError(error, stackTrace);
+  }
+
+  @override
+  Future close() => _target.close();
+
+  @override
+  Future addStream(Stream<T> source) => _target.addStream(source);
+
+  @override
+  Future get done => _target.done;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rxdart
-version: 0.16.1
+version: 0.16.2
 authors:
 - Frank Pepermans <frank@igindo.com>
 - Brian Egan <brian@brianegan.com>

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -258,5 +258,22 @@ void main() {
 
       await expectLater(subject.stream, equals(subject.stream));
     });
+
+    test('adding to sink has same behavior as adding to Subject itself',
+        () async {
+      // ignore: close_sinks
+      final BehaviorSubject<int> subject = new BehaviorSubject<int>();
+
+      subject.sink.add(1);
+
+      expect(subject.value, 1);
+
+      subject.sink.add(2);
+      subject.sink.add(3);
+
+      await expectLater(subject.stream, emits(3));
+      await expectLater(subject.stream, emits(3));
+      await expectLater(subject.stream, emits(3));
+    });
   });
 }

--- a/test/subject/publish_subject_test.dart
+++ b/test/subject/publish_subject_test.dart
@@ -233,5 +233,21 @@ void main() {
 
       await expectLater(subject.stream, equals(subject.stream));
     });
+
+    test('adding to sink has same behavior as adding to Subject itself',
+        () async {
+      // ignore: close_sinks
+      final StreamController<int> subject = new PublishSubject<int>();
+
+      scheduleMicrotask(() {
+        subject.sink.add(1);
+        subject.sink.add(2);
+        subject.sink.add(3);
+        subject.sink.close();
+      });
+
+      await expectLater(
+          subject.stream, emitsInOrder(<dynamic>[1, 2, 3, emitsDone]));
+    });
   });
 }

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -255,5 +255,19 @@ void main() {
 
       await expectLater(subject.stream, equals(subject.stream));
     });
+
+    test('adding to sink has same behavior as adding to Subject itself',
+        () async {
+      // ignore: close_sinks
+      final StreamController<int> subject = new ReplaySubject<int>();
+
+      subject.sink.add(1);
+      subject.sink.add(2);
+      subject.sink.add(3);
+
+      await expectLater(subject.stream, emitsInOrder(<int>[1, 2, 3]));
+      await expectLater(subject.stream, emitsInOrder(<int>[1, 2, 3]));
+      await expectLater(subject.stream, emitsInOrder(<int>[1, 2, 3]));
+    });
   });
 }


### PR DESCRIPTION
By default, getting sink returns an internal wrapper object encapsulating the controller.

However, calling add on this sink, will internally only call add on the controller, ignoring the add and onAdd methods in the Subject.

This wrapper fixes this flow