### PR TITLE
fixes buffer count and window count

### DIFF
--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -1198,44 +1198,56 @@ class Observable<T> extends Stream<T> {
               OnDataTransform<List<T>, List<T>> scheduleHandler) =>
           sampler(stream, bufferHandler, scheduleHandler)));
 
-  /// Creates an Observable where each item is a [List] containing the items
-  /// from the source sequence, in batches of [count].
-  ///
-  /// If [startBufferEvery] is provided, each group will start where the previous group
-  /// ended minus the [startBufferEvery] value.
+  /// Buffers a number of values from the source Observable by [count] then
+  /// emits the buffer and clears it, and starts a new buffer each
+  /// [startBufferEvery] values. If [startBufferEvery] is not provided or is
+  /// null, then new buffers are started immediately at the start of the source
+  /// and when each buffer closes and is emitted.
   ///
   /// ### Example
+  /// [count] is the maximum size of the buffer emitted
   ///
   ///     Observable.range(1, 4)
   ///       .bufferCount(2)
-  ///       .listen(print); // prints [1, 2], [3, 4]
+  ///       .listen(print); // prints [1, 2], [3, 4] done!
   ///
-  /// ### Example with startBufferEvery
+  /// ### Example
+  /// if [startBufferEvery] is 2, then a new buffer will be started
+  /// on every other value from the source. A new buffer is started at the
+  /// beginning of the source by default.
   ///
-  ///     Observable.range(1, 4).bufferCount(2, 1)
-  ///       .listen(print); // prints [1, 2], [2, 3], [3, 4], [4]
+  /// ### Example with [startBufferEvery]
+  ///
+  ///     Observable.range(1, 5).bufferCount(3, 2)
+  ///       .listen(print); // prints [1, 2, 3], [3, 4, 5], [5] done!
   Observable<List<T>> bufferCount(int count, [int startBufferEvery = 0]) =>
       transform(new BufferStreamTransformer<T>(
           onCount<T, List<T>>(count, startBufferEvery)));
 
   /// Deprecated: Please use [bufferCount]
   ///
-  /// Creates an Observable where each item is a [List] containing the items
-  /// from the source sequence, in batches of [count].
-  ///
-  /// If [startBufferEvery] is provided, each group will start where the previous group
-  /// ended minus the [startBufferEvery] value.
+  /// Buffers a number of values from the source Observable by [count] then
+  /// emits the buffer and clears it, and starts a new buffer each
+  /// [startBufferEvery] values. If [startBufferEvery] is not provided or is
+  /// null, then new buffers are started immediately at the start of the source
+  /// and when each buffer closes and is emitted.
   ///
   /// ### Example
-  ///
-  ///     Observable.range(1, 4).bufferWithCount(2)
-  ///       .listen(print); // prints [1, 2], [3, 4]
-  ///
-  /// ### Example with startBufferEvery
+  /// [count] is the maximum size of the buffer emitted
   ///
   ///     Observable.range(1, 4)
-  ///       .bufferWithCount(2, 1)
-  ///       .listen(print); // prints [1, 2], [2, 3], [3, 4], [4]
+  ///       .bufferCount(2)
+  ///       .listen(print); // prints [1, 2], [3, 4] done!
+  ///
+  /// ### Example
+  /// if [startBufferEvery] is 2, then a new buffer will be started
+  /// on every other value from the source. A new buffer is started at the
+  /// beginning of the source by default.
+  ///
+  /// ### Example with [startBufferEvery]
+  ///
+  ///     Observable.range(1, 5).bufferCount(3, 2)
+  ///       .listen(print); // prints [1, 2, 3], [3, 4, 5], [5] done!
   @deprecated
   Observable<List<T>> bufferWithCount(int count, [int startBufferEvery = 0]) =>
       transform(new BufferStreamTransformer<T>(
@@ -2290,27 +2302,34 @@ class Observable<T> extends Stream<T> {
               OnDataTransform<Stream<T>, Stream<T>> scheduleHandler) =>
           sampler(stream, bufferHandler, scheduleHandler)));
 
-  /// Creates an Observable where each item is a [Stream] containing the items
-  /// from the source sequence, in batches of [count].
-  ///
-  /// If [startBufferEvery] is provided, each group will start where the previous group
-  /// ended minus the [startBufferEvery] value.
+  /// Buffers a number of values from the source Observable by [count] then
+  /// emits the values inside the buffer as a new [Stream],
+  /// and starts a new buffer each [startBufferEvery] values.
+  /// If [startBufferEvery] is not provided or is null, then new buffers are
+  /// started immediately at the start of the source and when each buffer
+  /// closes and is emitted.
   ///
   /// ### Example
+  /// [count] is the maximum size of the buffer emitted
   ///
   ///     Observable.range(1, 4)
   ///       .windowCount(2)
-  ///       .doOnData((_) => print('next window'))
-  ///       .flatMap((s) => s)
-  ///       .listen(print); // prints next window 1, 2, next window 3, 4
+  ///       .doOnData((_) => print('new Stream emitted))
+  ///       .flatMap((stream) => stream)
+  ///       .listen(print); // prints new Stream emitted, 1, 2, new Stream emitted, 3, 4 done!
   ///
-  /// ### Example with startBufferEvery
+  /// ### Example
+  /// if [startBufferEvery] is 2, then a new buffer will be started
+  /// on every other value from the source. A new buffer is started at the
+  /// beginning of the source by default.
   ///
-  ///     Observable.range(1, 4)
-  ///       .windowCount(2, 1)
-  ///       .doOnData((_) => print('next window'))
-  ///       .flatMap((s) => s)
-  ///       .listen(print); // prints next window 1, 2, next window 2, 3, next window 3, 4, next window 4
+  /// ### Example with [startBufferEvery]
+  ///
+  ///     Observable.range(1, 5)
+  ///       .windowCount(3, 2)
+  ///       .doOnData((_) => print('new Stream emitted))
+  ///       .flatMap((stream) => stream)
+  ///       .listen(print); // prints new Stream emitted, 1, 2, 3 new Stream emitted 3, 4, 5 new Stream emitted 5 done!
   Observable<Stream<T>> windowCount(int count, [int startBufferEvery = 0]) =>
       transform(
           new WindowStreamTransformer<T>(onCount(count, startBufferEvery)));

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -1972,7 +1972,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     Observable.range(1, 4)
   ///       .pairwise()
