### PR TITLE
CombineLatest & Zip Refactor

### DIFF
--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -764,18 +764,63 @@ class Observable<T> extends Stream<T> {
   ///     .listen(print); // prints "Hi Friend"
   static Observable<T> zip2<A, B, T>(
           Stream<A> streamA, Stream<B> streamB, T zipper(A a, B b)) =>
-      new Observable<T>(
-          new ZipStream<T, A, B, Null, Null, Null, Null, Null, Null, Null>(
-              <Stream<dynamic>>[streamA, streamB],
-              (A a, B b,
-                      [Null c,
-                      Null d,
-                      Null e,
-                      Null f,
-                      Null g,
-                      Null h,
-                      Null i]) =>
-                  zipper(a, b)));
+      Observable<T>(ZipStream.zip2(streamA, streamB, zipper));
+
+  /// Merges the iterable streams into one observable sequence using the given
+  /// zipper function whenever all of the observable sequences have produced
+  /// an element at a corresponding index.
+  ///
+  /// It applies this function in strict sequence, so the first item emitted by
+  /// the new Observable will be the result of the function applied to the first
+  /// item emitted by Observable #1 and the first item emitted by Observable #2;
+  /// the second item emitted by the new zip-Observable will be the result of
+  /// the function applied to the second item emitted by Observable #1 and the
+  /// second item emitted by Observable #2; and so forth. It will only emit as
+  /// many items as the number of items emitted by the source Observable that
+  /// emits the fewest items.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#zip)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.zip(
+  ///       [
+  ///         Observable.just("Hi "),
+  ///         Observable.fromIterable(["Friend", "Dropped"]),
+  ///       ],
+  ///       (values) => values.first + values.last
+  ///     )
+  ///     .listen(print); // prints "Hi Friend"
+  static Observable<R> zip<T, R>(
+          Iterable<Stream<T>> streams, R zipper(List<T> values)) =>
+      Observable<R>(ZipStream(streams, zipper));
+
+  /// Merges the iterable streams into one observable sequence using the given
+  /// zipper function whenever all of the observable sequences have produced
+  /// an element at a corresponding index.
+  ///
+  /// It applies this function in strict sequence, so the first item emitted by
+  /// the new Observable will be the result of the function applied to the first
+  /// item emitted by Observable #1 and the first item emitted by Observable #2;
+  /// the second item emitted by the new zip-Observable will be the result of
+  /// the function applied to the second item emitted by Observable #1 and the
+  /// second item emitted by Observable #2; and so forth. It will only emit as
+  /// many items as the number of items emitted by the source Observable that
+  /// emits the fewest items.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#zip)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.zipList(
+  ///       [
+  ///         Observable.just("Hi "),
+  ///         Observable.fromIterable(["Friend", "Dropped"]),
+  ///       ],
+  ///     )
+  ///     .listen(print); // prints ['Hi ', 'Friend']
+  static Observable<List<T>> zipList<T>(Iterable<Stream<T>> streams) =>
+      Observable<List<T>>(ZipStream.list(streams));
 
   /// Merges the specified streams into one observable sequence using the given
   /// zipper function whenever all of the observable sequences have produced
@@ -802,12 +847,7 @@ class Observable<T> extends Stream<T> {
   ///     .listen(print); //prints "abc"
   static Observable<T> zip3<A, B, C, T>(Stream<A> streamA, Stream<B> streamB,
           Stream<C> streamC, T zipper(A a, B b, C c)) =>
-      new Observable<T>(
-          new ZipStream<T, A, B, C, Null, Null, Null, Null, Null, Null>(
-              <Stream<dynamic>>[streamA, streamB, streamC],
-              (A a, B b,
-                      [C c, Null d, Null e, Null f, Null g, Null h, Null i]) =>
-                  zipper(a, b, c)));
+      Observable<T>(ZipStream.zip3(streamA, streamB, streamC, zipper));
 
   /// Merges the specified streams into one observable sequence using the given
   /// zipper function whenever all of the observable sequences have produced
@@ -835,11 +875,7 @@ class Observable<T> extends Stream<T> {
   ///     .listen(print); //prints "abcd"
   static Observable<T> zip4<A, B, C, D, T>(Stream<A> streamA, Stream<B> streamB,
           Stream<C> streamC, Stream<D> streamD, T zipper(A a, B b, C c, D d)) =>
-      new Observable<T>(
-          new ZipStream<T, A, B, C, D, Null, Null, Null, Null, Null>(
-              <Stream<dynamic>>[streamA, streamB, streamC, streamD],
-              (A a, B b, [C c, D d, Null e, Null f, Null g, Null h, Null i]) =>
-                  zipper(a, b, c, d)));
+      Observable<T>(ZipStream.zip4(streamA, streamB, streamC, streamD, zipper));
 
   /// Merges the specified streams into one observable sequence using the given
   /// zipper function whenever all of the observable sequences have produced
@@ -873,10 +909,8 @@ class Observable<T> extends Stream<T> {
           Stream<D> streamD,
           Stream<E> streamE,
           T zipper(A a, B b, C c, D d, E e)) =>
-      new Observable<T>(new ZipStream<T, A, B, C, D, E, Null, Null, Null, Null>(
-          <Stream<dynamic>>[streamA, streamB, streamC, streamD, streamE],
-          (A a, B b, [C c, D d, E e, Null f, Null g, Null h, Null i]) =>
-              zipper(a, b, c, d, e)));
+      Observable<T>(
+          ZipStream.zip5(streamA, streamB, streamC, streamD, streamE, zipper));
 
   /// Merges the specified streams into one observable sequence using the given
   /// zipper function whenever all of the observable sequences have produced
@@ -912,17 +946,15 @@ class Observable<T> extends Stream<T> {
           Stream<E> streamE,
           Stream<F> streamF,
           T zipper(A a, B b, C c, D d, E e, F f)) =>
-      new Observable<T>(new ZipStream<T, A, B, C, D, E, F, Null, Null, Null>(
-          <Stream<dynamic>>[
-            streamA,
-            streamB,
-            streamC,
-            streamD,
-            streamE,
-            streamF
-          ],
-          (A a, B b, [C c, D d, E e, F f, Null g, Null h, Null i]) =>
-              zipper(a, b, c, d, e, f)));
+      Observable<T>(ZipStream.zip6(
+        streamA,
+        streamB,
+        streamC,
+        streamD,
+        streamE,
+        streamF,
+        zipper,
+      ));
 
   /// Merges the specified streams into one observable sequence using the given
   /// zipper function whenever all of the observable sequences have produced
@@ -960,18 +992,16 @@ class Observable<T> extends Stream<T> {
           Stream<F> streamF,
           Stream<G> streamG,
           T zipper(A a, B b, C c, D d, E e, F f, G g)) =>
-      new Observable<T>(new ZipStream<T, A, B, C, D, E, F, G, Null, Null>(
-          <Stream<dynamic>>[
-            streamA,
-            streamB,
-            streamC,
-            streamD,
-            streamE,
-            streamF,
-            streamG
-          ],
-          (A a, B b, [C c, D d, E e, F f, G g, Null h, Null i]) =>
-              zipper(a, b, c, d, e, f, g)));
+      Observable<T>(ZipStream.zip7(
+        streamA,
+        streamB,
+        streamC,
+        streamD,
+        streamE,
+        streamF,
+        streamG,
+        zipper,
+      ));
 
   /// Merges the specified streams into one observable sequence using the given
   /// zipper function whenever all of the observable sequences have produced
@@ -1011,19 +1041,17 @@ class Observable<T> extends Stream<T> {
           Stream<G> streamG,
           Stream<H> streamH,
           T zipper(A a, B b, C c, D d, E e, F f, G g, H h)) =>
-      new Observable<T>(new ZipStream<T, A, B, C, D, E, F, G, H, Null>(
-          <Stream<dynamic>>[
-            streamA,
-            streamB,
-            streamC,
-            streamD,
-            streamE,
-            streamF,
-            streamG,
-            streamH
-          ],
-          (A a, B b, [C c, D d, E e, F f, G g, H h, Null i]) =>
-              zipper(a, b, c, d, e, f, g, h)));
+      Observable<T>(ZipStream.zip8(
+        streamA,
+        streamB,
+        streamC,
+        streamD,
+        streamE,
+        streamF,
+        streamG,
+        streamH,
+        zipper,
+      ));
 
   /// Merges the specified streams into one observable sequence using the given
   /// zipper function whenever all of the observable sequences have produced
@@ -1065,20 +1093,18 @@ class Observable<T> extends Stream<T> {
           Stream<H> streamH,
           Stream<I> streamI,
           T zipper(A a, B b, C c, D d, E e, F f, G g, H h, I i)) =>
-      new Observable<T>(new ZipStream<T, A, B, C, D, E, F, G, H, I>(
-          <Stream<dynamic>>[
-            streamA,
-            streamB,
-            streamC,
-            streamD,
-            streamE,
-            streamF,
-            streamG,
-            streamH,
-            streamI
-          ],
-          (A a, B b, [C c, D d, E e, F f, G g, H h, I i]) =>
-              zipper(a, b, c, d, e, f, g, h, i)));
+      Observable<T>(ZipStream.zip9(
+        streamA,
+        streamB,
+        streamC,
+        streamD,
+        streamE,
+        streamF,
+        streamG,
+        streamH,
+        streamI,
+        zipper,
+      ));
 
   /// Returns a multi-subscription stream that produces the same events as this.
   ///
@@ -2390,20 +2416,7 @@ class Observable<T> extends Stream<T> {
   ///         .zipWith(new Observable.just(2), (one, two) => one + two)
   ///         .listen(print); // prints 3
   Observable<R> zipWith<S, R>(Stream<S> other, R zipper(T t, S s)) =>
-      new Observable<R>(
-          new ZipStream<R, T, S, Null, Null, Null, Null, Null, Null, Null>(
-              <Stream<dynamic>>[_stream, other],
-              (
-                      [T a,
-                      S b,
-                      Null c,
-                      Null d,
-                      Null e,
-                      Null f,
-                      Null g,
-                      Null h,
-                      Null i]) =>
-                  zipper(a, b)));
+      Observable<R>(ZipStream.zip2(_stream, other, zipper));
 
   /// Convert the current Observable into a [ConnectableObservable]
   /// that can be listened to multiple times. It will not begin emitting items

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -102,6 +102,46 @@ class Observable<T> extends Stream<T> {
   AsObservableFuture<bool> any(bool test(T element)) =>
       new AsObservableFuture<bool>(_stream.any(test));
 
+  /// Merges the given Streams into one Observable that emits a List of the
+  /// values emitted by the source Stream. This is helpful when you need to
+  /// combine a dynamic number of Streams.
+  ///
+  /// The Observable will not emit any lists of values until all of the source
+  /// streams have emitted at least one value.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.combineLatestList([
+  ///       Observable.just(1),
+  ///       Observable.fromIterable([0, 1, 2]),
+  ///     ])
+  ///     .listen(print); // prints [1, 0], [1, 1], [1, 2]
+  static Observable<R> combineLatest<T, R>(
+          Iterable<Stream<T>> streams, R combiner(List<T> values)) =>
+      new Observable<R>(CombineLatestStream<T, R>(streams, combiner));
+
+  /// Merges the given Streams into one Observable that emits a List of the
+  /// values emitted by the source Stream. This is helpful when you need to
+  /// combine a dynamic number of Streams.
+  ///
+  /// The Observable will not emit any lists of values until all of the source
+  /// streams have emitted at least one value.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.combineLatestList([
+  ///       Observable.just(1),
+  ///       Observable.fromIterable([0, 1, 2]),
+  ///     ])
+  ///     .listen(print); // prints [1, 0], [1, 1], [1, 2]
+  static Observable<List<T>> combineLatestList<T>(
+          Iterable<Stream<T>> streams) =>
+      new Observable<List<T>>(CombineLatestStream.list<T>(streams));
+
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an
   /// item.
@@ -119,13 +159,9 @@ class Observable<T> extends Stream<T> {
   ///       (a, b) => a + b)
   ///     .listen(print); //prints 1, 2, 3
   static Observable<T> combineLatest2<A, B, T>(
-          Stream<A> streamOne, Stream<B> streamTwo, T combiner(A a, B b)) =>
-      new Observable<T>(new CombineLatestStream<T, A, B, Null, Null, Null, Null,
-              Null, Null, Null>(
-          <Stream<dynamic>>[streamOne, streamTwo],
-          (A a, B b,
-                  [Null c, Null d, Null e, Null f, Null g, Null h, Null i]) =>
-              combiner(a, b)));
+          Stream<A> streamA, Stream<B> streamB, T combiner(A a, B b)) =>
+      new Observable<T>(
+          CombineLatestStream.combine2(streamA, streamB, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an
@@ -144,16 +180,10 @@ class Observable<T> extends Stream<T> {
   ///       new Observable.fromIterable(["c", "c"]),
   ///       (a, b, c) => a + b + c)
   ///     .listen(print); //prints "abc", "abc"
-  static Observable<T> combineLatest3<A, B, C, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          T combiner(A a, B b, C c)) =>
-      new Observable<T>(new CombineLatestStream<T, A, B, C, Null, Null, Null,
-              Null, Null, Null>(
-          <Stream<dynamic>>[streamOne, streamTwo, streamThree],
-          (A a, B b, [C c, Null d, Null e, Null f, Null g, Null h, Null i]) =>
-              combiner(a, b, c)));
+  static Observable<T> combineLatest3<A, B, C, T>(Stream<A> streamA,
+          Stream<B> streamB, Stream<C> streamC, T combiner(A a, B b, C c)) =>
+      new Observable<T>(
+          CombineLatestStream.combine3(streamA, streamB, streamC, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an
@@ -174,16 +204,13 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d) => a + b + c + d)
   ///     .listen(print); //prints "abcd", "abcd"
   static Observable<T> combineLatest4<A, B, C, D, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
           T combiner(A a, B b, C c, D d)) =>
-      new Observable<T>(
-          new CombineLatestStream<T, A, B, C, D, Null, Null, Null, Null, Null>(
-              <Stream<dynamic>>[streamOne, streamTwo, streamThree, streamFour],
-              (A a, B b, [C c, D d, Null e, Null f, Null g, Null h, Null i]) =>
-                  combiner(a, b, c, d)));
+      new Observable<T>(CombineLatestStream.combine4(
+          streamA, streamB, streamC, streamD, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an
@@ -205,23 +232,14 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d, e) => a + b + c + d + e)
   ///     .listen(print); //prints "abcde", "abcde"
   static Observable<T> combineLatest5<A, B, C, D, E, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          Stream<E> streamFive,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
           T combiner(A a, B b, C c, D d, E e)) =>
-      new Observable<T>(
-          new CombineLatestStream<T, A, B, C, D, E, Null, Null, Null, Null>(
-              <Stream<dynamic>>[
-            streamOne,
-            streamTwo,
-            streamThree,
-            streamFour,
-            streamFive
-          ],
-              (A a, B b, [C c, D d, E e, Null f, Null g, Null h, Null i]) =>
-                  combiner(a, b, c, d, e)));
+      new Observable<T>(CombineLatestStream.combine5(
+          streamA, streamB, streamC, streamD, streamE, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an
@@ -244,25 +262,15 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d, e, f) => a + b + c + d + e + f)
   ///     .listen(print); //prints "abcdef", "abcdef"
   static Observable<T> combineLatest6<A, B, C, D, E, F, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          Stream<E> streamFive,
-          Stream<F> streamSix,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
           T combiner(A a, B b, C c, D d, E e, F f)) =>
-      new Observable<T>(
-          new CombineLatestStream<T, A, B, C, D, E, F, Null, Null, Null>(
-              <Stream<dynamic>>[
-            streamOne,
-            streamTwo,
-            streamThree,
-            streamFour,
-            streamFive,
-            streamSix
-          ],
-              (A a, B b, [C c, D d, E e, F f, Null g, Null h, Null i]) =>
-                  combiner(a, b, c, d, e, f)));
+      new Observable<T>(CombineLatestStream.combine6(
+          streamA, streamB, streamC, streamD, streamE, streamF, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an
@@ -286,27 +294,16 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d, e, f, g) => a + b + c + d + e + f + g)
   ///     .listen(print); //prints "abcdefg", "abcdefg"
   static Observable<T> combineLatest7<A, B, C, D, E, F, G, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          Stream<E> streamFive,
-          Stream<F> streamSix,
-          Stream<G> streamSeven,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
+          Stream<G> streamG,
           T combiner(A a, B b, C c, D d, E e, F f, G g)) =>
-      new Observable<T>(
-          new CombineLatestStream<T, A, B, C, D, E, F, G, Null, Null>(
-              <Stream<dynamic>>[
-            streamOne,
-            streamTwo,
-            streamThree,
-            streamFour,
-            streamFive,
-            streamSix,
-            streamSeven
-          ],
-              (A a, B b, [C c, D d, E e, F f, G g, Null h, Null i]) =>
-                  combiner(a, b, c, d, e, f, g)));
+      new Observable<T>(CombineLatestStream.combine7(streamA, streamB, streamC,
+          streamD, streamE, streamF, streamG, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an
@@ -331,29 +328,28 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h)
   ///     .listen(print); //prints "abcdefgh", "abcdefgh"
   static Observable<T> combineLatest8<A, B, C, D, E, F, G, H, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          Stream<E> streamFive,
-          Stream<F> streamSix,
-          Stream<G> streamSeven,
-          Stream<H> streamEight,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
+          Stream<G> streamG,
+          Stream<H> streamH,
           T combiner(A a, B b, C c, D d, E e, F f, G g, H h)) =>
       new Observable<T>(
-          new CombineLatestStream<T, A, B, C, D, E, F, G, H, Null>(
-              <Stream<dynamic>>[
-            streamOne,
-            streamTwo,
-            streamThree,
-            streamFour,
-            streamFive,
-            streamSix,
-            streamSeven,
-            streamEight
-          ],
-              (A a, B b, [C c, D d, E e, F f, G g, H h, Null i]) =>
-                  combiner(a, b, c, d, e, f, g, h)));
+        CombineLatestStream.combine8(
+          streamA,
+          streamB,
+          streamC,
+          streamD,
+          streamE,
+          streamF,
+          streamG,
+          streamH,
+          combiner,
+        ),
+      );
 
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an
@@ -379,30 +375,30 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h + i)
   ///     .listen(print); //prints "abcdefghi", "abcdefghi"
   static Observable<T> combineLatest9<A, B, C, D, E, F, G, H, I, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          Stream<E> streamFive,
-          Stream<F> streamSix,
-          Stream<G> streamSeven,
-          Stream<H> streamEight,
-          Stream<I> streamNine,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
+          Stream<G> streamG,
+          Stream<H> streamH,
+          Stream<I> streamI,
           T combiner(A a, B b, C c, D d, E e, F f, G g, H h, I i)) =>
