### PR TITLE
Add flatMapIterable, remove retype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.18.0
+
+* Breaking Change: remove `retype` method, deprecated as part of Dart 2.
+* Add `flatMapIterable`
+
 ## 0.17.0
 
 * Breaking Change: `stream` property on Observable is now private.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ var myObservable = Observable.combineLatest3(
 - [doOnResume](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/doOnResume.html) / [DoStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/DoStreamTransformer-class.html)
 - [exhaustMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/exhaustMap.html) / [ExhaustMapStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/ExhaustMapStreamTransformer-class.html)
 - [flatMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/flatMap.html) / [FlatMapStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/FlatMapStreamTransformer-class.html)
+- [flatMapIterable](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/flatMapIterable.html)
 - [interval](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/interval.html) / [IntervalStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/IntervalStreamTransformer-class.html)
 - [materialize](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/materialize.html) / [MaterializeStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/MaterializeStreamTransformer-class.html)
 - [mergeWith](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/mergeWith.html)

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -1530,6 +1530,23 @@ class Observable<T> extends Stream<T> {
   Observable<S> flatMap<S>(Stream<S> mapper(T value)) =>
       transform(new FlatMapStreamTransformer<T, S>(mapper));
 
+  /// Converts each item into a new Stream. The Stream must return an
+  /// Iterable. Then, each item from the Iterable will be emitted one by one.
+  ///
+  /// Use case: you may have an API that returns a list of items, such as
+  /// a Stream<List<String>>. However, you might want to operate on the individual items
+  /// rather than the list itself. This is the job of `flatMapIterable`.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.range(1, 4)
+  ///       .flatMapIterable((i) =>
+  ///         new Observable.just([i])
+  ///       .listen(print); // prints 1, 2, 3, 4
+  Observable<S> flatMapIterable<S>(Stream<Iterable<S>> mapper(T value)) =>
+      transform(new FlatMapStreamTransformer<T, Iterable<S>>(mapper))
+          .expand((Iterable<S> iterable) => iterable);
+
   /// Deprecated: Please use [switchMap] instead.
   ///
   /// This is the old name of this method This Converts each emitted item into a new Stream using the given mapper

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -1914,17 +1914,6 @@ class Observable<T> extends Stream<T> {
   Observable<T> repeat(int repeatCount) =>
       transform(new RepeatStreamTransformer<T>(repeatCount));
 
-  /// Deprecated. Please use [cast] instead.
-  ///
-  /// Adapt this stream to be a `Stream<R>`.
-  ///
-  /// This stream is wrapped as a `Stream<R>` which checks at run-time that
-  /// each data event emitted by this stream is also an instance of [R].
-  @override
-  @deprecated
-  Observable<R> retype<R>() =>
-      new Observable<R>(_stream.retype<R>()); // ignore: deprecated_member_use
-
   /// Returns an Observable that, when the specified sample stream emits
   /// an item or completes, emits the most recently emitted item (if any)
   /// emitted by the source stream since the previous emission from

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rxdart
-version: 0.17.0
+version: 0.18.0
 authors:
 - Frank Pepermans <frank@igindo.com>
 - Brian Egan <brian@brianegan.com>

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -56,6 +56,7 @@ import 'transformers/exhaust_map_test.dart' as exhaust_map_test;
 import 'transformers/expand_test.dart' as expand_test;
 import 'transformers/first_test.dart' as first_test;
 import 'transformers/first_where_test.dart' as first_where_test;
+import 'transformers/flat_map_iterable_test.dart' as flat_map_iterable_test;
 import 'transformers/flat_map_latest_test.dart' as flat_map_latest_test;
 import 'transformers/flat_map_test.dart' as flat_map_test;
 import 'transformers/fold_test.dart' as fold_test;
@@ -74,7 +75,8 @@ import 'transformers/on_error_resume_next_test.dart'
     as on_error_resume_next_test;
 import 'transformers/on_error_return_test.dart' as on_error_resume_test;
 import 'transformers/on_error_return_test.dart' as on_error_return_test;
-import 'transformers/on_error_return_with_test.dart' as on_error_return_with_test;
+import 'transformers/on_error_return_with_test.dart'
+    as on_error_return_with_test;
 import 'transformers/reduce_test.dart' as reduce_test;
 import 'transformers/repeat_test.dart' as repeat_test;
 import 'transformers/sample_test.dart' as sample_test;
@@ -162,6 +164,7 @@ void main() {
   first_where_test.main();
   flat_map_latest_test.main();
   flat_map_test.main();
+  flat_map_iterable_test.main();
   fold_test.main();
   for_each_test.main();
   handle_error_test.main();

--- a/test/transformers/flat_map_iterable_test.dart
+++ b/test/transformers/flat_map_iterable_test.dart
@@ -1,0 +1,13 @@
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Observable.flatMapIterable', () {
+    test('transforms a Stream<Iterable<S>> into individual items', () {
+      expect(
+          Observable.range(1, 4).flatMapIterable(
+              (int i) => new Observable<List<int>>.just(<int>[i])),
+          emitsInOrder(<dynamic>[1, 2, 3, 4, emitsDone]));
+    });
+  });
+}


### PR DESCRIPTION
  - Removes retype to fix #160.
  - Adds `flatMapIterable` operator (a simple but useful combo of FlatMap + Expand)