### PR TITLE
Distinguish between seeded- and not-seeded BehaviorSubject

### DIFF
--- a/lib/src/observables/connectable_observable.dart
+++ b/lib/src/observables/connectable_observable.dart
@@ -97,9 +97,20 @@ class ValueConnectableObservable<T> extends ConnectableObservable<T>
 
   ValueConnectableObservable._(this._source, this._subject) : super(_subject);
 
-  factory ValueConnectableObservable(Stream<T> source, {T seedValue}) =>
+  factory ValueConnectableObservable(Stream<T> source) =>
       ValueConnectableObservable<T>._(
-          source, BehaviorSubject<T>(seedValue: seedValue));
+        source,
+        BehaviorSubject<T>(),
+      );
+
+  factory ValueConnectableObservable.seeded(
+    Stream<T> source,
+    T seedValue,
+  ) =>
+      ValueConnectableObservable<T>._(
+        source,
+        BehaviorSubject<T>.seeded(seedValue),
+      );
 
   @override
   ValueObservable<T> autoConnect({
@@ -144,6 +155,9 @@ class ValueConnectableObservable<T> extends ConnectableObservable<T>
 
   @override
   T get value => _subject.value;
+
+  @override
+  bool get hasValue => _subject.hasValue;
 }
 
 /// A [ConnectableObservable] that converts a single-subscription Stream into

--- a/lib/src/observables/value_observable.dart
+++ b/lib/src/observables/value_observable.dart
@@ -2,5 +2,9 @@ import 'package:rxdart/src/observables/observable.dart';
 
 /// An [Observable] that provides synchronous access to the last emitted item
 abstract class ValueObservable<T> implements Observable<T> {
+  /// Last emitted value, or null if there has been no emission yet
+  /// See [hasValue]
   T get value;
+
+  bool get hasValue;
 }

--- a/test/observables/value_connectable_observable_test.dart
+++ b/test/observables/value_connectable_observable_test.dart
@@ -86,6 +86,34 @@ void main() {
       expect(observable, emits(3));
     });
 
+    test('replays the seeded item', () async {
+      final observable = new ValueConnectableObservable.seeded(
+              StreamController<int>().stream, 3)
+          .autoConnect();
+
+      expect(observable, emitsInOrder(const <int>[3]));
+      expect(observable, emitsInOrder(const <int>[3]));
+      expect(observable, emitsInOrder(const <int>[3]));
+
+      await Future<Null>.delayed(Duration(milliseconds: 200));
+
+      expect(observable, emits(3));
+    });
+
+    test('replays the seeded null item', () async {
+      final observable = new ValueConnectableObservable.seeded(
+              StreamController<int>().stream, null)
+          .autoConnect();
+
+      expect(observable, emitsInOrder(const <int>[null]));
+      expect(observable, emitsInOrder(const <int>[null]));
+      expect(observable, emitsInOrder(const <int>[null]));
+
+      await Future<Null>.delayed(Duration(milliseconds: 200));
+
+      expect(observable, emits(null));
+    });
+
     test('can multicast observables', () async {
       final observable = Observable.fromIterable(const [1, 2, 3]).shareValue();
 
@@ -96,7 +124,7 @@ void main() {
 
     test('transform Observables with initial value', () async {
       final observable =
-          Observable.fromIterable(const [1, 2, 3]).shareValue(seedValue: 0);
+          Observable.fromIterable(const [1, 2, 3]).shareValueSeeded(0);
 
       expect(observable.value, 0);
       expect(observable, emitsInOrder(const <int>[0, 1, 2, 3]));

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -20,6 +20,20 @@ void main() {
       await expectLater(subject.stream, emits(3));
     });
 
+    test('emits the most recently emitted null item to every subscriber',
+        () async {
+      // ignore: close_sinks
+      final subject = new BehaviorSubject<int>();
+
+      subject.add(1);
+      subject.add(2);
+      subject.add(null);
+
+      await expectLater(subject.stream, emits(isNull));
+      await expectLater(subject.stream, emits(isNull));
+      await expectLater(subject.stream, emits(isNull));
+    });
+
     test(
         'emits the most recently emitted item to every subscriber that subscribe to the subject directly',
         () async {
@@ -88,20 +102,55 @@ void main() {
       await expectLater(subject.value, 3);
     });
 
+    test('can synchronously get the latest null value', () async {
+      // ignore: close_sinks
+      final subject = new BehaviorSubject<int>();
+
+      subject.add(1);
+      subject.add(2);
+      subject.add(null);
+
+      await expectLater(subject.value, isNull);
+    });
+
     test('emits the seed item if no new items have been emitted', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>(seedValue: 1);
+      final subject = new BehaviorSubject<int>.seeded(1);
 
       await expectLater(subject.stream, emits(1));
       await expectLater(subject.stream, emits(1));
       await expectLater(subject.stream, emits(1));
     });
 
+    test('emits the null seed item if no new items have been emitted',
+        () async {
+      // ignore: close_sinks
+      final subject = new BehaviorSubject<int>.seeded(null);
+
+      await expectLater(subject.stream, emits(isNull));
+      await expectLater(subject.stream, emits(isNull));
+      await expectLater(subject.stream, emits(isNull));
+    });
+
     test('can synchronously get the initial value', () {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>(seedValue: 1);
+      final subject = new BehaviorSubject<int>.seeded(1);
 
       expect(subject.value, 1);
+    });
+
+    test('can synchronously get the initial null value', () {
+      // ignore: close_sinks
+      final subject = new BehaviorSubject<int>.seeded(null);
+
+      expect(subject.value, null);
+    });
+
+    test('initial value is null when no value has been emitted', () {
+      // ignore: close_sinks
+      final subject = new BehaviorSubject<int>();
+
+      expect(subject.value, isNull);
     });
 
     test('emits done event to listeners when the subject is closed', () async {
@@ -297,7 +346,7 @@ void main() {
 
     test('can be listened to multiple times', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject(seedValue: 1);
+      final subject = new BehaviorSubject.seeded(1);
       final stream = subject.stream;
 
       await expectLater(stream, emits(1));
@@ -335,6 +384,36 @@ void main() {
 
       expect(subject.isBroadcast, isTrue);
       expect(stream.isBroadcast, isTrue);
+    });
+
+    test('hasValue returns false for an empty subject', () {
+      // ignore: close_sinks
+      final subject = new BehaviorSubject<int>();
+
+      expect(subject.hasValue, isFalse);
+    });
+
+    test('hasValue returns true for a seeded subject with non-null seed', () {
+      // ignore: close_sinks
+      final subject = new BehaviorSubject<int>.seeded(1);
+
+      expect(subject.hasValue, isTrue);
+    });
+
+    test('hasValue returns true for a seeded subject with null seed', () {
+      // ignore: close_sinks
+      final subject = new BehaviorSubject<int>.seeded(null);
+
+      expect(subject.hasValue, isTrue);
+    });
+
+    test('hasValue returns true for an unseeded subject after an emission', () {
+      // ignore: close_sinks
+      final subject = new BehaviorSubject<int>();
+
+      subject.add(1);
+
+      expect(subject.hasValue, isTrue);
     });
   });
 }


### PR DESCRIPTION
An attempt to fix #170 

As you can see, this prompted some more changes, specifically in `ValueConnectableObservable` and `Observable` itself. I wasn't quite sure how to handle them, so I'm looking forward to feedback.

Making this PR convinced me that `null` values should be straight away forbidden everywhere ;)

I haven't updated dartdoc or documentation yet, as I'm not sure the PR will be accepted. If the changes look good please let me know, and I'll push an update with documentation updated