-      new Observable<T>(new CombineLatestStream<T, A, B, C, D, E, F, G, H, I>(
-          <Stream<dynamic>>[
-            streamOne,
-            streamTwo,
-            streamThree,
-            streamFour,
-            streamFive,
-            streamSix,
-            streamSeven,
-            streamEight,
-            streamNine
-          ],
-          (A a, B b, [C c, D d, E e, F f, G g, H h, I i]) =>
-              combiner(a, b, c, d, e, f, g, h, i)));
+      new Observable<T>(
+        CombineLatestStream.combine9(
+          streamA,
+          streamB,
+          streamC,
+          streamD,
+          streamE,
+          streamF,
+          streamG,
+          streamH,
+          streamI,
+          combiner,
+        ),
+      );
 
   /// Concatenates all of the specified stream sequences, as long as the
   /// previous stream sequence terminated successfully.
@@ -767,10 +763,10 @@ class Observable<T> extends Stream<T> {
   ///       (a, b) => a + b)
   ///     .listen(print); // prints "Hi Friend"
   static Observable<T> zip2<A, B, T>(
-          Stream<A> streamOne, Stream<B> streamTwo, T zipper(A a, B b)) =>
+          Stream<A> streamA, Stream<B> streamB, T zipper(A a, B b)) =>
       new Observable<T>(
           new ZipStream<T, A, B, Null, Null, Null, Null, Null, Null, Null>(
-              <Stream<dynamic>>[streamOne, streamTwo],
+              <Stream<dynamic>>[streamA, streamB],
               (A a, B b,
                       [Null c,
                       Null d,
@@ -804,14 +800,11 @@ class Observable<T> extends Stream<T> {
   ///       new Observable.fromIterable(["c", "dropped"]),
   ///       (a, b, c) => a + b + c)
   ///     .listen(print); //prints "abc"
-  static Observable<T> zip3<A, B, C, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          T zipper(A a, B b, C c)) =>
+  static Observable<T> zip3<A, B, C, T>(Stream<A> streamA, Stream<B> streamB,
+          Stream<C> streamC, T zipper(A a, B b, C c)) =>
       new Observable<T>(
           new ZipStream<T, A, B, C, Null, Null, Null, Null, Null, Null>(
-              <Stream<dynamic>>[streamOne, streamTwo, streamThree],
+              <Stream<dynamic>>[streamA, streamB, streamC],
               (A a, B b,
                       [C c, Null d, Null e, Null f, Null g, Null h, Null i]) =>
                   zipper(a, b, c)));
@@ -840,15 +833,11 @@ class Observable<T> extends Stream<T> {
   ///       new Observable.fromIterable(["d", "dropped"]),
   ///       (a, b, c, d) => a + b + c + d)
   ///     .listen(print); //prints "abcd"
-  static Observable<T> zip4<A, B, C, D, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          T zipper(A a, B b, C c, D d)) =>
+  static Observable<T> zip4<A, B, C, D, T>(Stream<A> streamA, Stream<B> streamB,
+          Stream<C> streamC, Stream<D> streamD, T zipper(A a, B b, C c, D d)) =>
       new Observable<T>(
           new ZipStream<T, A, B, C, D, Null, Null, Null, Null, Null>(
-              <Stream<dynamic>>[streamOne, streamTwo, streamThree, streamFour],
+              <Stream<dynamic>>[streamA, streamB, streamC, streamD],
               (A a, B b, [C c, D d, Null e, Null f, Null g, Null h, Null i]) =>
                   zipper(a, b, c, d)));
 
@@ -878,20 +867,14 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d, e) => a + b + c + d + e)
   ///     .listen(print); //prints "abcde"
   static Observable<T> zip5<A, B, C, D, E, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          Stream<E> streamFive,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
           T zipper(A a, B b, C c, D d, E e)) =>
       new Observable<T>(new ZipStream<T, A, B, C, D, E, Null, Null, Null, Null>(
-          <Stream<dynamic>>[
-            streamOne,
-            streamTwo,
-            streamThree,
-            streamFour,
-            streamFive
-          ],
+          <Stream<dynamic>>[streamA, streamB, streamC, streamD, streamE],
           (A a, B b, [C c, D d, E e, Null f, Null g, Null h, Null i]) =>
               zipper(a, b, c, d, e)));
 
@@ -922,21 +905,21 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d, e, f) => a + b + c + d + e + f)
   ///     .listen(print); //prints "abcdef"
   static Observable<T> zip6<A, B, C, D, E, F, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          Stream<E> streamFive,
