### PR TITLE
Fixes #177: Chained flatMaps not calling `onDone` with single values

### DIFF
--- a/lib/src/transformers/flat_map.dart
+++ b/lib/src/transformers/flat_map.dart
@@ -64,7 +64,7 @@ class FlatMapStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
                 },
                 onError: controller.addError,
                 onDone: () {
-                  if (!hasMainEvent)
+                  if (!hasMainEvent || streams.isEmpty)
                     controller.close();
                   else
                     closeAfterNextEvent = true;

--- a/test/transformers/flat_map_test.dart
+++ b/test/transformers/flat_map_test.dart
@@ -108,4 +108,13 @@ void main() {
     subscription.pause();
     subscription.resume();
   });
+
+  test('rx.Observable.flatMap.chains', () {
+    expect(
+      Observable<int>.just(1)
+          .flatMap((int _) => Observable<int>.just(2))
+          .flatMap((int _) => Observable<int>.just(3)),
+      emitsInOrder(<dynamic>[3, emitsDone]),
+    );
+  });
 }


### PR DESCRIPTION
OnDone was not being properly called with `flatMap` chains that contain only a single item.