### PR TITLE
SwitchLatestStream

### DIFF
--- a/lib/src/streams/switch_latest.dart
+++ b/lib/src/streams/switch_latest.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+/// Convert a Stream that emits Streams (aka a "Higher Order Stream") into a
+/// single Stream that emits the items emitted by the most-recently-emitted of
+/// those Streams.
+///
+/// This stream will unsubscribe from the previously-emitted Stream when a new
+/// Stream is emitted from the source Stream.
+///
+/// ### Example
+///
+/// ```dart
+/// final switchLatestStream = new SwitchLatestStream<String>(
+///   new Stream.fromIterable(<Stream<String>>[
+///     new Observable.timer('A', new Duration(seconds: 2)),
+///     new Observable.timer('B', new Duration(seconds: 1)),
+///     new Observable.just('C'),
+///   ]),
+/// );
+///
+/// // Since the first two Streams do not emit data for 1-2 seconds, and the 3rd
+/// // Stream will be emitted before that time, only data from the 3rd Stream
+/// // will be emitted to the listener.
+/// switchLatestStream.listen(print); // prints 'C'
+/// ```
+class SwitchLatestStream<T> extends Stream<T> {
+  final Stream<Stream<T>> streams;
+
+  // ignore: close_sinks
+  StreamController<T> _controller;
+
+  SwitchLatestStream(this.streams);
+
+  @override
+  StreamSubscription<T> listen(
+    void onData(T event), {
+    Function onError,
+    void onDone(),
+    bool cancelOnError,
+  }) {
+    if (_controller == null) {
+      _controller = _buildController(streams, cancelOnError);
+    }
+
+    return _controller.stream.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  static StreamController<T> _buildController<T>(
+    Stream<Stream<T>> streams,
+    bool cancelOnError,
+  ) {
+    StreamController<T> controller;
+    StreamSubscription<Stream<T>> subscription;
+    StreamSubscription<T> otherSubscription;
+    bool leftClosed = false;
+    bool rightClosed = false;
+    bool hasMainEvent = false;
+
+    controller = new StreamController<T>(
+        sync: true,
+        onListen: () {
+          subscription = streams.listen(
+            (Stream<T> value) {
+              try {
+                otherSubscription?.cancel();
+
+                hasMainEvent = true;
+
+                otherSubscription = value.listen(
+                  controller.add,
+                  onError: controller.addError,
+                  onDone: () {
+                    rightClosed = true;
+
+                    if (leftClosed) controller.close();
+                  },
+                );
+              } catch (e, s) {
+                controller.addError(e, s);
+              }
+            },
+            onError: controller.addError,
+            onDone: () {
+              leftClosed = true;
+
+              if (rightClosed || !hasMainEvent) {
+                controller.close();
+              }
+            },
+            cancelOnError: cancelOnError,
+          );
+        },
+        onPause: ([Future<dynamic> resumeSignal]) {
+          subscription.pause(resumeSignal);
+          otherSubscription?.pause(resumeSignal);
+        },
+        onResume: () {
+          subscription.resume();
+          otherSubscription?.resume();
+        },
+        onCancel: () async {
+          await subscription.cancel();
+
+          if (hasMainEvent) await otherSubscription.cancel();
+        });
+
+    return controller;
+  }
+}

--- a/lib/src/subjects/subject.dart
+++ b/lib/src/subjects/subject.dart
@@ -14,11 +14,12 @@ import 'package:rxdart/src/observable.dart';
 /// complex example.
 abstract class Subject<T> extends Observable<T> implements StreamController<T> {
   final StreamController<T> controller;
-  
-  bool _isAddingStreamItems = false;
-  Observable<T> _observable;
 
-  Subject(StreamController<T> controller, Observable<T> observable): this._observable= observable, this.controller = controller,super(observable);
+  bool _isAddingStreamItems = false;
+
+  Subject(StreamController<T> controller, Observable<T> observable)
+      : this.controller = controller,
+        super(observable);
 
   @override
   StreamSink<T> get sink => new _StreamSinkWrapper<T>(this);
@@ -32,7 +33,7 @@ abstract class Subject<T> extends Observable<T> implements StreamController<T> {
   }
 
   @override
-  Observable<T> get stream  => _observable;
+  Observable<T> get stream => this;
 
   @override
   ControllerCallback get onPause =>

--- a/lib/streams.dart
+++ b/lib/streams.dart
@@ -11,6 +11,7 @@ export 'package:rxdart/src/streams/never.dart';
 export 'package:rxdart/src/streams/race.dart';
 export 'package:rxdart/src/streams/range.dart';
 export 'package:rxdart/src/streams/retry.dart';
+export 'package:rxdart/src/streams/switch_latest.dart';
 export 'package:rxdart/src/streams/timer.dart';
 export 'package:rxdart/src/streams/tween.dart';
 export 'package:rxdart/src/streams/zip.dart';

--- a/lib/subjects.dart
+++ b/lib/subjects.dart
@@ -1,5 +1,6 @@
 library rx_subjects;
 
+export 'package:rxdart/src/subjects/subject.dart';
 export 'package:rxdart/src/subjects/behavior_subject.dart';
 export 'package:rxdart/src/subjects/publish_subject.dart';
 export 'package:rxdart/src/subjects/replay_subject.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -22,6 +22,7 @@ import 'streams/race_test.dart' as race_test;
 import 'streams/range_test.dart' as range_test;
 import 'streams/retry_test.dart' as retry_test;
 import 'streams/stream_test.dart' as stream_test;
+import 'streams/switch_latest_test.dart' as switch_latest_test;
 import 'streams/timer_test.dart' as timer_test;
 import 'streams/tween_test.dart' as tween_test;
 import 'streams/zip_test.dart' as zip_test;
@@ -124,6 +125,7 @@ void main() {
   race_test.main();
   retry_test.main();
   stream_test.main();
+  switch_latest_test.main();
   zip_test.main();
 
   // StreamTransformers

--- a/test/streams/switch_latest_test.dart
+++ b/test/streams/switch_latest_test.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SwitchLatest', () {
+    test('emits all values from an emitted Stream', () {
+      expect(
+        new Observable<String>.switchLatest(
+          new Observable<Stream<String>>.just(
+            new Stream<String>.fromIterable(<String>['A', 'B', 'C']),
+          ),
+        ),
+        emitsInOrder(<dynamic>['A', 'B', 'C', emitsDone]),
+      );
+    });
+
+    test('only emits values from the latest emitted stream', () {
+      expect(
+        new Observable<String>.switchLatest(testObservable),
+        emits('C'),
+      );
+    });
+
+    test('emits errors from the higher order Stream to the listener', () {
+      expect(
+        new Observable<String>.switchLatest(
+          new Observable<Stream<String>>.error(new Exception()),
+        ),
+        emitsError(isException),
+      );
+    });
+
+    test('emits errors from the emitted Stream to the listener', () {
+      expect(
+        new Observable<String>.switchLatest(errorObservable),
+        emitsError(isException),
+      );
+    });
+
+    test('closes after the last event from the last emitted Stream', () {
+      expect(
+        new Observable<String>.switchLatest(testObservable),
+        emitsThrough(emitsDone),
+      );
+    });
+
+    test('closes if the higher order stream is empty', () {
+      expect(
+        new Observable<String>.switchLatest(
+          new Observable<Stream<String>>.empty(),
+        ),
+        emitsThrough(emitsDone),
+      );
+    });
+
+    test('is single subscription', () {
+      final SwitchLatestStream<String> stream =
+          new SwitchLatestStream<String>(testObservable);
+
+      expect(stream, emits('C'));
+      expect(() => stream.listen(null), throwsStateError);
+    });
+
+    test('can be paused and resumed', () {
+      // ignore: cancel_subscriptions
+      final StreamSubscription<String> subscription =
+          new Observable<String>.switchLatest(testObservable)
+              .listen(expectAsync1((String result) {
+        expect(result, 'C');
+      }));
+
+      subscription.pause();
+      subscription.resume();
+    });
+  });
+}
+
+Observable<Stream<String>> get testObservable =>
+    new Observable<Stream<String>>.fromIterable(<Stream<String>>[
+      new Observable<String>.timer('A', new Duration(seconds: 2)),
+      new Observable<String>.timer('B', new Duration(seconds: 1)),
+      new Observable<String>.just('C'),
+    ]);
+
+Observable<Stream<String>> get errorObservable =>
+    new Observable<Stream<String>>.fromIterable(<Stream<String>>[
+      new Observable<String>.timer('A', new Duration(seconds: 2)),
+      new Observable<String>.timer('B', new Duration(seconds: 1)),
+      new Observable<String>.error(new Exception()),
+    ]);


### PR DESCRIPTION
Listens to a Stream of Streams and only emits items from the last emitted Stream. Please see dartdoc comments for more details or the ReactiveX page: http://reactivex.io/documentation/operators/switch.html.

Note: This also performs a bit of clean-up: I've made the `stream` property on `Observable` private (should not be exposed to the end-user).

This allowed us to clean up the `Subject` implementation a bit as well, by returning `this` from the `get stream` method instead of a locally stored `_observable` variable.