-          Stream<F> streamSix,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
           T zipper(A a, B b, C c, D d, E e, F f)) =>
       new Observable<T>(new ZipStream<T, A, B, C, D, E, F, Null, Null, Null>(
           <Stream<dynamic>>[
-            streamOne,
-            streamTwo,
-            streamThree,
-            streamFour,
-            streamFive,
-            streamSix
+            streamA,
+            streamB,
+            streamC,
+            streamD,
+            streamE,
+            streamF
           ],
           (A a, B b, [C c, D d, E e, F f, Null g, Null h, Null i]) =>
               zipper(a, b, c, d, e, f)));
@@ -969,23 +952,23 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d, e, f, g) => a + b + c + d + e + f + g)
   ///     .listen(print); //prints "abcdefg"
   static Observable<T> zip7<A, B, C, D, E, F, G, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          Stream<E> streamFive,
-          Stream<F> streamSix,
-          Stream<G> streamSeven,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
+          Stream<G> streamG,
           T zipper(A a, B b, C c, D d, E e, F f, G g)) =>
       new Observable<T>(new ZipStream<T, A, B, C, D, E, F, G, Null, Null>(
           <Stream<dynamic>>[
-            streamOne,
-            streamTwo,
-            streamThree,
-            streamFour,
-            streamFive,
-            streamSix,
-            streamSeven
+            streamA,
+            streamB,
+            streamC,
+            streamD,
+            streamE,
+            streamF,
+            streamG
           ],
           (A a, B b, [C c, D d, E e, F f, G g, Null h, Null i]) =>
               zipper(a, b, c, d, e, f, g)));
