### PR TITLE
Fixes #207: switchIfEmpty not calling onDone

### DIFF
--- a/lib/src/transformers/switch_if_empty.dart
+++ b/lib/src/transformers/switch_if_empty.dart
@@ -62,13 +62,15 @@ class SwitchIfEmptyStreamTransformer<T> extends StreamTransformerBase<T, T> {
                 },
                 onError: controller.addError,
                 onDone: () {
-                  if (!hasEvent) {
-                    switchSubscription = fallbackStream.listen((T value) {
-                      controller.add(value);
-                    },
-                        onError: controller.addError,
-                        onDone: onDone,
-                        cancelOnError: cancelOnError);
+                  if (hasEvent) {
+                    controller.close();
+                  } else {
+                    switchSubscription = fallbackStream.listen(
+                      controller.add,
+                      onError: controller.addError,
+                      onDone: onDone,
+                      cancelOnError: cancelOnError,
+                    );
                   }
                 },
                 cancelOnError: cancelOnError);

--- a/test/transformers/switch_if_empty_test.dart
+++ b/test/transformers/switch_if_empty_test.dart
@@ -5,11 +5,17 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.switchIfEmpty.whenEmpty', () async {
-    new Observable(new Stream<bool>.empty())
-        .switchIfEmpty(new Observable.just(true))
-        .listen(expectAsync1((result) {
-          expect(result, true);
-        }, count: 1));
+    expect(
+      Observable<int>.empty().switchIfEmpty(Observable.just(1)),
+      emitsInOrder(<dynamic>[1, emitsDone]),
+    );
+  });
+
+  test('rx.Observable.initial.completes', () async {
+    expect(
+      Observable.just(99).switchIfEmpty(Observable.just(1)),
+      emitsInOrder(<dynamic>[99, emitsDone]),
+    );
   });
 
   test('rx.Observable.switchIfEmpty.reusable', () async {


### PR DESCRIPTION
SwitchIfEmpty was not properly closing the underlying Stream controller onDone if the original Stream was not empty.