### PR TITLE
Debounce selector

### DIFF
--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -1326,15 +1326,51 @@ class Observable<T> extends Stream<T> {
   /// The Debounce operator filters out items emitted by the source Observable
   /// that are rapidly followed by another emitted item.
   ///
+  /// If [duration] is null, then the events are emitted immediately.
+  ///
   /// [Interactive marble diagram](http://rxmarbles.com/#debounce)
   ///
   /// ### Example
   ///
   ///     new Observable.range(1, 100)
-  ///       .debounce(new Duration(seconds: 1))
+  ///       .debounce(const Duration(seconds: 1))
   ///       .listen(print); // prints 100
   Observable<T> debounce(Duration duration) =>
-      transform(new DebounceStreamTransformer<T>(duration));
+      transform(new DebounceStreamTransformer<T>((_) => duration));
+
+  /// Creates an Observable that will only emit items from the source sequence
+  /// if a particular time span has passed without the source sequence emitting
+  /// another item.
+  ///
+  /// The Debounce operator filters out items emitted by the source Observable
+  /// that are rapidly followed by another emitted item.
+  ///
+  /// The debounceSelector can resolve an arbitrary timeout, based on the
+  /// last emitted value.
+  ///
+  /// If [debounceSelector] resolves to null,
+  /// then the events are emitted immediately.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#debounce)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.range(1, 100)
+  ///       .debounceSelector((value) {
+  ///         if (value <= 50) {
+  ///           // short pause if the value is <= 50
+  ///           return const Duration(seconds: 1);
+  ///         } else if (value <= 75) {
+  ///           // long pause if value is > 50 and <= 75
+  ///           return const Duration(seconds: 10);
+  ///         }
+  ///
+  ///         // for the remaining events > 75, do not use a timeout
+  ///         return null;
+  ///       })
+  ///       .listen(print); // prints 100
+  Observable<T> debounceSelector(Duration durationSelector(T event)) =>
+      transform(new DebounceStreamTransformer<T>(durationSelector));
 
   /// Emit items from the source Stream, or a single default item if the source
   /// Stream emits nothing.

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -1348,7 +1348,7 @@ class Observable<T> extends Stream<T> {
   /// The debounceSelector can resolve an arbitrary timeout, based on the
   /// last emitted value.
   ///
-  /// If [debounceSelector] resolves to null,
+  /// If [durationSelector] resolves to null,
   /// then the events are emitted immediately.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#debounce)

--- a/lib/src/transformers/debounce.dart
+++ b/lib/src/transformers/debounce.dart
@@ -1,11 +1,17 @@
 import 'dart:async';
 
-/// Transforms a Stream so that will only emit items from the source sequence
+/// Creates an Observable that will only emit items from the source sequence
 /// if a particular time span has passed without the source sequence emitting
 /// another item.
 ///
-/// The Debounce Transformer filters out items emitted by the source Observable
+/// The Debounce operator filters out items emitted by the source Observable
 /// that are rapidly followed by another emitted item.
+///
+/// The debounceSelector can resolve an arbitrary timeout, based on the
+/// last emitted value.
+///
+/// If durationSelector resolves to null,
+/// then the events are emitted immediately.
 ///
 /// [Interactive marble diagram](http://rxmarbles.com/#debounce)
 ///
@@ -14,6 +20,23 @@ import 'dart:async';
 ///     new Observable.fromIterable([1, 2, 3, 4])
 ///       .debounce(const Duration(seconds: 1))
 ///       .listen(print); // prints 4
+///
+/// ### Example
+///
+///     new Observable.range(1, 100)
+///       .debounceSelector((value) {
+///         if (value <= 50) {
+///           // short pause if the value is <= 50
+///           return const Duration(seconds: 1);
+///         } else if (value <= 75) {
+///           // long pause if value is > 50 and <= 75
+///           return const Duration(seconds: 10);
+///         }
+///
+///         // for the remaining events > 75, do not use a timeout
+///         return null;
+///       })
+///       .listen(print); // prints 100///
 class DebounceStreamTransformer<T> extends StreamTransformerBase<T, T> {
   final StreamTransformer<T, T> transformer;
 


### PR DESCRIPTION
Small change for the `DebounceTransformer`, which now accepts a selector instead of a fixed `Duration`.

As requested in https://github.com/ReactiveX/rxdart/issues/168

On our `Observable`, we now have:
```
debounce(Duration duration);
debounceSelector(Duration durationSelector(T event));
```