@@ -1019,25 +1002,25 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h)
   ///     .listen(print); //prints "abcdefgh"
   static Observable<T> zip8<A, B, C, D, E, F, G, H, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          Stream<E> streamFive,
-          Stream<F> streamSix,
-          Stream<G> streamSeven,
-          Stream<H> streamEight,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
+          Stream<G> streamG,
+          Stream<H> streamH,
           T zipper(A a, B b, C c, D d, E e, F f, G g, H h)) =>
       new Observable<T>(new ZipStream<T, A, B, C, D, E, F, G, H, Null>(
           <Stream<dynamic>>[
-            streamOne,
-            streamTwo,
-            streamThree,
-            streamFour,
-            streamFive,
-            streamSix,
-            streamSeven,
-            streamEight
+            streamA,
+            streamB,
+            streamC,
+            streamD,
+            streamE,
+            streamF,
+            streamG,
+            streamH
           ],
           (A a, B b, [C c, D d, E e, F f, G g, H h, Null i]) =>
               zipper(a, b, c, d, e, f, g, h)));
@@ -1072,27 +1055,27 @@ class Observable<T> extends Stream<T> {
   ///       (a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h + i)
   ///     .listen(print); //prints "abcdefghi"
   static Observable<T> zip9<A, B, C, D, E, F, G, H, I, T>(
-          Stream<A> streamOne,
-          Stream<B> streamTwo,
-          Stream<C> streamThree,
-          Stream<D> streamFour,
-          Stream<E> streamFive,
-          Stream<F> streamSix,
-          Stream<G> streamSeven,
-          Stream<H> streamEight,
-          Stream<I> streamNine,
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
+          Stream<G> streamG,
+          Stream<H> streamH,
+          Stream<I> streamI,
           T zipper(A a, B b, C c, D d, E e, F f, G g, H h, I i)) =>
       new Observable<T>(new ZipStream<T, A, B, C, D, E, F, G, H, I>(
           <Stream<dynamic>>[
-            streamOne,
-            streamTwo,
-            streamThree,
-            streamFour,
-            streamFive,
-            streamSix,
-            streamSeven,
-            streamEight,
-            streamNine
+            streamA,
+            streamB,
+            streamC,
+            streamD,
+            streamE,
+            streamF,
+            streamG,
+            streamH,
+            streamI
           ],
           (A a, B b, [C c, D d, E e, F f, G g, H h, I i]) =>
               zipper(a, b, c, d, e, f, g, h, i)));

--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -9,163 +9,306 @@ import 'dart:async';
 ///
 /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
 ///
-/// ### Example
+/// ### Basic Example
 ///
-///     new CombineLatestStream([
-///       new Stream.fromIterable(["a"]),
-///       new Stream.fromIterable(["b"]),
-///       new Stream.fromIterable(["c", "c"])],
-///       (a, b, c) => a + b + c)
-///     .listen(print); //prints "abc", "abc"
-class CombineLatestStream<T, A, B, C, D, E, F, G, H, I> extends Stream<T> {
-  final StreamController<T> controller;
+/// This constructor takes in an `Iterable<Stream<T>>` and outputs a
+/// `Stream<Iterable<T>>` whenever any of the values change from the source
+/// stream. This is useful with a dynamic number of source streams!
+///
+///     CombineLatestStream.list<String>([
+///       Stream.fromIterable(["a"]),
+///       Stream.fromIterable(["b"]),
+///       Stream.fromIterable(["C", "D"])])
+///     .listen(print); //prints ['a', 'b', 'C'], ['a', 'b', 'D']
+///
+/// ### Example with combiner
+///
+/// If you wish to combine the list of values into a new object before you
+///
+///     CombineLatestStream(
+///       [
+///         Stream.fromIterable(["a"]),
+///         Stream.fromIterable(["b"]),
+///         Stream.fromIterable(["C", "D"])
+///       ],
+///       (values) => values.last
+///     )
+///     .listen(print); //prints 'C', 'D'
+///
+/// ### Example with a specific number of Streams
+///
+/// If you wish to combine a specific number of Streams together with proper
+/// types information for the value of each Stream, use the
+/// [combine2] - [combine9] operators.
+///
+///     CombineLatestStream.combine2(
+///       Stream.fromIterable(1),
+///       Stream.fromIterable([2, 3]),
+///       (a, b) => a + b,
+///     )
+///     .listen(print); // prints 3, 4
+class CombineLatestStream<T, R> extends StreamView<R> {
+  CombineLatestStream(
+    Iterable<Stream<T>> streams,
+    R combiner(List<T> values),
+  )   : assert(streams != null && streams.every((s) => s != null),
+            'streams cannot be null'),
+        assert(streams.length > 1, 'provide at least 2 streams'),
+        assert(combiner != null, 'must provide a combiner function'),
+        super(_buildController(streams, combiner).stream);
 
-  CombineLatestStream(Iterable<Stream<dynamic>> streams,
-      T combiner(A a, B b, [C c, D d, E e, F f, G g, H h, I i]))
-      : controller = _buildController(streams, combiner);
-
-  @override
-  StreamSubscription<T> listen(void onData(T event),
-      {Function onError, void onDone(), bool cancelOnError}) {
-    return controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  static CombineLatestStream<T, List<T>> list<T>(
+    Iterable<Stream<T>> streams,
+  ) {
+    return CombineLatestStream<T, List<T>>(
+      streams,
+      (List<T> values) => values,
+    );
   }
 
-  static StreamController<T> _buildController<T, A, B, C, D, E, F, G, H, I>(
-      Iterable<Stream<dynamic>> streams,
-      T combiner(A a, B b, [C c, D d, E e, F f, G g, H h, I i])) {
-    if (streams == null) {
-      throw new ArgumentError('streams cannot be null');
-    } else if (streams.isEmpty) {
-      throw new ArgumentError('provide at least 1 stream');
-    } else if (combiner == null) {
-      throw new ArgumentError('combiner cannot be null');
-    }
+  static CombineLatestStream<dynamic, R> combine2<A, B, R>(
+    Stream<A> streamOne,
+    Stream<B> streamTwo,
+    R combiner(A a, B b),
+  ) {
+    return CombineLatestStream<dynamic, R>(
+      [streamOne, streamTwo],
+      (List<dynamic> values) => combiner(values[0] as A, values[1] as B),
+    );
+  }
 
-    final subscriptions = new List<StreamSubscription<dynamic>>(streams.length);
-    StreamController<T> controller;
+  static CombineLatestStream<dynamic, R> combine3<A, B, C, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    R combiner(A a, B b, C c),
+  ) {
+    return CombineLatestStream<dynamic, R>(
+      [streamA, streamB, streamC],
+      (List<dynamic> values) {
+        return combiner(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+        );
+      },
+    );
+  }
 
-    controller = new StreamController<T>(
-        sync: true,
-        onListen: () {
-          final values = new List<dynamic>(streams.length);
-          final triggered = new List.generate(streams.length, (_) => false);
-          final completedStatus =
-              new List.generate(streams.length, (_) => false);
-          var allStreamsHaveEvents = false;
+  static CombineLatestStream<dynamic, R> combine4<A, B, C, D, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    R combiner(A a, B b, C c, D d),
+  ) {
+    return CombineLatestStream<dynamic, R>(
+      [streamA, streamB, streamC, streamD],
+      (List<dynamic> values) {
+        return combiner(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+        );
+      },
+    );
+  }
 
-          for (var i = 0, len = streams.length; i < len; i++) {
-            var stream = streams.elementAt(i);
+  static CombineLatestStream<dynamic, R> combine5<A, B, C, D, E, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    R combiner(A a, B b, C c, D d, E e),
+  ) {
+    return CombineLatestStream<dynamic, R>(
+      [streamA, streamB, streamC, streamD, streamE],
+      (List<dynamic> values) {
+        return combiner(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+        );
+      },
+    );
+  }
 
-            subscriptions[i] = stream.listen(
-                (dynamic value) {
-                  values[i] = value;
-                  triggered[i] = true;
+  static CombineLatestStream<dynamic, R> combine6<A, B, C, D, E, F, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    R combiner(A a, B b, C c, D d, E e, F f),
+  ) {
+    return CombineLatestStream<dynamic, R>(
+      [streamA, streamB, streamC, streamD, streamE, streamF],
+      (List<dynamic> values) {
+        return combiner(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+        );
+      },
+    );
+  }
 
-                  if (!allStreamsHaveEvents)
-                    allStreamsHaveEvents = triggered.reduce((a, b) => a && b);
+  static CombineLatestStream<dynamic, R> combine7<A, B, C, D, E, F, G, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    Stream<G> streamG,
+    R combiner(A a, B b, C c, D d, E e, F f, G g),
+  ) {
+    return CombineLatestStream<dynamic, R>(
+      [streamA, streamB, streamC, streamD, streamE, streamF, streamG],
+      (List<dynamic> values) {
+        return combiner(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+          values[6] as G,
+        );
+      },
+    );
+  }
 
-                  if (allStreamsHaveEvents)
-                    updateWithValues(combiner, values, controller);
-                },
-                onError: controller.addError,
-                onDone: () {
-                  completedStatus[i] = true;
+  static CombineLatestStream<dynamic, R> combine8<A, B, C, D, E, F, G, H, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    Stream<G> streamG,
+    Stream<H> streamH,
+    R combiner(A a, B b, C c, D d, E e, F f, G g, H h),
+  ) {
+    return CombineLatestStream<dynamic, R>(
+      [streamA, streamB, streamC, streamD, streamE, streamF, streamG, streamH],
+      (List<dynamic> values) {
+        return combiner(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+          values[6] as G,
+          values[7] as H,
+        );
+      },
+    );
+  }
 
-                  if (completedStatus.reduce((a, b) => a && b))
-                    controller.close();
-                });
-          }
-        },
-        onPause: ([Future<dynamic> resumeSignal]) => subscriptions.forEach(
-            (StreamSubscription<dynamic> subscription) =>
-                subscription.pause(resumeSignal)),
-        onResume: () => subscriptions.forEach(
-            (StreamSubscription<dynamic> subscription) =>
-                subscription.resume()),
-        onCancel: () => Future.wait<dynamic>(subscriptions
-            .map((StreamSubscription<dynamic> subscription) =>
-                subscription.cancel())
-            .where((Future<dynamic> cancelFuture) => cancelFuture != null)));
+  static CombineLatestStream<dynamic, R> combine9<A, B, C, D, E, F, G, H, I, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    Stream<G> streamG,
+    Stream<H> streamH,
+    Stream<I> streamI,
+    R combiner(A a, B b, C c, D d, E e, F f, G g, H h, I i),
+  ) {
+    return CombineLatestStream<dynamic, R>(
+      [
+        streamA,
+        streamB,
+        streamC,
+        streamD,
+        streamE,
+        streamF,
+        streamG,
+        streamH,
+        streamI
+      ],
+      (List<dynamic> values) {
+        return combiner(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+          values[6] as G,
+          values[7] as H,
+          values[8] as I,
+        );
+      },
+    );
+  }
+
+  static StreamController<R> _buildController<T, R>(
+    Iterable<Stream<T>> streams,
+    R combiner(List<T> values),
+  ) {
+    final subscriptions = List<StreamSubscription<dynamic>>(streams.length);
+    StreamController<R> controller;
+
+    controller = StreamController<R>(
+      sync: true,
+      onListen: () {
+        final values = List<T>(streams.length);
+        final triggered = List.generate(streams.length, (_) => false);
+        final completedStatus = List.generate(streams.length, (_) => false);
+        var allStreamsHaveEvents = false;
+
+        for (var i = 0, len = streams.length; i < len; i++) {
+          final stream = streams.elementAt(i);
+
+          subscriptions[i] = stream.listen(
+            (T value) {
+              values[i] = value;
+              triggered[i] = true;
+
+              if (!allStreamsHaveEvents)
+                allStreamsHaveEvents = triggered.every((t) => t);
+
+              if (allStreamsHaveEvents) {
+                try {
+                  controller.add(combiner(values.toList()));
+                } catch (e, s) {
+                  controller.addError(e, s);
+                }
+              }
+            },
+            onError: controller.addError,
+            onDone: () {
+              completedStatus[i] = true;
+
+              if (completedStatus.every((c) => c)) controller.close();
+            },
+          );
+        }
+      },
+      onPause: ([Future<dynamic> resumeSignal]) => subscriptions.forEach(
+          (StreamSubscription<dynamic> subscription) =>
+              subscription.pause(resumeSignal)),
+      onResume: () => subscriptions.forEach(
+          (StreamSubscription<dynamic> subscription) => subscription.resume()),
+      onCancel: () => Future.wait<dynamic>(subscriptions
+          .map((StreamSubscription<dynamic> subscription) =>
+              subscription.cancel())
+          .where((Future<dynamic> cancelFuture) => cancelFuture != null)),
+    );
 
     return controller;
-  }
-
-  static void updateWithValues<T, A, B, C, D, E, F, G, H, I>(
-      T combiner(A a, B b, [C c, D d, E e, F f, G g, H h, I i]),
-      Iterable<dynamic> values,
-      StreamController<T> controller) {
-    try {
-      final len = values.length;
-      final A a = values.elementAt(0);
-      final B b = values.elementAt(1);
-      T result;
-
-      switch (len) {
-        case 2:
-          result = combiner(a, b);
-          break;
-        case 3:
-          final C c = values.elementAt(2);
-
-          result = combiner(a, b, c);
-          break;
-        case 4:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-
-          result = combiner(a, b, c, d);
-          break;
-        case 5:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-          final E e = values.elementAt(4);
-
-          result = combiner(a, b, c, d, e);
-          break;
-        case 6:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-          final E e = values.elementAt(4);
-          final F f = values.elementAt(5);
-
-          result = combiner(a, b, c, d, e, f);
-          break;
-        case 7:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-          final E e = values.elementAt(4);
-          final F f = values.elementAt(5);
-          final G g = values.elementAt(6);
-
-          result = combiner(a, b, c, d, e, f, g);
-          break;
-        case 8:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-          final E e = values.elementAt(4);
-          final F f = values.elementAt(5);
-          final G g = values.elementAt(6);
-          final H h = values.elementAt(7);
-
-          result = combiner(a, b, c, d, e, f, g, h);
-          break;
-        case 9:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-          final E e = values.elementAt(4);
-          final F f = values.elementAt(5);
-          final G g = values.elementAt(6);
-          final H h = values.elementAt(7);
-          final I i = values.elementAt(8);
-
-          result = combiner(a, b, c, d, e, f, g, h, i);
-          break;
-      }
-
-      controller.add(result);
-    } catch (e, s) {
-      controller.addError(e, s);
-    }
   }
 }

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 /// Merges the specified streams into one observable sequence using the given
-/// combiner function whenever all of the observable sequences have produced
+/// zipper function whenever all of the observable sequences have produced
 /// an element at a corresponding index.
 ///
 /// It applies this function in strict sequence, so the first item emitted by
