### PR TITLE
adds groupBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ var myObservable = Observable.combineLatest3(
 - [exhaustMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/exhaustMap.html) / [ExhaustMapStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/ExhaustMapStreamTransformer-class.html)
 - [flatMap](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/flatMap.html) / [FlatMapStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/FlatMapStreamTransformer-class.html)
 - [flatMapIterable](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/flatMapIterable.html)
+- [groupBy](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/groupBy.html) / [GroupByStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/GroupByStreamTransformer-class.html)
 - [interval](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/interval.html) / [IntervalStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/IntervalStreamTransformer-class.html)
 - [mapTo](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/mapTo.html) / [MapToStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/MapToStreamTransformer-class.html)
 - [materialize](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/materialize.html) / [MaterializeStreamTransformer](https://www.dartdocs.org/documentation/rxdart/latest/rx/MaterializeStreamTransformer-class.html)

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -1596,13 +1596,15 @@ class Observable<T> extends Stream<T> {
       new AsObservableFuture<dynamic>(_stream.forEach(action));
 
   /// The GroupBy operator divides an [Observable] that emits items into
-  /// an [Observable] that emits [Observable],
+  /// an [Observable] that emits [GroupByObservable],
   /// each one of which emits some subset of the items
   /// from the original source [Observable].
   ///
-  /// Which items end up on which Observable is decided by a
-  /// [grouper] that evaluates each item and assigns it a key.
-  /// All items with the same key are emitted by the same Observable.
+  /// [GroupByObservable] acts like a regular [Observable], yet
+  /// adding a 'key' property, which receives its [Type] and value from
+  /// the [grouper] Function.
+  ///
+  /// All items with the same key are emitted by the same [GroupByObservable].
   Observable<GroupByObservable<T, S>> groupBy<S>(S grouper(T value)) =>
       transform(new GroupByStreamTransformer<T, S>(grouper));
 

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -5,8 +5,6 @@ import 'package:rxdart/samplers.dart';
 import 'package:rxdart/src/observables/connectable_observable.dart';
 import 'package:rxdart/src/observables/replay_observable.dart';
 import 'package:rxdart/src/observables/value_observable.dart';
-import 'package:rxdart/src/transformers/group_by.dart'
-    show GroupByStreamTransformer;
 import 'package:rxdart/streams.dart';
 import 'package:rxdart/transformers.dart';
 

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -5,6 +5,8 @@ import 'package:rxdart/samplers.dart';
 import 'package:rxdart/src/observables/connectable_observable.dart';
 import 'package:rxdart/src/observables/replay_observable.dart';
 import 'package:rxdart/src/observables/value_observable.dart';
+import 'package:rxdart/src/transformers/group_by.dart'
+    show GroupByStreamTransformer;
 import 'package:rxdart/streams.dart';
 import 'package:rxdart/transformers.dart';
 
@@ -1594,6 +1596,17 @@ class Observable<T> extends Stream<T> {
   @override
   AsObservableFuture<dynamic> forEach(void action(T element)) =>
       new AsObservableFuture<dynamic>(_stream.forEach(action));
+
+  /// The GroupBy operator divides an [Observable] that emits items into
+  /// an [Observable] that emits [Observable],
+  /// each one of which emits some subset of the items
+  /// from the original source [Observable].
+  ///
+  /// Which items end up on which Observable is decided by a
+  /// [grouper] that evaluates each item and assigns it a key.
+  /// All items with the same key are emitted by the same Observable.
+  Observable<GroupByObservable<T, S>> groupBy<S>(S grouper(T value)) =>
+      transform(new GroupByStreamTransformer<T, S>(grouper));
 
   /// Creates a wrapper Stream that intercepts some errors from this stream.
   ///

--- a/lib/src/transformers/group_by.dart
+++ b/lib/src/transformers/group_by.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:rxdart/src/observables/observable.dart' show Observable;
+
+/// The GroupBy operator divides an [Observable] that emits items into
+/// an [Observable] that emits [Observable],
+/// each one of which emits some subset of the items
+/// from the original source [Observable].
+///
+/// Which items end up on which Observable is decided by a
+/// [grouper] that evaluates each item and assigns it a key.
+/// All items with the same key are emitted by the same Observable.
+
+class GroupByStreamTransformer<T, S>
+    extends StreamTransformerBase<T, GroupByObservable<T, S>> {
+  final S Function(T) grouper;
+
+  GroupByStreamTransformer(this.grouper);
+
+  @override
+  Stream<GroupByObservable<T, S>> bind(Stream<T> stream) =>
+      _buildTransformer<T, S>(grouper).bind(stream);
+
+  static StreamTransformer<T, GroupByObservable<T, S>> _buildTransformer<T, S>(
+      S Function(T) grouper) {
+    return new StreamTransformer<T, GroupByObservable<T, S>>(
+        (Stream<T> input, bool cancelOnError) {
+      final mapper = <S, StreamController<T>>{};
+      StreamController<GroupByObservable<T, S>> controller;
+      StreamSubscription<T> subscription;
+
+      final controllerBuilder = (S forKey) => () {
+            final groupedController = new StreamController<T>();
+
+            controller.add(
+                new GroupByObservable<T, S>(forKey, groupedController.stream));
+
+            return groupedController;
+          };
+
+      controller = new StreamController<GroupByObservable<T, S>>(
+          sync: true,
+          onListen: () {
+            subscription = input.listen(
+                (T value) {
+                  try {
+                    final key = grouper(value);
+                    // ignore: close_sinks
+                    final groupedController =
+                        mapper.putIfAbsent(key, controllerBuilder(key));
+
+                    groupedController.add(value);
+                  } catch (e, s) {
+                    controller.addError(e, s);
+                  }
+                },
+                onError: controller.addError,
+                onDone: () {
+                  mapper.values.forEach((controller) => controller.close());
+                  mapper.clear();
+
+                  controller.close();
+                });
+          },
+          onPause: ([Future<dynamic> resumeSignal]) =>
+              subscription.pause(resumeSignal),
+          onResume: () => subscription.resume(),
+          onCancel: () => subscription.cancel());
+
+      return controller.stream.listen(null);
+    });
+  }
+}
+
+class GroupByObservable<T, S> extends Observable<T> {
+  final S key;
+
+  GroupByObservable(this.key, Stream<T> stream) : super(stream);
+}

--- a/lib/src/transformers/group_by.dart
+++ b/lib/src/transformers/group_by.dart
@@ -3,13 +3,15 @@ import 'dart:async';
 import 'package:rxdart/src/observables/observable.dart' show Observable;
 
 /// The GroupBy operator divides an [Observable] that emits items into
-/// an [Observable] that emits [Observable],
+/// an [Observable] that emits [GroupByObservable],
 /// each one of which emits some subset of the items
 /// from the original source [Observable].
 ///
-/// Which items end up on which Observable is decided by a
-/// [grouper] that evaluates each item and assigns it a key.
-/// All items with the same key are emitted by the same Observable.
+/// [GroupByObservable] acts like a regular [Observable], yet
+/// adding a 'key' property, which receives its [Type] and value from
+/// the [grouper] Function.
+///
+/// All items with the same key are emitted by the same [GroupByObservable].
 
 class GroupByStreamTransformer<T, S>
     extends StreamTransformerBase<T, GroupByObservable<T, S>> {

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -10,6 +10,7 @@ export 'package:rxdart/src/transformers/do.dart';
 export 'package:rxdart/src/transformers/exhaust_map.dart';
 export 'package:rxdart/src/transformers/flat_map.dart';
 export 'package:rxdart/src/transformers/flat_map_latest.dart';
+export 'package:rxdart/src/transformers/group_by.dart';
 export 'package:rxdart/src/transformers/ignore_elements.dart';
 export 'package:rxdart/src/transformers/interval.dart';
 export 'package:rxdart/src/transformers/map_to.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -68,6 +68,7 @@ import 'transformers/flat_map_iterable_test.dart' as flat_map_iterable_test;
 import 'transformers/flat_map_test.dart' as flat_map_test;
 import 'transformers/fold_test.dart' as fold_test;
 import 'transformers/for_each_test.dart' as for_each_test;
+import 'transformers/group_by_test.dart' as group_by_test;
 import 'transformers/handle_error_test.dart' as handle_error_test;
 import 'transformers/ignore_elements_test.dart' as ignore_elements_test;
 import 'transformers/interval_test.dart' as interval_test;
@@ -175,6 +176,7 @@ void main() {
   flat_map_iterable_test.main();
   fold_test.main();
   for_each_test.main();
+  group_by_test.main();
   handle_error_test.main();
   ignore_elements_test.main();
   interval_test.main();

--- a/test/transformers/group_by_test.dart
+++ b/test/transformers/group_by_test.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+String _toEventOdd(int value) => value == 0 ? 'even' : 'odd';
+
+void main() {
+  test('rx.Observable.groupBy', () async {
+    await expectLater(
+        Observable.fromIterable([1, 2, 3, 4]).groupBy((value) => value),
+        emitsInOrder(<Matcher>[
+          TypeMatcher<GroupByObservable<int, int>>()
+              .having((observable) => observable.key, 'key', 1),
+          TypeMatcher<GroupByObservable<int, int>>()
+              .having((observable) => observable.key, 'key', 2),
+          TypeMatcher<GroupByObservable<int, int>>()
+              .having((observable) => observable.key, 'key', 3),
+          TypeMatcher<GroupByObservable<int, int>>()
+              .having((observable) => observable.key, 'key', 4),
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.groupBy.correctlyEmitsGroupEvents', () async {
+    await expectLater(
+        Observable.fromIterable([1, 2, 3, 4])
+            .groupBy((value) => _toEventOdd(value % 2))
+            .flatMap((observable) =>
+                observable.map((event) => {observable.key: event})),
+        emitsInOrder(<dynamic>[
+          {'odd': 1},
+          {'even': 2},
+          {'odd': 3},
+          {'even': 4},
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.groupBy.correctlyEmitsGroupEvents.alternate', () async {
+    await expectLater(
+        Observable.fromIterable([1, 2, 3, 4])
+            .groupBy((value) => _toEventOdd(value % 2))
+            // fold is called when onDone triggers on the Observable
+            .map((observable) async => await observable.fold(
+                {observable.key: <int>[]},
+                (Map<String, List<int>> previous, element) =>
+                    previous..[observable.key].add(element))),
+        emitsInOrder(<dynamic>[
+          {
+            'odd': [1, 3]
+          },
+          {
+            'even': [2, 4]
+          },
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.groupBy.emittedObservablesCallOnDone', () async {
+    await expectLater(
+        Observable.fromIterable([1, 2, 3, 4])
+            .groupBy((value) => value)
+            // drain will emit 'done' onDone
+            .map((observable) async => await observable.drain('done')),
+        emitsInOrder(<dynamic>['done', 'done', 'done', 'done', emitsDone]));
+  });
+
+  test('rx.Observable.groupBy.asBroadcastStream', () async {
+    final stream = new Observable(
+            new Stream.fromIterable([1, 2, 3, 4]).asBroadcastStream())
+        .groupBy((value) => value);
+
+    // listen twice on same stream
+    stream.listen(null);
+    stream.listen(null);
+    // code should reach here
+    await expectLater(true, true);
+  });
+
+  test('rx.Observable.groupBy.pause.resume', () async {
+    var count = 0;
+    StreamSubscription subscription;
+
+    subscription = new Observable(new Stream.fromIterable([1, 2, 3, 4]))
+        .groupBy((value) => value)
+        .listen(expectAsync1((result) {
+          count++;
+
+          if (count == 4) {
+            subscription.cancel();
+          }
+        }, count: 4));
+
+    subscription.pause(Future<void>.delayed(const Duration(milliseconds: 100)));
+  });
+
+  test('rx.Observable.groupBy.error.shouldThrow.onError', () async {
+    final observableWithError =
+        new Observable(new ErrorStream<void>(new Exception()))
+            .groupBy((value) => value);
+
+    observableWithError.listen(null,
+        onError: expectAsync2((Exception e, StackTrace s) {
+      expect(e, isException);
+    }));
+  });
+
+  test('rx.Observable.groupBy.error.shouldThrow.onGrouper', () async {
+    final observableWithError =
+        new Observable(new Stream.fromIterable([1, 2, 3, 4])).groupBy((value) {
+      throw new Exception();
+    });
+
+    observableWithError.listen(null,
+        onError: expectAsync2((Exception e, StackTrace s) {
+          expect(e, isException);
+        }, count: 4));
+  });
+}


### PR DESCRIPTION
Adds groupBy (see https://github.com/ReactiveX/rxdart/issues/235)

This operator takes a `Function`, this method returns a `key` based on the current `event`.
With this `key`, a new `Observable` is created (a `GroupByObservable` which has an extra `key` property).

All events that return the same `key`, are added to the same `GroupByObservable` with that same `key`.