### PR TITLE
DeferStream isBroadcast getter was wrong

### DIFF
--- a/lib/src/streams/defer.dart
+++ b/lib/src/streams/defer.dart
@@ -20,6 +20,9 @@ class DeferStream<T> extends Stream<T> {
   final bool _isReusable;
   bool _isUsed = false;
 
+  @override
+  bool get isBroadcast => _isReusable;
+
   DeferStream(this._streamFactory, {bool reusable: false})
       : _isReusable = reusable;
 

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -285,5 +285,14 @@ void main() {
       await expectLater(subject.stream, emits(3));
       await expectLater(subject.stream, emits(3));
     });
+
+    test('is always treated as a broadcast Stream', () async {
+      // ignore: close_sinks
+      final subject = new BehaviorSubject<int>();
+      final stream = subject.asyncMap((event) => new Future.value(event));
+
+      expect(subject.isBroadcast, isTrue);
+      expect(stream.isBroadcast, isTrue);
+    });
   });
 }

--- a/test/subject/publish_subject_test.dart
+++ b/test/subject/publish_subject_test.dart
@@ -287,5 +287,14 @@ void main() {
       await expectLater(
           subject.stream, emitsInOrder(<dynamic>[1, 2, 3, emitsDone]));
     });
+
+    test('is always treated as a broadcast Stream', () async {
+      // ignore: close_sinks
+      final subject = new PublishSubject<int>();
+      final stream = subject.asyncMap((event) => new Future.value(event));
+
+      expect(subject.isBroadcast, isTrue);
+      expect(stream.isBroadcast, isTrue);
+    });
   });
 }

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -282,5 +282,14 @@ void main() {
       await expectLater(subject.stream, emitsInOrder(const <int>[1, 2, 3]));
       await expectLater(subject.stream, emitsInOrder(const <int>[1, 2, 3]));
     });
+
+    test('is always treated as a broadcast Stream', () async {
+      // ignore: close_sinks
+      final subject = new ReplaySubject<int>();
+      final stream = subject.asyncMap((event) => new Future.value(event));
+
+      expect(subject.isBroadcast, isTrue);
+      expect(stream.isBroadcast, isTrue);
+    });
   });
 }


### PR DESCRIPTION
our `DeferStream` would always resolve `isBroadcast` to false, causing the issue seen in https://github.com/ReactiveX/rxdart/issues/213.

This fix treats the internal `_isReusable` as `isBroadcast`, which correctly propagates to the framework on subsequent transformations.