@@ -22,187 +22,275 @@ import 'dart:async';
 ///         new Stream.fromIterable([2, 3])
 ///       ], (a, b) => a + b)
 ///       .listen(print); // prints 3
-class ZipStream<T, A, B, C, D, E, F, G, H, I> extends Stream<T> {
-  final StreamController<T> controller;
+class ZipStream<T, R> extends StreamView<R> {
+  ZipStream(
+    Iterable<Stream<T>> streams,
+    R zipper(List<T> values),
+  )   : assert(streams != null && streams.every((s) => s != null),
+            'streams cannot be null'),
+        assert(streams.length > 1, 'provide at least 2 streams'),
+        assert(zipper != null, 'must provide a zipper function'),
+        super(_buildController(streams, zipper).stream);
 
-  ZipStream(Iterable<Stream<dynamic>> streams,
-      T zipper(A a, B b, [C c, D d, E e, F f, G g, H h, I i]))
-      : controller = _buildController(streams, zipper);
+  static ZipStream<T, List<T>> list<T>(Iterable<Stream<T>> streams) {
+    return ZipStream<T, List<T>>(
+      streams,
+      (List<T> values) => values,
+    );
+  }
 
-  @override
-  StreamSubscription<T> listen(void onData(T event),
-          {Function onError, void onDone(), bool cancelOnError}) =>
-      controller.stream.listen(onData,
-          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  static ZipStream<dynamic, R> zip2<A, B, R>(
+    Stream<A> streamOne,
+    Stream<B> streamTwo,
+    R zipper(A a, B b),
+  ) {
+    return ZipStream<dynamic, R>(
+      [streamOne, streamTwo],
+      (List<dynamic> values) => zipper(values[0] as A, values[1] as B),
+    );
+  }
 
-  static StreamController<T> _buildController<T, A, B, C, D, E, F, G, H, I>(
-      Iterable<Stream<dynamic>> streams,
-      T zipper(A a, B b, [C c, D d, E e, F f, G g, H h, I i])) {
-    if (streams == null) {
-      throw new ArgumentError('streams cannot be null');
-    } else if (streams.isEmpty) {
-      throw new ArgumentError('at least 1 stream needs to be provided');
-    } else if (streams.any((Stream<dynamic> stream) => stream == null)) {
-      throw new ArgumentError('One of the provided streams is null');
-    }
+  static ZipStream<dynamic, R> zip3<A, B, C, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    R zipper(A a, B b, C c),
+  ) {
+    return ZipStream<dynamic, R>(
+      [streamA, streamB, streamC],
+      (List<dynamic> values) {
+        return zipper(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+        );
+      },
+    );
+  }
 
-    StreamController<T> controller;
-    final pausedStates =
-        new List.generate(streams.length, (_) => false, growable: false);
-    final subscriptions = new List<StreamSubscription<dynamic>>(streams.length);
+  static ZipStream<dynamic, R> zip4<A, B, C, D, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    R zipper(A a, B b, C c, D d),
+  ) {
+    return ZipStream<dynamic, R>(
+      [streamA, streamB, streamC, streamD],
+      (List<dynamic> values) {
+        return zipper(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+        );
+      },
+    );
+  }
 
-    controller = new StreamController<T>(
-        sync: true,
-        onListen: () {
-          try {
-            final values = new List<dynamic>(streams.length);
-            final completedStatus =
-                new List.generate(streams.length, (_) => false);
+  static ZipStream<dynamic, R> zip5<A, B, C, D, E, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    R zipper(A a, B b, C c, D d, E e),
+  ) {
+    return ZipStream<dynamic, R>(
+      [streamA, streamB, streamC, streamD, streamE],
+      (List<dynamic> values) {
+        return zipper(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+        );
+      },
+    );
+  }
 
-            void doUpdate(int index, dynamic value) {
-              values[index] = value;
-              pausedStates[index] = true;
+  static ZipStream<dynamic, R> zip6<A, B, C, D, E, F, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    R zipper(A a, B b, C c, D d, E e, F f),
+  ) {
+    return ZipStream<dynamic, R>(
+      [streamA, streamB, streamC, streamD, streamE, streamF],
+      (List<dynamic> values) {
+        return zipper(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+        );
+      },
+    );
+  }
 
-              // subscriptions[i] might be null if doUpdate triggers
-              // instantly (i.e. BehaviorSubject)
-              if (subscriptions[index] != null) subscriptions[index].pause();
+  static ZipStream<dynamic, R> zip7<A, B, C, D, E, F, G, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    Stream<G> streamG,
+    R zipper(A a, B b, C c, D d, E e, F f, G g),
+  ) {
+    return ZipStream<dynamic, R>(
+      [streamA, streamB, streamC, streamD, streamE, streamF, streamG],
+      (List<dynamic> values) {
+        return zipper(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+          values[6] as G,
+        );
+      },
+    );
+  }
 
-              if (_areAllPaused(pausedStates)) {
-                updateWithValues(zipper, values, controller);
+  static ZipStream<dynamic, R> zip8<A, B, C, D, E, F, G, H, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    Stream<G> streamG,
+    Stream<H> streamH,
+    R zipper(A a, B b, C c, D d, E e, F f, G g, H h),
+  ) {
+    return ZipStream<dynamic, R>(
+      [streamA, streamB, streamC, streamD, streamE, streamF, streamG, streamH],
+      (List<dynamic> values) {
+        return zipper(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+          values[6] as G,
+          values[7] as H,
+        );
+      },
+    );
+  }
 
-                _resumeAll(subscriptions, pausedStates);
+  static ZipStream<dynamic, R> zip9<A, B, C, D, E, F, G, H, I, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    Stream<G> streamG,
+    Stream<H> streamH,
+    Stream<I> streamI,
+    R zipper(A a, B b, C c, D d, E e, F f, G g, H h, I i),
+  ) {
+    return ZipStream<dynamic, R>(
+      [
+        streamA,
+        streamB,
+        streamC,
+        streamD,
+        streamE,
+        streamF,
+        streamG,
+        streamH,
+        streamI
+      ],
+      (List<dynamic> values) {
+        return zipper(
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+          values[6] as G,
+          values[7] as H,
+          values[8] as I,
+        );
+      },
+    );
+  }
+
+  static StreamController<R> _buildController<T, R>(
+    Iterable<Stream<T>> streams,
+    R zipper(List<T> values),
+  ) {
+    {
+      StreamController<R> controller;
+      final subscriptions = List<StreamSubscription<T>>(streams.length);
+
+      controller = StreamController<R>(
+          sync: true,
+          onListen: () {
+            try {
+              final values = List<List<T>>.generate(streams.length, (_) => []);
+              final completedStatus =
+                  List.generate(streams.length, (_) => false);
+
+              void doUpdate(int index, T value) {
+                values[index].add(value);
+
+                if (values.every((v) => v.isNotEmpty)) {
+                  try {
+                    controller.add(zipper(
+                        values.fold([], (prev, vals) => prev..add(vals[0]))));
+                  } catch (e, s) {
+                    controller.addError(e, s);
+                  }
+
+                  values.forEach((v) => v..removeAt(0));
+                }
               }
+
+              void markDone(int i) {
+                completedStatus[i] = true;
+
+                if (completedStatus.reduce((bool a, bool b) => a && b))
+                  controller.close();
+              }
+
+              for (var i = 0, len = streams.length; i < len; i++) {
+                var stream = streams.elementAt(i);
+
+                subscriptions[i] = stream.listen(
+                    (T value) => doUpdate(i, value),
+                    onError: controller.addError,
+                    onDone: () => markDone(i));
+              }
+            } catch (e, s) {
+              controller.addError(e, s);
             }
+          },
+          onPause: ([Future<dynamic> resumeSignal]) =>
+              subscriptions.where((StreamSubscription<dynamic> subscription) => subscription != null).forEach(
+                  (StreamSubscription<dynamic> subscription) =>
+                      subscription.pause(resumeSignal)),
+          onResume: () =>
+              subscriptions.where((StreamSubscription<dynamic> subscription) => subscription != null).forEach(
+                  (StreamSubscription<dynamic> subscription) =>
+                      subscription.resume()),
+          onCancel: () => Future.wait<dynamic>(subscriptions
+              .map((StreamSubscription<dynamic> subscription) => subscription.cancel())
+              .where((Future<dynamic> cancelFuture) => cancelFuture != null)));
 
-            void markDone(int i) {
-              completedStatus[i] = true;
-
-              if (completedStatus.reduce((bool a, bool b) => a && b))
-                controller.close();
-            }
-
-            for (var i = 0, len = streams.length; i < len; i++) {
-              var stream = streams.elementAt(i);
-
-              subscriptions[i] = stream.listen(
-                  (dynamic value) => doUpdate(i, value),
-                  onError: controller.addError,
-                  onDone: () => markDone(i));
-
-              // updating the above subscription if doUpdate triggered too soon
-              if (pausedStates[i] && !subscriptions[i].isPaused)
-                subscriptions[i].pause();
-            }
-          } catch (e, s) {
-            controller.addError(e, s);
-          }
-        },
-        onPause: ([Future<dynamic> resumeSignal]) =>
-            subscriptions.where((StreamSubscription<dynamic> subscription) => subscription != null).forEach(
-                (StreamSubscription<dynamic> subscription) =>
-                    subscription.pause(resumeSignal)),
-        onResume: () =>
-            subscriptions.where((StreamSubscription<dynamic> subscription) => subscription != null).forEach(
-                (StreamSubscription<dynamic> subscription) =>
-                    subscription.resume()),
-        onCancel: () => Future.wait<dynamic>(subscriptions
-            .map((StreamSubscription<dynamic> subscription) => subscription.cancel())
-            .where((Future<dynamic> cancelFuture) => cancelFuture != null)));
-
-    return controller;
-  }
-
-  static void updateWithValues<T, A, B, C, D, E, F, G, H, I>(
-      T zipper(A a, B b, [C c, D d, E e, F f, G g, H h, I i]),
-      Iterable<dynamic> values,
-      StreamController<T> controller) {
-    try {
-      final len = values.length;
-      final A a = values.elementAt(0);
-      final B b = values.elementAt(1);
-      T result;
-
-      switch (len) {
-        case 2:
-          result = zipper(a, b);
-          break;
-        case 3:
-          final C c = values.elementAt(2);
-
-          result = zipper(a, b, c);
-          break;
-        case 4:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-
-          result = zipper(a, b, c, d);
-          break;
-        case 5:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-          final E e = values.elementAt(4);
-
-          result = zipper(a, b, c, d, e);
-          break;
-        case 6:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-          final E e = values.elementAt(4);
-          final F f = values.elementAt(5);
-
-          result = zipper(a, b, c, d, e, f);
-          break;
-        case 7:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-          final E e = values.elementAt(4);
-          final F f = values.elementAt(5);
-          final G g = values.elementAt(6);
-
-          result = zipper(a, b, c, d, e, f, g);
-          break;
-        case 8:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-          final E e = values.elementAt(4);
-          final F f = values.elementAt(5);
-          final G g = values.elementAt(6);
-          final H h = values.elementAt(7);
-
-          result = zipper(a, b, c, d, e, f, g, h);
-          break;
-        case 9:
-          final C c = values.elementAt(2);
-          final D d = values.elementAt(3);
-          final E e = values.elementAt(4);
-          final F f = values.elementAt(5);
-          final G g = values.elementAt(6);
-          final H h = values.elementAt(7);
-          final I i = values.elementAt(8);
-
-          result = zipper(a, b, c, d, e, f, g, h, i);
-          break;
-      }
-
-      controller.add(result);
-    } catch (e, s) {
-      controller.addError(e, s);
-    }
-  }
-
-  static bool _areAllPaused(List<bool> pausedStates) {
-    for (var i = 0, len = pausedStates.length; i < len; i++) {
-      if (!pausedStates[i]) return false;
-    }
-
-    return true;
-  }
-
-  static void _resumeAll(List<StreamSubscription<dynamic>> subscriptions,
-      List<bool> pausedStates) {
-    for (var i = 0, len = subscriptions.length; i < len; i++) {
-      pausedStates[i] = false;
-      subscriptions[i].resume();
+      return controller;
     }
   }
 }

