### PR TITLE
chore(example): Update mockito to 3.0.0

### DIFF
--- a/example/flutter/github_search/pubspec.yaml
+++ b/example/flutter/github_search/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   http: "^0.11.3+16"
 
 dev_dependencies:
-  mockito: 2.2.3
+  mockito: 3.0.0
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Without this change, getting the packages for this example causes the following:

```
[github_search] flutter packages get
Running "flutter packages get" in github_search...              
The current Dart SDK version is 2.1.0-dev.5.0.flutter-a2eb050044.

Because github_search depends on mockito >=0.8.1 <3.0.0-beta+3 which requires SDK version >=1.0.0 <2.0.0-∞, version solving failed.

pub get failed (1)
exit code 1

```