### PR TITLE
Upgrade to Dart 2 proper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 # Speed up builds by using containerization.
 sudo: false
 dart:
-- 2.0.0-dev.58.0
+- 2.0.0-dev.69.1
 with_content_shell: false
 before_install:
   - export DISPLAY=:99.0

--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ In order to run the web examples, please follow these steps:
 
   1. Clone this repo and enter the directory
   2. Run `pub get`
-  3. Run `pub serve example/web`
-  4. Navigate to [http://localhost:8080](http://localhost:8080) in your browser
+  3. Run `pub run build_runner serve example`
+  4. Navigate to [http://localhost:8080/web/](http://localhost:8080/web/) in your browser
 
 ### Command Line Examples
 
@@ -189,7 +189,7 @@ In order to run the command line example, please follow these steps:
 
   1. Clone this repo and enter the directory
   2. Run `pub get`
-  3. Run `dart example/bin/fibonacci.dart 10`
+  3. Run `dart example/example.dart 10`
   
 ### Flutter Example
   

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,5 @@
+targets:
+  $default:
+    builders:
+      build_web_compilers|entrypoint:
+        generate_for: ['example/web/**']

--- a/example/web/dragdrop/dragdrop.html
+++ b/example/web/dragdrop/dragdrop.html
@@ -16,8 +16,6 @@
       Drag Me!
     </div>
 
-    <script type="application/dart" src="dragdrop.dart"></script>
-    <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    <script defer src="dragdrop.dart.js" type="application/javascript"></script>
   </body>
 </html>

--- a/example/web/konami/konamicode.html
+++ b/example/web/konami/konamicode.html
@@ -24,8 +24,6 @@
             <h1 id="result"></h1>
         </div>
     </div>
-    <script type="application/dart" src="konamicode.dart"></script>
-    <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    <script defer src="konamicode.dart.js"></script>
 </body>
 </html>

--- a/example/web/search_github/search_github.html
+++ b/example/web/search_github/search_github.html
@@ -4,8 +4,7 @@
         <meta charset="UTF-8">
         <title>RxDart -- Search Github</title>
 
-        <script defer src="search_github.dart" type="application/dart"></script>
-        <script defer src="packages/browser/dart.js"></script>
+        <script defer src="search_github.dart.js"></script>
     </head>
 
     <body>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,20 @@
 name: rxdart
-version: 0.18.1
+version: 0.18.2
 authors:
 - Frank Pepermans <frank@igindo.com>
 - Brian Egan <brian@brianegan.com>
-description: RxDart is an implementation of the popular reactiveX api for asynchronous programming, leveraging the native Dart Streams api.
+description: >
+  RxDart is an implementation of the popular reactiveX api for asynchronous
+  programming, leveraging the native Dart Streams api.
 homepage: https://github.com/ReactiveX/rxdart
+
 environment:
   sdk: '>=2.0.0-dev <3.0.0'
+
 dev_dependencies:
-  browser: ^0.10.0+2
-  test: 1.0.0
-  benchmark_harness: ">=1.0.0 <2.0.0"
-  coverage: 0.11.0
+  test: ^1.0.0
+  benchmark_harness: ^1.0.0
+  coverage: '>=0.11.0 <0.13.0'
   stack_trace: ^1.9.2
-web:
-  compiler:
-    debug: dartdevc
+  build_runner: ^0.9.0
+  build_web_compilers: ^0.4.0


### PR DESCRIPTION
This gets rid of `pkg:browser`, loosens constraints on `pkg:test` and `pkg:coverage`.

This ensures that `_PUB_TEST_SDK_VERSION=2.0.0 pub upgrade` succeeds (explained [here](https://groups.google.com/a/dartlang.org/forum/#!msg/announce/dX6BJgYYmBE/ycPh1TTYAAAJ)). This wasn't possible just a few hours ago, when the `benchmark_harness` dependency was still in Dart 1 land.

Web examples are now precompiled via the recommended process. No `<script type="application/dart" src="dragdrop.dart">` is necessary anymore.