--- a/test/streams/combine_latest_test.dart
+++ b/test/streams/combine_latest_test.dart
@@ -18,7 +18,40 @@ Stream<bool> get streamC {
 }
 
 void main() {
+  test('rx.Observable.combineLatestList', () async {
+    final combined = Observable.combineLatestList<int>([
+      Observable.fromIterable([1, 2, 3]),
+      Observable.just(2),
+      Observable.just(3),
+    ]);
+
+    expect(
+      combined,
+      emitsInOrder(<dynamic>[
+        [1, 2, 3],
+        [2, 2, 3],
+        [3, 2, 3],
+      ]),
+    );
+  });
+
   test('rx.Observable.combineLatest', () async {
+    final combined = Observable.combineLatest<int, int>(
+      [
+        Observable.fromIterable([1, 2, 3]),
+        Observable.just(2),
+        Observable.just(3),
+      ],
+      (values) => values.fold(0, (acc, val) => acc + val),
+    );
+
+    expect(
+      combined,
+      emitsInOrder(<dynamic>[6, 7, 8]),
+    );
+  });
+
+  test('rx.Observable.combineLatest3', () async {
     const expectedOutput = ['0 4 true', '1 4 true', '2 4 true'];
     var count = 0;
 

--- a/test/streams/zip_test.dart
+++ b/test/streams/zip_test.dart
@@ -5,6 +5,31 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.zip', () async {
+    expect(
+      Observable.zip<String, String>([
+        Observable.fromIterable(["A1", "B1"]),
+        Observable.fromIterable(["A2", "B2", "C2"]),
+      ], (values) => values.first + values.last),
+      emitsInOrder(<dynamic>["A1A2", "B1B2", emitsDone]),
+    );
+  });
+
+  test('rx.Observable.zipList', () async {
+    expect(
+      Observable.zipList([
+        Observable.fromIterable(["A1", "B1"]),
+        Observable.fromIterable(["A2", "B2", "C2"]),
+        Observable.fromIterable(["A3", "B3", "C3"]),
+      ]),
+      emitsInOrder(<dynamic>[
+        ['A1', 'A2', 'A3'],
+        ['B1', 'B2', 'B3'],
+        emitsDone
+      ]),
+    );
+  });
+
+  test('rx.Observable.zipBasics', () async {
     const expectedOutput = [
       [0, 1, true],
       [1, 2, false],
@@ -272,8 +297,11 @@ void main() {
   });
 
   test('rx.Observable.zip.error.shouldThrowA', () async {
-    final observableWithError = Observable.zip2(new Observable.just(1),
-        new Observable.just(2), (int a, int b) => throw new Exception());
+    final observableWithError = Observable.zip2(
+      new Observable.just(1),
+      new Observable.just(2),
+      (int a, int b) => throw new Exception(),
+    );
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {


### PR DESCRIPTION
I've had a few people ask me in person, via email, or over chat platforms if we could support more than 9 operators, specifically if folks could pass through an `Iterable<Stream<T>>` such as `List<Stream<T>>` for combination.

Therefore, I refactored the CombineLatestStream & Zip Streams to support:

  * `combineLatest2-9` & `zip2-9` functionality unchanged, but now use a new path for construction. 
  * adds `combineLatest` and `zipLatest` which allows you to pass through an `Iterable<Stream<T>>` and a combiner that takes a `List<T>` when any source emits a change.
  * adds `combineLatestList` / `zipList` which allows you to take in an `Iterable<Stream<T>>` and emit a `Observable<List<T>>` with the values. Just a convenience factory if all you want is the list! 
  * Constructors are provided by the Stream implementation directly