### PR TITLE
adds mapTo operator

### DIFF
--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -1785,6 +1785,16 @@ class Observable<T> extends Stream<T> {
   Observable<S> map<S>(S convert(T event)) =>
       new Observable<S>(_stream.map(convert));
 
+  /// Emits the given constant value on the output Observable every time the source Observable emits a value.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.fromIterable([1, 2, 3, 4])
+  ///       .mapTo(true)
+  ///       .listen(print); // prints true, true, true, true
+  Observable<S> mapTo<S>(S value) =>
+      transform(new MapToStreamTransformer<T, S>(value));
+
   /// Converts the onData, on Done, and onError events into [Notification]
   /// objects that are passed into the downstream onData listener.
   ///

--- a/lib/src/transformers/map_to.dart
+++ b/lib/src/transformers/map_to.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+/// Emits the given constant value on the output Observable every time the source Observable emits a value.
+///
+/// ### Example
+///
+///     Observable.fromIterable([1, 2, 3, 4])
+///       .mapTo(true)
+///       .listen(print); // prints true, true, true, true
+class MapToStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
+  final StreamTransformer<S, T> transformer;
+
+  MapToStreamTransformer(T value) : transformer = _buildTransformer(value);
+
+  @override
+  Stream<T> bind(Stream<S> stream) => transformer.bind(stream);
+
+  static StreamTransformer<S, T> _buildTransformer<S, T>(T value) =>
+      new StreamTransformer<S, T>((Stream<S> input, bool cancelOnError) {
+        StreamController<T> controller;
+        StreamSubscription<S> subscription;
+
+        controller = new StreamController<T>(
+            sync: true,
+            onListen: () {
+              subscription = input.listen((_) => controller.add(value),
+                  onError: controller.addError,
+                  onDone: controller.close,
+                  cancelOnError: cancelOnError);
+            },
+            onPause: ([Future<dynamic> resumeSignal]) =>
+                subscription.pause(resumeSignal),
+            onResume: () => subscription.resume(),
+            onCancel: () => subscription.cancel());
+
+        return controller.stream.listen(null);
+      });
+}

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -14,6 +14,7 @@ export 'package:rxdart/src/transformers/flat_map.dart';
 export 'package:rxdart/src/transformers/flat_map_latest.dart';
 export 'package:rxdart/src/transformers/ignore_elements.dart';
 export 'package:rxdart/src/transformers/interval.dart';
+export 'package:rxdart/src/transformers/map_to.dart';
 export 'package:rxdart/src/transformers/materialize.dart';
 export 'package:rxdart/src/transformers/of_type.dart';
 export 'package:rxdart/src/transformers/on_error_resume_next.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -77,6 +77,7 @@ import 'transformers/is_empty_test.dart' as is_empty_test;
 import 'transformers/join_test.dart' as join_test;
 import 'transformers/last_test.dart' as last_test;
 import 'transformers/last_where_test.dart' as last_where_test;
+import 'transformers/map_to_test.dart' as map_to_test;
 import 'transformers/materialize_test.dart' as materialize_test;
 import 'transformers/merge_with_test.dart' as merge_with_test;
 import 'transformers/of_type_test.dart' as of_type_test;
@@ -184,6 +185,7 @@ void main() {
   join_test.main();
   last_test.main();
   last_where_test.main();
+  map_to_test.main();
   materialize_test.main();
   merge_with_test.main();
   of_type_test.main();

--- a/test/transformers/map_to_test.dart
+++ b/test/transformers/map_to_test.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('rx.Observable.mapTo', () async {
+    await expectLater(Observable.range(1, 4).mapTo(true),
+        emitsInOrder(<dynamic>[true, true, true, true, emitsDone]));
+  });
+
+  test('rx.Observable.mapTo.shouldThrow', () async {
+    await expectLater(
+        Observable.range(1, 4)
+            .concatWith([new ErrorStream<int>(new Error())]).mapTo(true),
+        emitsInOrder(<dynamic>[
+          true,
+          true,
+          true,
+          true,
+          emitsError(new TypeMatcher<Error>()),
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.mapTo.reusable', () async {
+    final transformer = new MapToStreamTransformer<int, bool>(true);
+    final observable = Observable.range(1, 4).asBroadcastStream();
+
+    observable.transform(transformer).listen(null);
+    observable.transform(transformer).listen(null);
+
+    await expectLater(true, true);
+  });
+
+  test('rx.Observable.mapTo.pause.resume', () async {
+    StreamSubscription<bool> subscription;
+    final stream = Observable.just(1).mapTo(true);
+
+    subscription = stream.listen(expectAsync1((value) {
+      expect(value, isTrue);
+
+      subscription.cancel();
+    }, count: 1));
+
+    subscription.pause();
+    subscription.resume();
+  });
+}


### PR DESCRIPTION
A very simple mapper, works by simply transforming each event into a constant value, see https://www.learnrxjs.io/operators/transformation/mapto.html

Thought it'd be useful to add, and makes the following example more terse:
```
Observable(element.click)
    .map((_) => 'clicked!');
```
becomes:
```
Observable(element.click)
    .mapTo('clicked!');
```