### PR TITLE
Add CompositeSubscription container to manage multiple subscriptions at once

### DIFF
--- a/lib/rxdart.dart
+++ b/lib/rxdart.dart
@@ -9,3 +9,4 @@ export 'package:rxdart/src/observables/value_observable.dart';
 export 'package:rxdart/streams.dart';
 export 'package:rxdart/subjects.dart';
 export 'package:rxdart/transformers.dart';
+export 'package:rxdart/src/utils/composite_subscription.dart';

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -1,0 +1,68 @@
+
+import 'dart:async';
+
+/**
+ * Acts as a container for multiple subscriptions that can be canceled at once 
+ * e.g. view subcriptions in Flutter that need to be canceled on view disposal
+ * 
+ * Can be cleared or disposed. When disposed, cannot be used again.
+ * ### Example
+ *      // init your subscriptions
+ *      composite.add(observable1.listen(listener1))
+ *            ..add(observable2.listen(listener1))
+ *            ..add(observable3.listen(listener1));
+ * 
+ *      // clear them all at once
+ *      composite.clear();
+ */
+class CompositeSubscription {
+
+  bool _isDisposed = false;
+
+  final List<StreamSubscription> _subscriptionsList = new List<StreamSubscription>();
+
+  /**
+   * Checks if this composite is disposed. If it is, the composite can't be used again
+   * and will throw an error if you try to add more subscriptions to it.
+   */
+  bool get isDisposed => _isDisposed;
+
+  /**
+   * Adds new subscription to this composite.
+   * 
+   * Throws an exception if this composite was disposed
+   */
+  CompositeSubscription add(StreamSubscription subscription) {
+    if (isDisposed) throw("This composite was disposed, try to use new instance instead");
+    _subscriptionsList.add(subscription);
+    return this;
+  }
+
+  /**
+   * Removes subscription from this composite.
+   */
+  CompositeSubscription remove(StreamSubscription subscription) {
+    _subscriptionsList.remove(subscription);
+    return this;
+  }
+  
+  /**
+   * Cancels all subscriptions added to this composite. Clears subscriptions collection.
+   * 
+   * This composite can be reused after calling this method.
+   */
+  void clear() {
+    _subscriptionsList.forEach((subscription) => subscription.cancel());
+    _subscriptionsList.clear();
+  }
+
+  /**
+   * Cancels all subscriptions added to this composite. Disposes this.
+   * 
+   * This composite can't be reused after calling this method.
+   */
+  void dispose() {
+    clear();
+    _isDisposed = true;
+  }
+}

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -1,4 +1,3 @@
-
 import 'dart:async';
 
 /**
@@ -16,10 +15,10 @@ import 'dart:async';
  *      composite.clear();
  */
 class CompositeSubscription {
-
   bool _isDisposed = false;
 
-  final List<StreamSubscription> _subscriptionsList = new List<StreamSubscription>();
+  final List<StreamSubscription> _subscriptionsList =
+      new List<StreamSubscription>();
 
   /**
    * Checks if this composite is disposed. If it is, the composite can't be used again
@@ -33,7 +32,8 @@ class CompositeSubscription {
    * Throws an exception if this composite was disposed
    */
   CompositeSubscription add(StreamSubscription subscription) {
-    if (isDisposed) throw("This composite was disposed, try to use new instance instead");
+    if (isDisposed)
+      throw ("This composite was disposed, try to use new instance instead");
     _subscriptionsList.add(subscription);
     return this;
   }
@@ -45,7 +45,7 @@ class CompositeSubscription {
     _subscriptionsList.remove(subscription);
     return this;
   }
-  
+
   /**
    * Cancels all subscriptions added to this composite. Clears subscriptions collection.
    * 

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -15,25 +15,25 @@ import 'dart:async';
 class CompositeSubscription {
   bool _isDisposed = false;
 
-  final List<StreamSubscription> _subscriptionsList =
-      new List<StreamSubscription>();
+  final List<StreamSubscription<dynamic>> _subscriptionsList =
+      new List<StreamSubscription<dynamic>>();
 
   /// Checks if this composite is disposed. If it is, the composite can't be used again
   /// and will throw an error if you try to add more subscriptions to it.
   bool get isDisposed => _isDisposed;
 
-  CompositeSubscription add(StreamSubscription subscription) {
   /// Adds new subscription to this composite.
   /// 
   /// Throws an exception if this composite was disposed
+  CompositeSubscription add(StreamSubscription<dynamic> subscription) {
     if (isDisposed)
       throw ("This composite was disposed, try to use new instance instead");
     _subscriptionsList.add(subscription);
     return this;
   }
 
-  CompositeSubscription remove(StreamSubscription subscription) {
   /// Removes subscription from this composite.
+  CompositeSubscription remove(StreamSubscription<dynamic> subscription) {
     _subscriptionsList.remove(subscription);
     return this;
   }
@@ -42,7 +42,7 @@ class CompositeSubscription {
   /// 
   /// This composite can be reused after calling this method.
   void clear() {
-    _subscriptionsList.forEach((subscription) => subscription.cancel());
+    _subscriptionsList.forEach((StreamSubscription<dynamic> subscription) => subscription.cancel());
     _subscriptionsList.clear();
   }
 

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -32,8 +32,9 @@ class CompositeSubscription {
     return this;
   }
 
-  /// Removes subscription from this composite.
+  /// Cancels subscripiton and removes it from this composite.
   CompositeSubscription remove(StreamSubscription<dynamic> subscription) {
+    subscription.cancel();
     _subscriptionsList.remove(subscription);
     return this;
   }

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -25,18 +25,17 @@ class CompositeSubscription {
   /// Adds new subscription to this composite.
   /// 
   /// Throws an exception if this composite was disposed
-  CompositeSubscription add(StreamSubscription<dynamic> subscription) {
+  StreamSubscription<T> add<T>(StreamSubscription<T> subscription) {
     if (isDisposed)
       throw ("This composite was disposed, try to use new instance instead");
     _subscriptionsList.add(subscription);
-    return this;
+    return subscription;
   }
 
   /// Cancels subscripiton and removes it from this composite.
-  CompositeSubscription remove(StreamSubscription<dynamic> subscription) {
+  void remove(StreamSubscription<dynamic> subscription) {
     subscription.cancel();
     _subscriptionsList.remove(subscription);
-    return this;
   }
 
   /// Cancels all subscriptions added to this composite. Clears subscriptions collection.

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -1,66 +1,54 @@
 import 'dart:async';
 
-/**
- * Acts as a container for multiple subscriptions that can be canceled at once 
- * e.g. view subcriptions in Flutter that need to be canceled on view disposal
- * 
- * Can be cleared or disposed. When disposed, cannot be used again.
- * ### Example
- *      // init your subscriptions
- *      composite.add(observable1.listen(listener1))
- *            ..add(observable2.listen(listener1))
- *            ..add(observable3.listen(listener1));
- * 
- *      // clear them all at once
- *      composite.clear();
- */
+/// Acts as a container for multiple subscriptions that can be canceled at once
+/// e.g. view subcriptions in Flutter that need to be canceled on view disposal
+/// 
+/// Can be cleared or disposed. When disposed, cannot be used again.
+/// ### Example
+/// // init your subscriptions
+/// composite.add(observable1.listen(listener1))
+/// ..add(observable2.listen(listener1))
+/// ..add(observable3.listen(listener1));
+/// 
+/// // clear them all at once
+/// composite.clear();
 class CompositeSubscription {
   bool _isDisposed = false;
 
   final List<StreamSubscription> _subscriptionsList =
       new List<StreamSubscription>();
 
-  /**
-   * Checks if this composite is disposed. If it is, the composite can't be used again
-   * and will throw an error if you try to add more subscriptions to it.
-   */
+  /// Checks if this composite is disposed. If it is, the composite can't be used again
+  /// and will throw an error if you try to add more subscriptions to it.
   bool get isDisposed => _isDisposed;
 
-  /**
-   * Adds new subscription to this composite.
-   * 
-   * Throws an exception if this composite was disposed
-   */
   CompositeSubscription add(StreamSubscription subscription) {
+  /// Adds new subscription to this composite.
+  /// 
+  /// Throws an exception if this composite was disposed
     if (isDisposed)
       throw ("This composite was disposed, try to use new instance instead");
     _subscriptionsList.add(subscription);
     return this;
   }
 
-  /**
-   * Removes subscription from this composite.
-   */
   CompositeSubscription remove(StreamSubscription subscription) {
+  /// Removes subscription from this composite.
     _subscriptionsList.remove(subscription);
     return this;
   }
 
-  /**
-   * Cancels all subscriptions added to this composite. Clears subscriptions collection.
-   * 
-   * This composite can be reused after calling this method.
-   */
+  /// Cancels all subscriptions added to this composite. Clears subscriptions collection.
+  /// 
+  /// This composite can be reused after calling this method.
   void clear() {
     _subscriptionsList.forEach((subscription) => subscription.cancel());
     _subscriptionsList.clear();
   }
 
-  /**
-   * Cancels all subscriptions added to this composite. Disposes this.
-   * 
-   * This composite can't be reused after calling this method.
-   */
+  /// Cancels all subscriptions added to this composite. Disposes this.
+  /// 
+  /// This composite can't be reused after calling this method.
   void dispose() {
     clear();
     _isDisposed = true;

--- a/test/observables/composite_subscription_test.dart
+++ b/test/observables/composite_subscription_test.dart
@@ -40,35 +40,17 @@ void main() {
 
       expect(() => composite.add(observable.listen(null)), throwsA(anything));
     });
-    test('should not cancel subscription on clear if it is removed from composite', () {
+    test('should cancel subscription on if it is removed from composite', () {
       const int value = 1;
       final Observable<int> observable =
           Observable<int>.fromIterable(<int>[value]).shareValue();
       final CompositeSubscription composite = CompositeSubscription();
+      final StreamSubscription<int> subscription = observable.listen(null);
 
-      final Func1<Null, int> listener = expectAsync1((int a) {
-        expect(a, value);
-      }, count: 1);
-      final StreamSubscription<int> subscription = observable.listen(listener);
+      composite.add(subscription);
+      composite.remove(subscription);
 
-      composite.add(subscription)..remove(subscription);
-
-      composite.clear();
-    });
-    test('should not cancel subscription on dispose if it is removed from composite', () {
-      const int value = 1;
-      final Observable<int> observable =
-          Observable<int>.fromIterable(<int>[value]).shareValue();
-      final CompositeSubscription composite = CompositeSubscription();
-
-      final Func1<Null, int> listener = expectAsync1((int a) {
-        expect(a, value);
-      }, count: 1);
-      final StreamSubscription<int> subscription = observable.listen(listener);
-
-      composite.add(subscription)..remove(subscription);
-
-      composite.dispose();
+      expect(observable, neverEmits(anything));
     });
   });
 }

--- a/test/observables/composite_subscription_test.dart
+++ b/test/observables/composite_subscription_test.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CompositeSubscription', () {
+    test('should cancel all subscriptions on clear()', () {
+      final Observable<int> observable =
+          Observable<int>.fromIterable(<int>[1, 2, 3]).shareValue();
+      final CompositeSubscription composite = CompositeSubscription();
+
+      composite.add(observable.listen(null))
+              ..add(observable.listen(null))
+              ..add(observable.listen(null));
+
+      composite.clear();
+
+      expect(observable, neverEmits(anything));
+    });
+    test('should cancel all subscriptions on dispose()', () {
+      final Observable<int> observable =
+          Observable<int>.fromIterable(<int>[1, 2, 3]).shareValue();
+      final CompositeSubscription composite = CompositeSubscription();
+
+      composite.add(observable.listen(null))
+              ..add(observable.listen(null))
+              ..add(observable.listen(null));
+
+      composite.dispose();
+
+      expect(observable, neverEmits(anything));
+    });
+    test('should throw exception if trying to add subscription to disposed composite', () {
+      final Observable<int> observable =
+          Observable<int>.fromIterable(<int>[1, 2, 3]).shareValue();
+      final CompositeSubscription composite = CompositeSubscription();
+
+      composite.dispose();
+
+      expect(() => composite.add(observable.listen(null)), throws);
+    });
+    test('should not cancel subscription on clear if it is removed from composite', () {
+      const int value = 1;
+      final Observable<int> observable =
+          Observable<int>.fromIterable(<int>[value]).shareValue();
+      final CompositeSubscription composite = CompositeSubscription();
+      
+      final listener = expectAsync1((int a){ expect(a, value);}, count: 1);
+      final StreamSubscription<int> subscription = observable.listen(listener);
+
+      composite.add(subscription)
+              ..remove(subscription);
+
+      composite.clear();
+    });
+    test('should not cancel subscription on dispose if it is removed from composite', () {
+      const int value = 1;
+      final Observable<int> observable =
+          Observable<int>.fromIterable(<int>[value]).shareValue();
+      final CompositeSubscription composite = CompositeSubscription();
+      
+      final listener = expectAsync1((int a){ expect(a, value);}, count: 1);
+      final StreamSubscription<int> subscription = observable.listen(listener);
+
+      composite.add(subscription)
+              ..remove(subscription);
+
+      composite.dispose();
+    });
+  });
+}

