### PR TITLE
fix doOnError documentation.

### DIFF
--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -1484,7 +1484,7 @@ class Observable<T> extends Stream<T> {
   /// ### Example
   ///
   ///     new Observable.error(new Exception())
-  ///       .doOnError(() => print("oh no"))
+  ///       .doOnError((error, stacktrace) => print("oh no"))
   ///       .listen(null); // prints "Oh no"
   Observable<T> doOnError(Function onError) =>
       transform(new DoStreamTransformer<T>(onError: onError));


### PR DESCRIPTION
the function that is called is provided an error and stacktrace objects.
If these are omitted by the developer as they follow the documentation,
we will end up with a NoSuchMethod unhandled exception and their doOnError
will never get called. This documentation should help the developer
understand how to implement this functionality correctly.