### PR TITLE
update the stream class documentation link for dart2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ In order to run the flutter example, you must have Flutter installed. For instal
   6. Run `flutter run`
 
 ## Notable References
-- [Documentation on the Dart Stream class](https://api.dartlang.org/stable/1.21.1/dart-async/Stream-class.html)
+- [Documentation on the Dart Stream class](https://api.dartlang.org/stable/2.0.0/dart-async/Stream-class.html)
 - [Tutorial on working with Streams in Dart](https://www.dartlang.org/tutorials/language/streams)
 - [ReactiveX (Rx)](http://reactivex.io/)
 


### PR DESCRIPTION
## pull request type -- Docs
> Update the stream class documentation link for dart2.0
- Previous:
**https://api.dartlang.org/stable/1.21.1/dart-async/Stream-class.html**
- Now
**https://api.dartlang.org/stable/2.0.0/dart-async/Stream-class.html**
#### I think Dart2.0 doc is more useful for RxDart user, so I create the pull request.
Thanks for All RxDart  contributor, hope it can be powerful state manage kit for flutter.