--- a/test/observables/composite_subscription_test.dart
+++ b/test/observables/composite_subscription_test.dart
@@ -38,7 +38,7 @@ void main() {
 
       composite.dispose();
 
-      expect(() => composite.add(observable.listen(null)), throws);
+      expect(() => composite.add(observable.listen(null)), throwsA(anything));
     });
     test('should not cancel subscription on clear if it is removed from composite', () {
       const int value = 1;
@@ -46,7 +46,7 @@ void main() {
           Observable<int>.fromIterable(<int>[value]).shareValue();
       final CompositeSubscription composite = CompositeSubscription();
 
-      final listener = expectAsync1((int a) {
+      final Func1<Null, int> listener = expectAsync1((int a) {
         expect(a, value);
       }, count: 1);
       final StreamSubscription<int> subscription = observable.listen(listener);
@@ -61,7 +61,7 @@ void main() {
           Observable<int>.fromIterable(<int>[value]).shareValue();
       final CompositeSubscription composite = CompositeSubscription();
 
-      final listener = expectAsync1((int a) {
+      final Func1<Null, int> listener = expectAsync1((int a) {
         expect(a, value);
       }, count: 1);
       final StreamSubscription<int> subscription = observable.listen(listener);

--- a/test/observables/composite_subscription_test.dart
+++ b/test/observables/composite_subscription_test.dart
@@ -10,7 +10,8 @@ void main() {
           Observable<int>.fromIterable(<int>[1, 2, 3]).shareValue();
       final CompositeSubscription composite = CompositeSubscription();
 
-      composite.add(observable.listen(null))
+      composite
+        ..add(observable.listen(null))
         ..add(observable.listen(null))
         ..add(observable.listen(null));
 
@@ -23,7 +24,8 @@ void main() {
           Observable<int>.fromIterable(<int>[1, 2, 3]).shareValue();
       final CompositeSubscription composite = CompositeSubscription();
 
-      composite.add(observable.listen(null))
+      composite
+        ..add(observable.listen(null))
         ..add(observable.listen(null))
         ..add(observable.listen(null));
 

--- a/test/observables/composite_subscription_test.dart
+++ b/test/observables/composite_subscription_test.dart
@@ -11,8 +11,8 @@ void main() {
       final CompositeSubscription composite = CompositeSubscription();
 
       composite.add(observable.listen(null))
-              ..add(observable.listen(null))
-              ..add(observable.listen(null));
+        ..add(observable.listen(null))
+        ..add(observable.listen(null));
 
       composite.clear();
 
@@ -24,8 +24,8 @@ void main() {
       final CompositeSubscription composite = CompositeSubscription();
 
       composite.add(observable.listen(null))
-              ..add(observable.listen(null))
-              ..add(observable.listen(null));
+        ..add(observable.listen(null))
+        ..add(observable.listen(null));
 
       composite.dispose();
 
@@ -45,12 +45,13 @@ void main() {
       final Observable<int> observable =
           Observable<int>.fromIterable(<int>[value]).shareValue();
       final CompositeSubscription composite = CompositeSubscription();
-      
-      final listener = expectAsync1((int a){ expect(a, value);}, count: 1);
+
+      final listener = expectAsync1((int a) {
+        expect(a, value);
+      }, count: 1);
       final StreamSubscription<int> subscription = observable.listen(listener);
 
-      composite.add(subscription)
-              ..remove(subscription);
+      composite.add(subscription)..remove(subscription);
 
       composite.clear();
     });
@@ -59,12 +60,13 @@ void main() {
       final Observable<int> observable =
           Observable<int>.fromIterable(<int>[value]).shareValue();
       final CompositeSubscription composite = CompositeSubscription();
-      
-      final listener = expectAsync1((int a){ expect(a, value);}, count: 1);
+
+      final listener = expectAsync1((int a) {
+        expect(a, value);
+      }, count: 1);
       final StreamSubscription<int> subscription = observable.listen(listener);
 
-      composite.add(subscription)
-              ..remove(subscription);
+      composite.add(subscription)..remove(subscription);
 
       composite.dispose();
     });

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -4,6 +4,7 @@ import 'futures/as_observable_future_test.dart' as as_observable_future_test;
 import 'futures/stream_max_test.dart' as stream_max_test;
 import 'futures/stream_min_test.dart' as stream_min_test;
 import 'futures/wrapped_future_test.dart' as wrapped_future_test;
+import 'observables/composite_subscription_test.dart' as composite_subscription_test;
 import 'observables/publish_connectable_observable_test.dart'
     as publish_connectable_observable_test;
 import 'observables/replay_connectable_observable_test.dart'
@@ -238,4 +239,5 @@ void main() {
   value_connectable_observable_test.main();
   replay_connectable_observable_test.main();
   publish_connectable_observable_test.main();
+  composite_subscription_test.main();
 }


### PR DESCRIPTION
This PR is intended to tackle the issue #183.

It adds `CompositeSubscription`, which is (quoting the issue)
>Basically a bag for multiple subscription (with add and remove methods) that can be unsubscribed at once: http://reactivex.io/RxJava/javadoc/io/reactivex/disposables/CompositeDisposable.html
```dart
final s = new CompositeSubscription();
s.add(firstStream.listen(...));
s.add(secondStream.listen(...));
//...
s.cancel(); // cancels all
```
>It's very useful when you listen to multiple streams and want to dispose them all at once (e.g. when a widget in Flutter is disposed).

I've had a positive experience with composites in Android dev with RxJava, so I'm glad to bring this experience to dart users. But I have no experience with `Serial` variant and don't really know any usecases for that