### PR TITLE
[WIP DO NOT MERGE] Fix bug with periodic timer in `bufferTime`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dev_dependencies:
   benchmark_harness: ">=1.0.0 <2.0.0"
   coverage: ^0.9.2
   stack_trace: "^1.9.2"
+  fake_async: ^1.0.0
 web:
   compiler:
     debug: dartdevc

--- a/test/transformers/buffer_time_test.dart
+++ b/test/transformers/buffer_time_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
@@ -167,5 +168,16 @@ void main() {
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
     }));
+  });
+
+  test('rx.Observable.bufferTime.stopsPeriodicTimer', () {
+    fakeAsync((FakeAsync fakeAsync) {
+      final PublishSubject<int> subject = new PublishSubject<int>();
+      subject.bufferTime(const Duration(milliseconds: 500)).listen((_) {});
+      fakeAsync.elapse(const Duration(seconds: 1));
+      subject.close();
+      fakeAsync.flushTimers(timeout: const Duration(seconds: 1));
+      expect(fakeAsync.periodicTimerCount, isZero);
+    });
   });
 }


### PR DESCRIPTION
After digging more into issue https://github.com/flutter/flutter/issues/17738, I _think_ there's a bug in `rxdart`'s `Observable.bufferTime` sampler.

I am out of my depth here, though. I've added a failing unit test, but I haven't been able to get to the bottom of the issue. There's [buffer_strategy.dart#L88](https://github.com/ReactiveX/rxdart/blob/master/lib/src/samplers/buffer_strategy.dart#L88) but then this seems to be cancelled when the sampler gets closed / canceled, which it does [here](https://github.com/ReactiveX/rxdart/blob/master/lib/src/transformers/sample.dart#L77).

It's possible that there needs to be a special case in `_OnStreamSampler` for Timer-based `onStream`s.

I would really like one of you folks to have a look before I try. But I'm ready to give it a go if you think I should.