-  ///       .listen(print); // prints [1, 2], [3, 4]
+  ///       .listen(print); // prints [1, 2], [2, 3]
   Observable<List<T>> pairwise() =>
       transform(new BufferStreamTransformer<T>(onCount<T, List<T>>(2, 1)));
 

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -1214,8 +1214,8 @@ class Observable<T> extends Stream<T> {
   ///
   ///     Observable.range(1, 4).bufferCount(2, 1)
   ///       .listen(print); // prints [1, 2], [2, 3], [3, 4], [4]
-  Observable<List<T>> bufferCount(int count, [int skip]) => transform(
-      new BufferStreamTransformer<T>(onCount<T, List<T>>(count, skip)));
+  Observable<List<T>> bufferCount(int count, [int startBufferEvery]) => transform(
+      new BufferStreamTransformer<T>(onCount<T, List<T>>(count, startBufferEvery)));
 
   /// Deprecated: Please use [bufferCount]
   ///
@@ -1236,8 +1236,8 @@ class Observable<T> extends Stream<T> {
   ///       .bufferWithCount(2, 1)
   ///       .listen(print); // prints [1, 2], [2, 3], [3, 4], [4]
   @deprecated
-  Observable<List<T>> bufferWithCount(int count, [int skip]) => transform(
-      new BufferStreamTransformer<T>(onCount<T, List<T>>(count, skip)));
+  Observable<List<T>> bufferWithCount(int count, [int startBufferEvery]) => transform(
+      new BufferStreamTransformer<T>(onCount<T, List<T>>(count, startBufferEvery)));
 
   /// Creates an Observable where each item is a [List] containing the items
   /// from the source sequence, batched whenever [onFutureHandler] completes.
@@ -2298,8 +2298,8 @@ class Observable<T> extends Stream<T> {
   ///       .doOnData((_) => print('next window'))
   ///       .flatMap((s) => s)
   ///       .listen(print); // prints next window 1, 2, next window 2, 3, next window 3, 4, next window 4
-  Observable<Stream<T>> windowCount(int count, [int skip]) =>
-      transform(new WindowStreamTransformer<T>(onCount(count, skip)));
+  Observable<Stream<T>> windowCount(int count, [int startBufferEvery]) =>
+      transform(new WindowStreamTransformer<T>(onCount(count, startBufferEvery)));
 
   /// Deprecated: Please use [windowCount]
   ///
@@ -2325,8 +2325,8 @@ class Observable<T> extends Stream<T> {
   ///       .flatMap((s) => s)
   ///       .listen(print); // prints next window 1, 2, next window 2, 3, next window 3, 4, next window 4
   @deprecated
-  Observable<Stream<T>> windowWithCount(int count, [int skip]) =>
-      transform(new WindowStreamTransformer<T>(onCount(count, skip)));
+  Observable<Stream<T>> windowWithCount(int count, [int startBufferEvery]) =>
+      transform(new WindowStreamTransformer<T>(onCount(count, startBufferEvery)));
 
   /// Creates an Observable where each item is a [Stream] containing the items
   /// from the source sequence, batched whenever [onFutureHandler] completes.

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -1216,9 +1216,8 @@ class Observable<T> extends Stream<T> {
   /// on every other value from the source. A new buffer is started at the
   /// beginning of the source by default.
   ///
-  /// ### Example with [startBufferEvery]
-  ///
-  ///     Observable.range(1, 5).bufferCount(3, 2)
+  ///     Observable.range(1, 5)
+  ///       .bufferCount(3, 2)
   ///       .listen(print); // prints [1, 2, 3], [3, 4, 5], [5] done!
   Observable<List<T>> bufferCount(int count, [int startBufferEvery = 0]) =>
       transform(new BufferStreamTransformer<T>(
@@ -2322,8 +2321,6 @@ class Observable<T> extends Stream<T> {
   /// if [startBufferEvery] is 2, then a new buffer will be started
   /// on every other value from the source. A new buffer is started at the
   /// beginning of the source by default.
-  ///
-  /// ### Example with [startBufferEvery]
   ///
   ///     Observable.range(1, 5)
   ///       .windowCount(3, 2)

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -1201,8 +1201,8 @@ class Observable<T> extends Stream<T> {
   /// Creates an Observable where each item is a [List] containing the items
   /// from the source sequence, in batches of [count].
   ///
-  /// If [skip] is provided, each group will start where the previous group
-  /// ended minus the [skip] value.
+  /// If [startBufferEvery] is provided, each group will start where the previous group
+  /// ended minus the [startBufferEvery] value.
   ///
   /// ### Example
   ///
@@ -1210,34 +1210,36 @@ class Observable<T> extends Stream<T> {
   ///       .bufferCount(2)
   ///       .listen(print); // prints [1, 2], [3, 4]
   ///
-  /// ### Example with skip
+  /// ### Example with startBufferEvery
   ///
   ///     Observable.range(1, 4).bufferCount(2, 1)
   ///       .listen(print); // prints [1, 2], [2, 3], [3, 4], [4]
-  Observable<List<T>> bufferCount(int count, [int startBufferEvery]) => transform(
-      new BufferStreamTransformer<T>(onCount<T, List<T>>(count, startBufferEvery)));
+  Observable<List<T>> bufferCount(int count, [int startBufferEvery = 0]) =>
+      transform(new BufferStreamTransformer<T>(
+          onCount<T, List<T>>(count, startBufferEvery)));
 
   /// Deprecated: Please use [bufferCount]
   ///
   /// Creates an Observable where each item is a [List] containing the items
   /// from the source sequence, in batches of [count].
   ///
-  /// If [skip] is provided, each group will start where the previous group
-  /// ended minus the [skip] value.
+  /// If [startBufferEvery] is provided, each group will start where the previous group
+  /// ended minus the [startBufferEvery] value.
   ///
   /// ### Example
   ///
   ///     Observable.range(1, 4).bufferWithCount(2)
   ///       .listen(print); // prints [1, 2], [3, 4]
   ///
-  /// ### Example with skip
+  /// ### Example with startBufferEvery
   ///
   ///     Observable.range(1, 4)
   ///       .bufferWithCount(2, 1)
   ///       .listen(print); // prints [1, 2], [2, 3], [3, 4], [4]
   @deprecated
-  Observable<List<T>> bufferWithCount(int count, [int startBufferEvery]) => transform(
-      new BufferStreamTransformer<T>(onCount<T, List<T>>(count, startBufferEvery)));
+  Observable<List<T>> bufferWithCount(int count, [int startBufferEvery = 0]) =>
+      transform(new BufferStreamTransformer<T>(
+          onCount<T, List<T>>(count, startBufferEvery)));
 
   /// Creates an Observable where each item is a [List] containing the items
   /// from the source sequence, batched whenever [onFutureHandler] completes.
@@ -1963,6 +1965,17 @@ class Observable<T> extends Stream<T> {
       transform(new OnErrorResumeStreamTransformer<T>(
           (dynamic e) => new Observable<T>.just(returnFn(e))));
 
+  /// Triggers on the second and subsequent triggerings of the input observable.
+  /// The Nth triggering of the input observable passes the arguments from the N-1th and Nth triggering as a pair.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.range(1, 4)
+  ///       .pairwise()
+  ///       .listen(print); // prints [1, 2], [3, 4]
+  Observable<List<T>> pairwise() =>
+      transform(new BufferStreamTransformer<T>(onCount<T, List<T>>(2, 1)));
+
   @override
   AsObservableFuture<dynamic> pipe(StreamConsumer<T> streamConsumer) =>
       new AsObservableFuture<dynamic>(_stream.pipe(streamConsumer));
@@ -2280,8 +2293,8 @@ class Observable<T> extends Stream<T> {
   /// Creates an Observable where each item is a [Stream] containing the items
   /// from the source sequence, in batches of [count].
   ///
-  /// If [skip] is provided, each group will start where the previous group
-  /// ended minus the [skip] value.
+  /// If [startBufferEvery] is provided, each group will start where the previous group
+  /// ended minus the [startBufferEvery] value.
   ///
   /// ### Example
   ///
@@ -2291,23 +2304,24 @@ class Observable<T> extends Stream<T> {
   ///       .flatMap((s) => s)
   ///       .listen(print); // prints next window 1, 2, next window 3, 4
   ///
-  /// ### Example with skip
+  /// ### Example with startBufferEvery
   ///
   ///     Observable.range(1, 4)
   ///       .windowCount(2, 1)
   ///       .doOnData((_) => print('next window'))
   ///       .flatMap((s) => s)
   ///       .listen(print); // prints next window 1, 2, next window 2, 3, next window 3, 4, next window 4
-  Observable<Stream<T>> windowCount(int count, [int startBufferEvery]) =>
-      transform(new WindowStreamTransformer<T>(onCount(count, startBufferEvery)));
+  Observable<Stream<T>> windowCount(int count, [int startBufferEvery = 0]) =>
+      transform(
+          new WindowStreamTransformer<T>(onCount(count, startBufferEvery)));
 
   /// Deprecated: Please use [windowCount]
   ///
   /// Creates an Observable where each item is a [Stream] containing the items
   /// from the source sequence, in batches of [count].
   ///
-  /// If [skip] is provided, each group will start where the previous group
-  /// ended minus the [skip] value.
+  /// If [startBufferEvery] is provided, each group will start where the previous group
+  /// ended minus the [startBufferEvery] value.
   ///
   /// ### Example
   ///
@@ -2317,7 +2331,7 @@ class Observable<T> extends Stream<T> {
   ///       .flatMap((s) => s)
   ///       .listen(print); // prints next window 1, 2, next window 3, 4
   ///
-  /// ### Example with skip
+  /// ### Example with startBufferEvery
   ///
   ///     Observable.range(1, 4)
   ///       .windowCount(2, 1)
@@ -2325,8 +2339,10 @@ class Observable<T> extends Stream<T> {
   ///       .flatMap((s) => s)
   ///       .listen(print); // prints next window 1, 2, next window 2, 3, next window 3, 4, next window 4
   @deprecated
-  Observable<Stream<T>> windowWithCount(int count, [int startBufferEvery]) =>
-      transform(new WindowStreamTransformer<T>(onCount(count, startBufferEvery)));
+  Observable<Stream<T>> windowWithCount(int count,
+          [int startBufferEvery = 0]) =>
+      transform(
+          new WindowStreamTransformer<T>(onCount(count, startBufferEvery)));
 
   /// Creates an Observable where each item is a [Stream] containing the items
   /// from the source sequence, batched whenever [onFutureHandler] completes.

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -1985,7 +1985,8 @@ class Observable<T> extends Stream<T> {
   ///       .pairwise()
   ///       .listen(print); // prints [1, 2], [2, 3]
   Observable<List<T>> pairwise() =>
-      transform(new BufferStreamTransformer<T>(onCount<T, List<T>>(2, 1)));
+      transform(new BufferStreamTransformer<T>(onCount<T, List<T>>(2, 1),
+          exhaustBufferOnDone: false));
 
   @override
   AsObservableFuture<dynamic> pipe(StreamConsumer<T> streamConsumer) =>

--- a/lib/src/samplers/buffer_strategy.dart
+++ b/lib/src/samplers/buffer_strategy.dart
@@ -22,7 +22,7 @@ Stream<S> Function(
   Stream<T> stream,
   OnDataTransform<T, S>,
   OnDataTransform<S, S>,
-) onCount<T, S>(int count, [int startBufferEvery]) => (
+) onCount<T, S>(int count, [int startBufferEvery = 0]) => (
       Stream<T> stream,
       OnDataTransform<T, S> bufferHandler,
       OnDataTransform<S, S> scheduleHandler,
@@ -194,13 +194,19 @@ class _OnCountSampler<T, S> extends StreamView<S> {
 
   factory _OnCountSampler(Stream<T> stream, OnDataTransform<T, S> bufferHandler,
       OnDataTransform<S, S> scheduleHandler, int count,
-      [int startBufferEvery]) {
+      [int startBufferEvery = 0]) {
     var eventIndex = 0;
-
-    startBufferEvery ??= 0;
 
     if (count == null) {
       throw new ArgumentError('count cannot be null');
+    } else if (count < 1) {
+      throw new ArgumentError(
+          'count needs to be greater than 1, currently it is: $count');
+    }
+
+    if (startBufferEvery < 0) {
+      throw new ArgumentError(
+          'startBufferEvery needs to be greater than, or equal to 0, currently it is: $startBufferEvery');
     }
 
     bool maybeNewBuffer(S _) => eventIndex % count == 0;
@@ -215,7 +221,6 @@ class _OnCountSampler<T, S> extends StreamView<S> {
         .where(maybeNewBuffer)
         .transform<S>(new StreamTransformer<S, S>.fromHandlers(
             handleData: (S data, EventSink<S> sink) {
-              startBufferEvery ??= 0;
               eventIndex -= startBufferEvery;
               scheduleHandler(data, sink, startBufferEvery);
             },

--- a/lib/src/transformers/buffer.dart
+++ b/lib/src/transformers/buffer.dart
@@ -76,7 +76,7 @@ class BufferStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
               ]) {
                 buffer.add(data);
                 sink.add(buffer);
-              }, (_, EventSink<List<T>> sink, [int startBufferEvery]) {
+              }, (_, EventSink<List<T>> sink, [int startBufferEvery = 0]) {
                 startBufferEvery ?? 0;
 
                 sink.add(new List<T>.unmodifiable(buffer));

--- a/lib/src/transformers/buffer.dart
+++ b/lib/src/transformers/buffer.dart
@@ -59,8 +59,7 @@ class BufferStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
       void onDone() {
         if (controller.isClosed) return;
 
-        // uncomment if we want to also add the remainder buffer as a final event
-        // if (buffer.isNotEmpty) controller.add(new List<T>.unmodifiable(buffer));
+        if (buffer.isNotEmpty) controller.add(new List<T>.from(buffer));
 
         controller.close();
       }

--- a/lib/src/transformers/buffer.dart
+++ b/lib/src/transformers/buffer.dart
@@ -59,7 +59,8 @@ class BufferStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
       void onDone() {
         if (controller.isClosed) return;
 
-        if (buffer.isNotEmpty) controller.add(new List<T>.unmodifiable(buffer));
+        // uncomment if we want to also add the remainder buffer as a final event
+        // if (buffer.isNotEmpty) controller.add(new List<T>.unmodifiable(buffer));
 
         controller.close();
       }

--- a/lib/src/transformers/buffer.dart
+++ b/lib/src/transformers/buffer.dart
@@ -59,8 +59,7 @@ class BufferStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
       void onDone() {
         if (controller.isClosed) return;
 
-        // uncomment if we want to also add the remainder buffer as a final event
-        // if (buffer.isNotEmpty) controller.add(new List<T>.unmodifiable(buffer));
+        if (buffer.isNotEmpty) controller.add(new List<T>.unmodifiable(buffer));
 
         controller.close();
       }

--- a/lib/src/transformers/buffer.dart
+++ b/lib/src/transformers/buffer.dart
@@ -39,15 +39,16 @@ import 'package:rxdart/src/samplers/buffer_strategy.dart';
 /// should the above samplers be insufficient for your use case.
 class BufferStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
   final SamplerBuilder<T, List<T>> sampler;
+  final bool exhaustBufferOnDone;
 
-  BufferStreamTransformer(this.sampler);
+  BufferStreamTransformer(this.sampler, {this.exhaustBufferOnDone = true});
 
   @override
   Stream<List<T>> bind(Stream<T> stream) =>
-      _buildTransformer<T>(sampler).bind(stream);
+      _buildTransformer<T>(sampler, exhaustBufferOnDone).bind(stream);
 
   static StreamTransformer<T, List<T>> _buildTransformer<T>(
-      SamplerBuilder<T, List<T>> scheduler) {
+      SamplerBuilder<T, List<T>> scheduler, bool exhaustBufferOnDone) {
     assertSampler(scheduler);
 
     return new StreamTransformer<T, List<T>>(
@@ -59,7 +60,8 @@ class BufferStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
       void onDone() {
         if (controller.isClosed) return;
 
-        if (buffer.isNotEmpty) controller.add(new List<T>.from(buffer));
+        if (exhaustBufferOnDone && buffer.isNotEmpty)
+          controller.add(new List<T>.from(buffer));
 
         controller.close();
       }

--- a/lib/src/transformers/buffer_with_count.dart
+++ b/lib/src/transformers/buffer_with_count.dart
@@ -34,8 +34,8 @@ class BufferWithCountStreamTransformer<T>
       _buildTransformer<T>(count, skip).bind(stream);
 
   static StreamTransformer<T, List<T>> _buildTransformer<T>(
-      int count, int skip) {
-    assertCountAndSkip(count, skip);
+      int count, int startBufferEvery) {
+    assertCountAndSkip(count, startBufferEvery);
 
     return new StreamTransformer<T, List<T>>(
         (Stream<T> input, bool cancelOnError) {
@@ -46,7 +46,7 @@ class BufferWithCountStreamTransformer<T>
           sync: true,
           onListen: () {
             subscription = input
-                .transform(new BufferStreamTransformer<T>(onCount(count, skip)))
+                .transform(new BufferStreamTransformer<T>(onCount(count, startBufferEvery)))
                 .listen(controller.add,
                     onError: controller.addError,
                     onDone: controller.close,

--- a/lib/src/transformers/window.dart
+++ b/lib/src/transformers/window.dart
@@ -69,9 +69,8 @@ class WindowStreamTransformer<T> extends StreamTransformerBase<T, Stream<T>> {
       void onDone() {
         if (controller.isClosed) return;
 
-        // uncomment if we want to also add the remainder buffer as a final event
-        /*if (buffer.isNotEmpty)
-          controller.add(new Stream<T>.fromIterable(buffer));*/
+        if (buffer.isNotEmpty)
+          controller.add(new Stream<T>.fromIterable(buffer));
 
         controller.close();
       }

--- a/lib/src/transformers/window.dart
+++ b/lib/src/transformers/window.dart
@@ -80,11 +80,11 @@ class WindowStreamTransformer<T> extends StreamTransformerBase<T, Stream<T>> {
           sync: true,
           onListen: () {
             try {
-              subscription = scheduler(input,
-                  (T data, EventSink<Stream<T>> sink, [int startBufferEvery]) {
+              subscription = scheduler(input, (T data,
+                  EventSink<Stream<T>> sink, [int startBufferEvery = 0]) {
                 buffer.add(data);
                 sink.add(new Stream<T>.fromIterable(buffer));
-              }, (_, EventSink<Stream<T>> sink, [int startBufferEvery]) {
+              }, (_, EventSink<Stream<T>> sink, [int startBufferEvery = 0]) {
                 startBufferEvery ?? 0;
 
                 sink.add(new Stream<T>.fromIterable(buffer));

--- a/lib/src/transformers/window.dart
+++ b/lib/src/transformers/window.dart
@@ -70,8 +70,9 @@ class WindowStreamTransformer<T> extends StreamTransformerBase<T, Stream<T>> {
       void onDone() {
         if (controller.isClosed) return;
 
-        if (buffer.isNotEmpty)
-          controller.add(new Stream<T>.fromIterable(buffer));
+        // uncomment if we want to also add the remainder buffer as a final event
+        /*if (buffer.isNotEmpty)
+          controller.add(new Stream<T>.fromIterable(buffer));*/
 
         controller.close();
       }

--- a/lib/src/transformers/window.dart
+++ b/lib/src/transformers/window.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:rxdart/src/samplers/buffer_strategy.dart';
-import 'package:rxdart/src/transformers/do.dart';
 
 /// Creates an Observable where each item is a [Stream] containing the items
 /// from the source sequence, batched by the [sampler].

--- a/lib/src/transformers/window.dart
+++ b/lib/src/transformers/window.dart
@@ -70,9 +70,8 @@ class WindowStreamTransformer<T> extends StreamTransformerBase<T, Stream<T>> {
       void onDone() {
         if (controller.isClosed) return;
 
-        // uncomment if we want to also add the remainder buffer as a final event
-        /*if (buffer.isNotEmpty)
-          controller.add(new Stream<T>.fromIterable(buffer));*/
+        if (buffer.isNotEmpty)
+          controller.add(new Stream<T>.fromIterable(buffer));
 
         controller.close();
       }

--- a/lib/src/transformers/window.dart
+++ b/lib/src/transformers/window.dart
@@ -49,15 +49,16 @@ import 'package:rxdart/src/samplers/buffer_strategy.dart';
 /// should the above samplers be insufficient for your use case.
 class WindowStreamTransformer<T> extends StreamTransformerBase<T, Stream<T>> {
   final SamplerBuilder<T, Stream<T>> sampler;
+  final bool exhaustBufferOnDone;
 
-  WindowStreamTransformer(this.sampler);
+  WindowStreamTransformer(this.sampler, {this.exhaustBufferOnDone = true});
 
   @override
   Stream<Stream<T>> bind(Stream<T> stream) =>
-      _buildTransformer<T>(sampler).bind(stream);
+      _buildTransformer<T>(sampler, exhaustBufferOnDone).bind(stream);
 
   static StreamTransformer<T, Stream<T>> _buildTransformer<T>(
-      SamplerBuilder<T, Stream<T>> scheduler) {
+      SamplerBuilder<T, Stream<T>> scheduler, bool exhaustBufferOnDone) {
     assertSampler(scheduler);
 
     return new StreamTransformer<T, Stream<T>>(
@@ -69,7 +70,7 @@ class WindowStreamTransformer<T> extends StreamTransformerBase<T, Stream<T>> {
       void onDone() {
         if (controller.isClosed) return;
 
-        if (buffer.isNotEmpty)
+        if (exhaustBufferOnDone && buffer.isNotEmpty)
           controller.add(new Stream<T>.fromIterable(buffer));
 
         controller.close();

--- a/lib/src/transformers/window.dart
+++ b/lib/src/transformers/window.dart
@@ -81,8 +81,7 @@ class WindowStreamTransformer<T> extends StreamTransformerBase<T, Stream<T>> {
           sync: true,
           onListen: () {
             try {
-              subscription = scheduler(
-                  input.transform(new DoStreamTransformer<T>(onDone: onDone)),
+              subscription = scheduler(input,
                   (T data, EventSink<Stream<T>> sink, [int startBufferEvery]) {
                 buffer.add(data);
                 sink.add(new Stream<T>.fromIterable(buffer));

--- a/lib/src/transformers/window_with_count.dart
+++ b/lib/src/transformers/window_with_count.dart
@@ -29,8 +29,8 @@ class WindowWithCountStreamTransformer<T>
       _buildTransformer<T>(count, skip).bind(stream);
 
   static StreamTransformer<T, Stream<T>> _buildTransformer<T>(
-      int count, int skip) {
-    assertCountAndSkip(count, skip);
+      int count, int startBufferEvery) {
+    assertCountAndSkip(count, startBufferEvery);
 
     return new StreamTransformer<T, Stream<T>>(
         (Stream<T> input, bool cancelOnError) {
@@ -41,7 +41,7 @@ class WindowWithCountStreamTransformer<T>
           sync: true,
           onListen: () {
             subscription = input
-                .transform(new WindowStreamTransformer<T>(onCount(count, skip)))
+                .transform(new WindowStreamTransformer<T>(onCount(count, startBufferEvery)))
                 .listen(controller.add,
                     onError: controller.addError,
                     onDone: controller.close,

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -86,6 +86,7 @@ import 'transformers/on_error_return_test.dart' as on_error_resume_test;
 import 'transformers/on_error_return_test.dart' as on_error_return_test;
 import 'transformers/on_error_return_with_test.dart'
     as on_error_return_with_test;
+import 'transformers/pairwise_test.dart' as pairwise_test;
 import 'transformers/reduce_test.dart' as reduce_test;
 import 'transformers/repeat_test.dart' as repeat_test;
 import 'transformers/sample_test.dart' as sample_test;
@@ -191,6 +192,7 @@ void main() {
   on_error_resume_test.main();
   on_error_return_test.main();
   on_error_return_with_test.main();
+  pairwise_test.main();
   reduce_test.main();
   repeat_test.main();
   sample_test.main();

--- a/test/transformers/buffer_count_test.dart
+++ b/test/transformers/buffer_count_test.dart
@@ -18,7 +18,7 @@ void main() {
       expect(expectedOutput[count][0], result[0]);
       expect(expectedOutput[count][1], result[1]);
       count++;
-    }, count: 2));
+    }, count: expectedOutput.length));
   });
 
   test('rx.Observable.bufferCount.noSkip.asBuffer', () async {
@@ -35,15 +35,14 @@ void main() {
       expect(expectedOutput[count][0], result[0]);
       expect(expectedOutput[count][1], result[1]);
       count++;
-    }, count: 2));
+    }, count: expectedOutput.length));
   });
 
   test('rx.Observable.bufferCount.skip', () async {
     const expectedOutput = [
       [1, 2],
       [2, 3],
-      [3, 4],
-      [4]
+      [3, 4]
     ];
     var count = 0;
 
@@ -56,15 +55,65 @@ void main() {
       if (expectedOutput[count].length > 1)
         expect(expectedOutput[count][1], result[1]);
       count++;
-    }, count: 4));
+    }, count: expectedOutput.length));
+  });
+
+  test('rx.Observable.bufferCount.skip2', () async {
+    const expectedOutput = [
+      [1, 2, 3],
+      [3, 4, 5],
+      [5, 6, 7]
+    ];
+    var count = 0;
+
+    final stream = Observable.range(1, 8).bufferCount(3, 2);
+
+    bool equalLists(List<int> lA, List<int> lB) {
+      for (var i = 0, len = lA.length; i < len; i++) {
+        if (lA[i] != lB[i]) return false;
+      }
+
+      return true;
+    }
+
+    stream.listen(expectAsync1((result) {
+      // test to see if the combined output matches
+      expect(expectedOutput[count].length, result.length);
+      expect(equalLists(expectedOutput[count], result), isTrue);
+      count++;
+    }, count: expectedOutput.length));
+  });
+
+  test('rx.Observable.bufferCount.skip3', () async {
+    const expectedOutput = [
+      [1, 2, 3],
+      [5, 6, 7]
+    ];
+    var count = 0;
+
+    final stream = Observable.range(1, 8).bufferCount(3, 4);
+
+    bool equalLists(List<int> lA, List<int> lB) {
+      for (var i = 0, len = lA.length; i < len; i++) {
+        if (lA[i] != lB[i]) return false;
+      }
+
+      return true;
+    }
+
+    stream.listen(expectAsync1((result) {
+      // test to see if the combined output matches
+      expect(expectedOutput[count].length, result.length);
+      expect(equalLists(expectedOutput[count], result), isTrue);
+      count++;
+    }, count: expectedOutput.length));
   });
 
   test('rx.Observable.bufferCount.skip.asBuffer', () async {
     const expectedOutput = [
       [1, 2],
       [2, 3],
-      [3, 4],
-      [4]
+      [3, 4]
     ];
     var count = 0;
 
@@ -77,7 +126,7 @@ void main() {
       if (expectedOutput[count].length > 1)
         expect(expectedOutput[count][1], result[1]);
       count++;
-    }, count: 4));
+    }, count: expectedOutput.length));
   });
 
   test('rx.Observable.bufferCount.reusable', () async {
@@ -96,7 +145,7 @@ void main() {
       expect(expectedOutput[countA][0], result[0]);
       expect(expectedOutput[countA][1], result[1]);
       countA++;
-    }, count: 2));
+    }, count: expectedOutput.length));
 
     final streamB = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer);
@@ -106,7 +155,7 @@ void main() {
       expect(expectedOutput[countB][0], result[0]);
       expect(expectedOutput[countB][1], result[1]);
       countB++;
-    }, count: 2));
+    }, count: expectedOutput.length));
   });
 
   test('rx.Observable.bufferCount.asBroadcastStream', () async {
@@ -155,22 +204,6 @@ void main() {
   });
 
   test('rx.Observable.bufferCount.skip.shouldThrowB', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
-        .bufferCount(2, 100)
-        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
-      expect(e, isArgumentError);
-    }));
-  });
-
-  test('rx.Observable.bufferCount.skip.shouldThrowB.asBuffer', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
-        .buffer(onCount(2, 100))
-        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
-      expect(e, isArgumentError);
-    }));
-  });
-
-  test('rx.Observable.bufferCount.skip.shouldThrowC', () {
     new Observable<int>.fromIterable(const [1, 2, 3, 4])
         .bufferCount(null)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
@@ -178,7 +211,7 @@ void main() {
     }));
   });
 
-  test('rx.Observable.bufferCount.skip.shouldThrowC.asBuffer', () {
+  test('rx.Observable.bufferCount.skip.shouldThrowB.asBuffer', () {
     new Observable.fromIterable(const [1, 2, 3, 4])
         .buffer(onCount(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {

--- a/test/transformers/buffer_count_test.dart
+++ b/test/transformers/buffer_count_test.dart
@@ -38,7 +38,8 @@ void main() {
     }, count: expectedOutput.length));
   });
 
-  test('rx.Observable.bufferCount.skip', () async {
+  test('rx.Observable.bufferCount.startBufferEvery.count2startBufferEvery1',
+      () async {
     const expectedOutput = [
       [1, 2],
       [2, 3],
@@ -58,7 +59,8 @@ void main() {
     }, count: expectedOutput.length));
   });
 
-  test('rx.Observable.bufferCount.skip2', () async {
+  test('rx.Observable.bufferCount.startBufferEvery.count3startBufferEvery2',
+      () async {
     const expectedOutput = [
       [1, 2, 3],
       [3, 4, 5],
@@ -84,7 +86,8 @@ void main() {
     }, count: expectedOutput.length));
   });
 
-  test('rx.Observable.bufferCount.skip3', () async {
+  test('rx.Observable.bufferCount.startBufferEvery.count3startBufferEvery4',
+      () async {
     const expectedOutput = [
       [1, 2, 3],
       [5, 6, 7]
@@ -109,7 +112,7 @@ void main() {
     }, count: expectedOutput.length));
   });
 
-  test('rx.Observable.bufferCount.skip.asBuffer', () async {
+  test('rx.Observable.bufferCount.startBufferEvery.asBuffer', () async {
     const expectedOutput = [
       [1, 2],
       [2, 3],
@@ -203,7 +206,15 @@ void main() {
     }));
   });
 
-  test('rx.Observable.bufferCount.skip.shouldThrowB', () {
+  test('rx.Observable.bufferCount.shouldThrow.invalidCount.negative', () {
+    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+        .bufferCount(-1)
+        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
+      expect(e, isArgumentError);
+    }));
+  });
+
+  test('rx.Observable.bufferCount.shouldThrow.invalidCount.isNull', () {
     new Observable<int>.fromIterable(const [1, 2, 3, 4])
         .bufferCount(null)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
@@ -211,9 +222,29 @@ void main() {
     }));
   });
 
-  test('rx.Observable.bufferCount.skip.shouldThrowB.asBuffer', () {
+  test('rx.Observable.bufferCount.shouldThrow.invalidCount.negative.asBuffer',
+      () {
+    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+        .buffer(onCount(-1))
+        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
+      expect(e, isArgumentError);
+    }));
+  });
+
+  test('rx.Observable.bufferCount.shouldThrow.invalidCount.isNull.asBuffer',
+      () {
     new Observable.fromIterable(const [1, 2, 3, 4])
         .buffer(onCount(null))
+        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
+      expect(e, isArgumentError);
+    }));
+  });
+
+  test(
+      'rx.Observable.bufferCount.startBufferEvery.shouldThrow.invalidStartBufferEvery',
+      () {
+    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+        .bufferCount(2, -1)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
     }));

--- a/test/transformers/buffer_count_test.dart
+++ b/test/transformers/buffer_count_test.dart
@@ -4,7 +4,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('rx.Observable.bufferCount.noSkip', () async {
+  test('rx.Observable.bufferCount.noStartBufferEvery', () async {
     const expectedOutput = [
       [1, 2],
       [3, 4]
@@ -21,7 +21,7 @@ void main() {
     }, count: expectedOutput.length));
   });
 
-  test('rx.Observable.bufferCount.noSkip.asBuffer', () async {
+  test('rx.Observable.bufferCount.noStartBufferEvery.asBuffer', () async {
     const expectedOutput = [
       [1, 2],
       [3, 4]
@@ -43,7 +43,8 @@ void main() {
     const expectedOutput = [
       [1, 2],
       [2, 3],
-      [3, 4]
+      [3, 4],
+      [4]
     ];
     var count = 0;
 
@@ -64,7 +65,8 @@ void main() {
     const expectedOutput = [
       [1, 2, 3],
       [3, 4, 5],
-      [5, 6, 7]
+      [5, 6, 7],
+      [7, 8]
     ];
     var count = 0;
 
@@ -116,7 +118,8 @@ void main() {
     const expectedOutput = [
       [1, 2],
       [2, 3],
-      [3, 4]
+      [3, 4],
+      [4]
     ];
     var count = 0;
 

--- a/test/transformers/pairwise_test.dart
+++ b/test/transformers/pairwise_test.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('rx.Observable.pairwise', () async {
+    const expectedOutput = [
+      [1, 2],
+      [2, 3],
+      [3, 4]
+    ];
+    var count = 0;
+
+    final stream = Observable.range(1, 4).pairwise();
+
+    stream.listen(expectAsync1((result) {
+      // test to see if the combined output matches
+      expect(expectedOutput[count].length, result.length);
+      expect(expectedOutput[count][0], result[0]);
+      if (expectedOutput[count].length > 1)
+        expect(expectedOutput[count][1], result[1]);
+      count++;
+    }, count: expectedOutput.length));
+  });
+
+  test('rx.Observable.pairwise.asBroadcastStream', () async {
+    final stream = new Observable(
+            new Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
+        .pairwise();
+
+    // listen twice on same stream
+    stream.listen(null);
+    stream.listen(null);
+    // code should reach here
+    await expectLater(true, true);
+  });
+
+  test('rx.Observable.pairwise.error.shouldThrow.onError', () async {
+    final observableWithError =
+        new Observable(new ErrorStream<void>(new Exception())).pairwise();
+
+    observableWithError.listen(null,
+        onError: expectAsync2((Exception e, StackTrace s) {
+      expect(e, isException);
+    }));
+  });
+}

--- a/test/transformers/window_count_test.dart
+++ b/test/transformers/window_count_test.dart
@@ -40,7 +40,8 @@ void main() {
     }, count: expectedOutput.length));
   });
 
-  test('rx.Observable.windowCount.skip', () async {
+  test('rx.Observable.windowCount.startBufferEvery.count2startBufferEvery1',
+      () async {
     const expectedOutput = [
       [1, 2],
       [2, 3],
@@ -61,7 +62,8 @@ void main() {
     }, count: expectedOutput.length));
   });
 
-  test('rx.Observable.windowCount.skip2', () async {
+  test('rx.Observable.windowCount.startBufferEvery.count3startBufferEvery2',
+      () async {
     const expectedOutput = [
       [1, 2, 3],
       [3, 4, 5],
@@ -69,7 +71,8 @@ void main() {
     ];
     var count = 0;
 
-    final stream = Observable.range(1, 8).windowCount(3, 2).asyncMap((s) => s.toList());
+    final stream =
+        Observable.range(1, 8).windowCount(3, 2).asyncMap((s) => s.toList());
 
     bool equalLists(List<int> lA, List<int> lB) {
       for (var i = 0, len = lA.length; i < len; i++) {
@@ -87,14 +90,16 @@ void main() {
     }, count: expectedOutput.length));
   });
 
-  test('rx.Observable.windowCount.skip3', () async {
+  test('rx.Observable.windowCount.startBufferEvery.count3startBufferEvery4',
+      () async {
     const expectedOutput = [
       [1, 2, 3],
       [5, 6, 7]
     ];
     var count = 0;
 
-    final stream = Observable.range(1, 8).windowCount(3, 4).asyncMap((s) => s.toList());
+    final stream =
+        Observable.range(1, 8).windowCount(3, 4).asyncMap((s) => s.toList());
 
     bool equalLists(List<int> lA, List<int> lB) {
       for (var i = 0, len = lA.length; i < len; i++) {
@@ -112,7 +117,7 @@ void main() {
     }, count: expectedOutput.length));
   });
 
-  test('rx.Observable.windowCount.skip.asWindow', () async {
+  test('rx.Observable.windowCount.startBufferEvery.asWindow', () async {
     const expectedOutput = [
       [1, 2],
       [2, 3],
@@ -215,17 +220,45 @@ void main() {
     }));
   });
 
-  test('rx.Observable.windowCount.skip.shouldThrowB', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+  test('rx.Observable.windowCount.shouldThrow.invalidCount.negative', () {
+    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+        .windowCount(-1)
+        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
+      expect(e, isArgumentError);
+    }));
+  });
+
+  test('rx.Observable.windowCount.shouldThrow.invalidCount.isNull', () {
+    new Observable<int>.fromIterable(const [1, 2, 3, 4])
         .windowCount(null)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
     }));
   });
 
-  test('rx.Observable.windowCount.skip.shouldThrowB.asWindow', () {
+  test('rx.Observable.windowCount.shouldThrow.invalidCount.negative.asBuffer',
+      () {
+    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+        .window(onCount(-1))
+        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
+      expect(e, isArgumentError);
+    }));
+  });
+
+  test('rx.Observable.windowCount.shouldThrow.invalidCount.isNull.asBuffer',
+      () {
     new Observable.fromIterable(const [1, 2, 3, 4])
         .window(onCount(null))
+        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
+      expect(e, isArgumentError);
+    }));
+  });
+
+  test(
+      'rx.Observable.windowCount.startBufferEvery.shouldThrow.invalidStartBufferEvery',
+      () {
+    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+        .windowCount(2, -1)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
     }));

--- a/test/transformers/window_count_test.dart
+++ b/test/transformers/window_count_test.dart
@@ -19,7 +19,7 @@ void main() {
       expect(expectedOutput[count][0], result[0]);
       expect(expectedOutput[count][1], result[1]);
       count++;
-    }, count: 2));
+    }, count: expectedOutput.length));
   });
 
   test('rx.Observable.windowCount.noSkip.asWindow', () async {
@@ -37,15 +37,14 @@ void main() {
       expect(expectedOutput[count][0], result[0]);
       expect(expectedOutput[count][1], result[1]);
       count++;
-    }, count: 2));
+    }, count: expectedOutput.length));
   });
 
   test('rx.Observable.windowCount.skip', () async {
     const expectedOutput = [
       [1, 2],
       [2, 3],
-      [3, 4],
-      [4]
+      [3, 4]
     ];
     var count = 0;
 
@@ -59,15 +58,65 @@ void main() {
       if (expectedOutput[count].length > 1)
         expect(expectedOutput[count][1], result[1]);
       count++;
-    }, count: 4));
+    }, count: expectedOutput.length));
+  });
+
+  test('rx.Observable.windowCount.skip2', () async {
+    const expectedOutput = [
+      [1, 2, 3],
+      [3, 4, 5],
+      [5, 6, 7]
+    ];
+    var count = 0;
+
+    final stream = Observable.range(1, 8).windowCount(3, 2).asyncMap((s) => s.toList());
+
+    bool equalLists(List<int> lA, List<int> lB) {
+      for (var i = 0, len = lA.length; i < len; i++) {
+        if (lA[i] != lB[i]) return false;
+      }
+
+      return true;
+    }
+
+    stream.listen(expectAsync1((result) {
+      // test to see if the combined output matches
+      expect(expectedOutput[count].length, result.length);
+      expect(equalLists(expectedOutput[count], result), isTrue);
+      count++;
+    }, count: expectedOutput.length));
+  });
+
+  test('rx.Observable.windowCount.skip3', () async {
+    const expectedOutput = [
+      [1, 2, 3],
+      [5, 6, 7]
+    ];
+    var count = 0;
+
+    final stream = Observable.range(1, 8).windowCount(3, 4).asyncMap((s) => s.toList());
+
+    bool equalLists(List<int> lA, List<int> lB) {
+      for (var i = 0, len = lA.length; i < len; i++) {
+        if (lA[i] != lB[i]) return false;
+      }
+
+      return true;
+    }
+
+    stream.listen(expectAsync1((result) {
+      // test to see if the combined output matches
+      expect(expectedOutput[count].length, result.length);
+      expect(equalLists(expectedOutput[count], result), isTrue);
+      count++;
+    }, count: expectedOutput.length));
   });
 
   test('rx.Observable.windowCount.skip.asWindow', () async {
     const expectedOutput = [
       [1, 2],
       [2, 3],
-      [3, 4],
-      [4]
+      [3, 4]
     ];
     var count = 0;
 
@@ -82,7 +131,7 @@ void main() {
       if (expectedOutput[count].length > 1)
         expect(expectedOutput[count][1], result[1]);
       count++;
-    }, count: 4));
+    }, count: expectedOutput.length));
   });
 
   test('rx.Observable.windowCount.reusable', () async {
@@ -102,7 +151,7 @@ void main() {
       expect(expectedOutput[countA][0], result[0]);
       expect(expectedOutput[countA][1], result[1]);
       countA++;
-    }, count: 2));
+    }, count: expectedOutput.length));
 
     final streamB = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer)
