### PR TITLE
Add Errors and Stacktraces to RetryError class

### DIFF
--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -608,7 +608,8 @@ class Observable<T> extends Stream<T> {
   ///
   /// If the retry count is not specified, it retries indefinitely. If the retry
   /// count is met, but the Stream has not terminated successfully, a
-  /// [RetryError] will be thrown.
+  /// [RetryError] will be thrown. The RetryError will contain all of the Errors
+  /// and StackTraces that caused the failure.
   ///
   /// ### Example
   ///
@@ -1843,6 +1844,8 @@ class Observable<T> extends Stream<T> {
   Observable<T> repeat(int repeatCount) =>
       transform(new RepeatStreamTransformer<T>(repeatCount));
 
+  /// Deprecated. Please use [cast] instead.
+  ///
   /// Adapt this stream to be a `Stream<R>`.
   ///
   /// This stream is wrapped as a `Stream<R>` which checks at run-time that

--- a/test/streams/retry_test.dart
+++ b/test/streams/retry_test.dart
@@ -78,6 +78,24 @@ void main() {
             <Matcher>[emitsError(new isInstanceOf<RetryError>()), emitsDone]));
   });
 
+  test('RetryStream.error.capturesErrors', () async {
+    Stream<int> observableWithError =
+    new RetryStream<int>(_getRetryStream(3), 2);
+
+    await expectLater(
+        observableWithError,
+        emitsInOrder(<Matcher>[
+          emitsError(
+            predicate<RetryError>((RetryError a) {
+              return a.errors.length == 3 &&
+                  a.errors.every((ErrorAndStacktrace es) =>
+                  es.error != null && es.stacktrace != null);
+            }),
+          ),
+          emitsDone,
+        ]));
+  });
+
   test('RetryStream.pause.resume', () async {
     StreamSubscription<int> subscription;
     int retries = 3;


### PR DESCRIPTION
Fixes #148.

With this change, we accumulate all errors and stack traces that led to the final RetryError so consumers can use this information.