@@ -113,7 +162,7 @@ void main() {
       expect(expectedOutput[countB][0], result[0]);
       expect(expectedOutput[countB][1], result[1]);
       countB++;
-    }, count: 2));
+    }, count: expectedOutput.length));
   });
 
   test('rx.Observable.windowCount.asBroadcastStream', () async {
@@ -168,29 +217,13 @@ void main() {
 
   test('rx.Observable.windowCount.skip.shouldThrowB', () {
     new Observable.fromIterable(const [1, 2, 3, 4])
-        .windowCount(2, 100)
-        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
-      expect(e, isArgumentError);
-    }));
-  });
-
-  test('rx.Observable.windowCount.skip.shouldThrowB.asWindow', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
-        .window(onCount(2, 100))
-        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
-      expect(e, isArgumentError);
-    }));
-  });
-
-  test('rx.Observable.windowCount.skip.shouldThrowC', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
         .windowCount(null)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
     }));
   });
 
-  test('rx.Observable.windowCount.skip.shouldThrowC.asWindow', () {
+  test('rx.Observable.windowCount.skip.shouldThrowB.asWindow', () {
     new Observable.fromIterable(const [1, 2, 3, 4])
         .window(onCount(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {

--- a/test/transformers/window_count_test.dart
+++ b/test/transformers/window_count_test.dart
@@ -4,7 +4,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('rx.Observable.windowCount.noSkip', () async {
+  test('rx.Observable.windowCount.noStartBufferEvery', () async {
     const expectedOutput = [
       [1, 2],
       [3, 4]
@@ -22,7 +22,7 @@ void main() {
     }, count: expectedOutput.length));
   });
 
-  test('rx.Observable.windowCount.noSkip.asWindow', () async {
+  test('rx.Observable.windowCount.noStartBufferEvery.asWindow', () async {
     const expectedOutput = [
       [1, 2],
       [3, 4]
@@ -45,7 +45,8 @@ void main() {
     const expectedOutput = [
       [1, 2],
       [2, 3],
-      [3, 4]
+      [3, 4],
+      [4]
     ];
     var count = 0;
 
@@ -67,7 +68,8 @@ void main() {
     const expectedOutput = [
       [1, 2, 3],
       [3, 4, 5],
-      [5, 6, 7]
+      [5, 6, 7],
+      [7, 8]
     ];
     var count = 0;
 
@@ -121,7 +123,8 @@ void main() {
     const expectedOutput = [
       [1, 2],
       [2, 3],
-      [3, 4]
+      [3, 4],
+      [4]
     ];
     var count = 0;
 


### PR DESCRIPTION
This fix should properly handle `buffer` on `count` and `window` on `count`, when using the `startBufferEvery` parameter.

This *is* a breaking change:
- startBufferEvery should now work correctly
- when the parent `Stream` completes, we no longer add the remainder `buffer` as a final `event`:
i.e. if the `buffer` is set to group by 3 events, and the parent `Stream` outputs `1, 2, 3, 4`, then the only `event` on `buffer(3)` would be `[1, 2, 3]`. 
Before, we would also dispatch `[4]` as the remainder `onDone`.