### PR TITLE
dartfmt

### DIFF
--- a/lib/src/futures/as_observable_future.dart
+++ b/lib/src/futures/as_observable_future.dart
@@ -19,6 +19,6 @@ class AsObservableFuture<T> extends WrappedFuture<T> {
   AsObservableFuture(Future<T> wrapped) : super(wrapped);
 
   Observable<T> asObservable() {
-    return new Observable<T>.fromFuture(wrapped);
+    return Observable<T>.fromFuture(wrapped);
   }
 }

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -82,7 +82,7 @@ class Observable<T> extends Stream<T> {
 
   @override
   AsObservableFuture<bool> any(bool test(T element)) =>
-      new AsObservableFuture<bool>(_stream.any(test));
+      AsObservableFuture<bool>(_stream.any(test));
 
   /// Merges the given Streams into one Observable that emits a List of the
   /// values emitted by the source Stream. This is helpful when you need to
@@ -102,7 +102,7 @@ class Observable<T> extends Stream<T> {
   ///     .listen(print); // prints [1, 0], [1, 1], [1, 2]
   static Observable<R> combineLatest<T, R>(
           Iterable<Stream<T>> streams, R combiner(List<T> values)) =>
-      new Observable<R>(CombineLatestStream<T, R>(streams, combiner));
+      Observable<R>(CombineLatestStream<T, R>(streams, combiner));
 
   /// Merges the given Streams into one Observable that emits a List of the
   /// values emitted by the source Stream. This is helpful when you need to
@@ -122,7 +122,7 @@ class Observable<T> extends Stream<T> {
   ///     .listen(print); // prints [1, 0], [1, 1], [1, 2]
   static Observable<List<T>> combineLatestList<T>(
           Iterable<Stream<T>> streams) =>
-      new Observable<List<T>>(CombineLatestStream.list<T>(streams));
+      Observable<List<T>>(CombineLatestStream.list<T>(streams));
 
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an
@@ -142,8 +142,7 @@ class Observable<T> extends Stream<T> {
   ///     .listen(print); //prints 1, 2, 3
   static Observable<T> combineLatest2<A, B, T>(
           Stream<A> streamA, Stream<B> streamB, T combiner(A a, B b)) =>
-      new Observable<T>(
-          CombineLatestStream.combine2(streamA, streamB, combiner));
+      Observable<T>(CombineLatestStream.combine2(streamA, streamB, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an
@@ -164,7 +163,7 @@ class Observable<T> extends Stream<T> {
   ///     .listen(print); //prints "abc", "abc"
   static Observable<T> combineLatest3<A, B, C, T>(Stream<A> streamA,
           Stream<B> streamB, Stream<C> streamC, T combiner(A a, B b, C c)) =>
-      new Observable<T>(
+      Observable<T>(
           CombineLatestStream.combine3(streamA, streamB, streamC, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
@@ -191,7 +190,7 @@ class Observable<T> extends Stream<T> {
           Stream<C> streamC,
           Stream<D> streamD,
           T combiner(A a, B b, C c, D d)) =>
-      new Observable<T>(CombineLatestStream.combine4(
+      Observable<T>(CombineLatestStream.combine4(
           streamA, streamB, streamC, streamD, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
@@ -220,7 +219,7 @@ class Observable<T> extends Stream<T> {
           Stream<D> streamD,
           Stream<E> streamE,
           T combiner(A a, B b, C c, D d, E e)) =>
-      new Observable<T>(CombineLatestStream.combine5(
+      Observable<T>(CombineLatestStream.combine5(
           streamA, streamB, streamC, streamD, streamE, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
@@ -251,7 +250,7 @@ class Observable<T> extends Stream<T> {
           Stream<E> streamE,
           Stream<F> streamF,
           T combiner(A a, B b, C c, D d, E e, F f)) =>
-      new Observable<T>(CombineLatestStream.combine6(
+      Observable<T>(CombineLatestStream.combine6(
           streamA, streamB, streamC, streamD, streamE, streamF, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
@@ -284,7 +283,7 @@ class Observable<T> extends Stream<T> {
           Stream<F> streamF,
           Stream<G> streamG,
           T combiner(A a, B b, C c, D d, E e, F f, G g)) =>
-      new Observable<T>(CombineLatestStream.combine7(streamA, streamB, streamC,
+      Observable<T>(CombineLatestStream.combine7(streamA, streamB, streamC,
           streamD, streamE, streamF, streamG, combiner));
 
   /// Merges the given Streams into one Observable sequence by using the
@@ -319,7 +318,7 @@ class Observable<T> extends Stream<T> {
           Stream<G> streamG,
           Stream<H> streamH,
           T combiner(A a, B b, C c, D d, E e, F f, G g, H h)) =>
-      new Observable<T>(
+      Observable<T>(
         CombineLatestStream.combine8(
           streamA,
           streamB,
@@ -367,7 +366,7 @@ class Observable<T> extends Stream<T> {
           Stream<H> streamH,
           Stream<I> streamI,
           T combiner(A a, B b, C c, D d, E e, F f, G g, H h, I i)) =>
-      new Observable<T>(
+      Observable<T>(
         CombineLatestStream.combine9(
           streamA,
           streamB,
@@ -399,7 +398,7 @@ class Observable<T> extends Stream<T> {
   ///     ])
   ///     .listen(print); // prints 1, 2, 3
   factory Observable.concat(Iterable<Stream<T>> streams) =>
-      new Observable<T>(new ConcatStream<T>(streams));
+      Observable<T>(ConcatStream<T>(streams));
 
   /// Concatenates all of the specified stream sequences, as long as the
   /// previous stream sequence terminated successfully.
@@ -420,7 +419,7 @@ class Observable<T> extends Stream<T> {
   ///     ])
   ///     .listen(print); // prints 1, 2, 3
   factory Observable.concatEager(Iterable<Stream<T>> streams) =>
-      new Observable<T>(new ConcatEagerStream<T>(streams));
+      Observable<T>(ConcatEagerStream<T>(streams));
 
   /// The defer factory waits until an observer subscribes to it, and then it
   /// creates an Observable with the given factory function.
@@ -436,8 +435,9 @@ class Observable<T> extends Stream<T> {
   ///
   ///     new Observable.defer(() => new Observable.just(1))
   ///       .listen(print); //prints 1
-  factory Observable.defer(Stream<T> streamFactory(), {bool reusable: false}) =>
-      new Observable<T>(new DeferStream<T>(streamFactory, reusable: reusable));
+  factory Observable.defer(Stream<T> streamFactory(),
+          {bool reusable = false}) =>
+      Observable<T>(DeferStream<T>(streamFactory, reusable: reusable));
 
   /// Returns an observable sequence that emits an [error], then immediately
   /// completes.
@@ -449,7 +449,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     new Observable.error(new ArgumentError());
   factory Observable.error(Object error) =>
-      new Observable<T>(new ErrorStream<T>(error));
+      Observable<T>(ErrorStream<T>(error));
 
   ///  Creates an Observable where all events of an existing stream are piped
   ///  through a sink-transformation.
@@ -463,7 +463,7 @@ class Observable<T> extends Stream<T> {
   ///  being the sink it received.
   factory Observable.eventTransformed(
           Stream<T> source, EventSink<T> mapSink(EventSink<T> sink)) =>
-      new Observable<T>((new Stream<T>.eventTransformed(source, mapSink)));
+      Observable<T>((Stream<T>.eventTransformed(source, mapSink)));
 
   /// Creates an Observable from the future.
   ///
@@ -475,7 +475,7 @@ class Observable<T> extends Stream<T> {
   ///     new Observable.fromFuture(new Future.value("Hello"))
   ///       .listen(print); // prints "Hello"
   factory Observable.fromFuture(Future<T> future) =>
-      new Observable<T>((new Stream<T>.fromFuture(future)));
+      Observable<T>((Stream<T>.fromFuture(future)));
 
   /// Creates an Observable that gets its data from [data].
   ///
@@ -491,7 +491,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     new Observable.fromIterable([1, 2]).listen(print); // prints 1, 2
   factory Observable.fromIterable(Iterable<T> data) =>
-      new Observable<T>((new Stream<T>.fromIterable(data)));
+      Observable<T>((Stream<T>.fromIterable(data)));
 
   /// Creates an Observable that contains a single value
   ///
@@ -501,7 +501,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///      new Observable.just(1).listen(print); // prints 1
   factory Observable.just(T data) =>
-      new Observable<T>((new Stream<T>.fromIterable(<T>[data])));
+      Observable<T>((Stream<T>.fromIterable(<T>[data])));
 
   /// Creates an Observable that contains no values.
   ///
@@ -511,7 +511,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     new Observable.empty().listen(
   ///       (_) => print("data"), onDone: () => print("done")); // prints "done"
-  factory Observable.empty() => new Observable<T>((new Stream<T>.empty()));
+  factory Observable.empty() => Observable<T>((Stream<T>.empty()));
 
   /// Flattens the items emitted by the given [streams] into a single Observable
   /// sequence.
@@ -526,7 +526,7 @@ class Observable<T> extends Stream<T> {
   ///     ])
   ///     .listen(print); // prints 2, 1
   factory Observable.merge(Iterable<Stream<T>> streams) =>
-      new Observable<T>(new MergeStream<T>(streams));
+      Observable<T>(MergeStream<T>(streams));
 
   /// Returns a non-terminating observable sequence, which can be used to denote
   /// an infinite duration.
@@ -539,7 +539,7 @@ class Observable<T> extends Stream<T> {
   /// ### Example
   ///
   ///     new Observable.never().listen(print); // Neither prints nor terminates
-  factory Observable.never() => new Observable<T>(new NeverStream<T>());
+  factory Observable.never() => Observable<T>(NeverStream<T>());
 
   /// Creates an Observable that repeatedly emits events at [period] intervals.
   ///
@@ -555,7 +555,7 @@ class Observable<T> extends Stream<T> {
   ///        .listen(print); // prints 0, 1, 2
   factory Observable.periodic(Duration period,
           [T computation(int computationCount)]) =>
-      new Observable<T>((new Stream<T>.periodic(period, computation)));
+      Observable<T>((Stream<T>.periodic(period, computation)));
 
   /// Given two or more source [streams], emit all of the items from only
   /// the first of these [streams] to emit an item or notification.
@@ -570,7 +570,7 @@ class Observable<T> extends Stream<T> {
   ///       new Observable.timer(3, new Duration(seconds: 1))
   ///     ]).listen(print); // prints 3
   factory Observable.race(Iterable<Stream<T>> streams) =>
-      new Observable<T>(new RaceStream<T>(streams));
+      Observable<T>(RaceStream<T>(streams));
 
   /// Returns an Observable that emits a sequence of Integers within a specified
   /// range.
@@ -581,7 +581,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     Observable.range(3, 1).listen((i) => print(i)); // Prints 3, 2, 1
   static Observable<int> range(int startInclusive, int endInclusive) =>
-      new Observable<int>(new RangeStream(startInclusive, endInclusive));
+      Observable<int>(RangeStream(startInclusive, endInclusive));
 
   /// Creates a [Stream] that will recreate and re-listen to the source
   /// Stream the specified number of times until the [Stream] terminates
@@ -596,7 +596,7 @@ class Observable<T> extends Stream<T> {
   ///         .listen((i) => print(i)); // Prints 'repeat index: 0, repeat index: 1, repeat index: 2'
   factory Observable.repeat(Stream<T> streamFactory(int repeatIndex),
           [int count]) =>
-      new Observable(new RepeatStream<T>(streamFactory, count));
+      Observable(RepeatStream<T>(streamFactory, count));
 
   /// Creates an Observable that will recreate and re-listen to the source
   /// Stream the specified number of times until the Stream terminates
@@ -618,7 +618,7 @@ class Observable<T> extends Stream<T> {
   ///        }, 1)
   ///        .listen(print, onError: (e, s) => print(e)); // Prints 1, 1, RetryError
   factory Observable.retry(Stream<T> streamFactory(), [int count]) {
-    return new Observable<T>(new RetryStream<T>(streamFactory, count));
+    return Observable<T>(RetryStream<T>(streamFactory, count));
   }
 
   /// Creates a Stream that will recreate and re-listen to the source
@@ -680,8 +680,7 @@ class Observable<T> extends Stream<T> {
   /// ```
   factory Observable.retryWhen(Stream<T> streamFactory(),
       Stream<void> retryWhenFactory(dynamic error, StackTrace stack)) {
-    return new Observable<T>(
-        new RetryWhenStream<T>(streamFactory, retryWhenFactory));
+    return Observable<T>(RetryWhenStream<T>(streamFactory, retryWhenFactory));
   }
 
   /// Convert a Stream that emits Streams (aka a "Higher Order Stream") into a
@@ -709,7 +708,7 @@ class Observable<T> extends Stream<T> {
   /// switchLatestStream.listen(print); // prints 'C'
   /// ```
   factory Observable.switchLatest(Stream<Stream<T>> streams) =>
-      new Observable<T>(new SwitchLatestStream<T>(streams));
+      Observable<T>(SwitchLatestStream<T>(streams));
 
   /// Emits the given value after a specified amount of time.
   ///
@@ -718,7 +717,7 @@ class Observable<T> extends Stream<T> {
   ///     new Observable.timer("hi", new Duration(minutes: 1))
   ///         .listen((i) => print(i)); // print "hi" after 1 minute
   factory Observable.timer(T value, Duration duration) =>
-      new Observable<T>((new TimerStream<T>(value, duration)));
+      Observable<T>((TimerStream<T>(value, duration)));
 
   /// Merges the specified streams into one observable sequence using the given
   /// zipper function whenever all of the observable sequences have produced
@@ -1109,7 +1108,7 @@ class Observable<T> extends Stream<T> {
   Observable<T> asBroadcastStream(
           {void onListen(StreamSubscription<T> subscription),
           void onCancel(StreamSubscription<T> subscription)}) =>
-      new Observable<T>(
+      Observable<T>(
           _stream.asBroadcastStream(onListen: onListen, onCancel: onCancel));
 
   /// Maps each emitted item to a new [Stream] using the given mapper, then
@@ -1132,7 +1131,7 @@ class Observable<T> extends Stream<T> {
   ///       .listen(print); // prints 4, 3, 2, 1
   @override
   Observable<S> asyncExpand<S>(Stream<S> mapper(T value)) =>
-      new Observable<S>(_stream.asyncExpand(mapper));
+      Observable<S>(_stream.asyncExpand(mapper));
 
   /// Creates an Observable with each data event of this stream asynchronously
   /// mapped to a new event.
@@ -1144,7 +1143,7 @@ class Observable<T> extends Stream<T> {
   /// The returned stream is a broadcast stream if this stream is.
   @override
   Observable<S> asyncMap<S>(FutureOr<S> convert(T value)) =>
-      new Observable<S>(_stream.asyncMap(convert));
+      Observable<S>(_stream.asyncMap(convert));
 
   /// Creates an Observable where each item is a [List] containing the items
   /// from the source sequence, batched by the [sampler].
@@ -1182,7 +1181,7 @@ class Observable<T> extends Stream<T> {
   /// You can create your own sampler by extending [StreamView]
   /// should the above samplers be insufficient for your use case.
   Observable<List<T>> buffer(SamplerBuilder<T, List<T>> sampler) =>
-      transform(new BufferStreamTransformer<T>((Stream<T> stream,
+      transform(BufferStreamTransformer<T>((Stream<T> stream,
               OnDataTransform<T, List<T>> bufferHandler,
               OnDataTransform<List<T>, List<T>> scheduleHandler) =>
           sampler(stream, bufferHandler, scheduleHandler)));
@@ -1209,7 +1208,7 @@ class Observable<T> extends Stream<T> {
   ///       .bufferCount(3, 2)
   ///       .listen(print); // prints [1, 2, 3], [3, 4, 5], [5] done!
   Observable<List<T>> bufferCount(int count, [int startBufferEvery = 0]) =>
-      transform(new BufferStreamTransformer<T>(
+      transform(BufferStreamTransformer<T>(
           onCount<T, List<T>>(count, startBufferEvery)));
 
   /// Creates an Observable where each item is a [List] containing the items
@@ -1221,7 +1220,7 @@ class Observable<T> extends Stream<T> {
   ///       .bufferFuture(() => new Future.delayed(const Duration(milliseconds: 220)))
   ///       .listen(print); // prints [0, 1] [2, 3] [4, 5] ...
   Observable<List<T>> bufferFuture<O>(Future<O> onFutureHandler()) => transform(
-      new BufferStreamTransformer<T>(onFuture<T, List<T>, O>(onFutureHandler)));
+      BufferStreamTransformer<T>(onFuture<T, List<T>, O>(onFutureHandler)));
 
   /// Creates an Observable where each item is a [List] containing the items
   /// from the source sequence, batched whenever [onTestHandler] passes.
@@ -1231,8 +1230,8 @@ class Observable<T> extends Stream<T> {
   ///     new Observable.periodic(const Duration(milliseconds: 100), (int i) => i)
   ///       .bufferTest((i) => i % 2 == 0)
   ///       .listen(print); // prints [0], [1, 2] [3, 4] [5, 6] ...
-  Observable<List<T>> bufferTest(bool onTestHandler(T event)) => transform(
-      new BufferStreamTransformer<T>(onTest<T, List<T>>(onTestHandler)));
+  Observable<List<T>> bufferTest(bool onTestHandler(T event)) =>
+      transform(BufferStreamTransformer<T>(onTest<T, List<T>>(onTestHandler)));
 
   /// Creates an Observable where each item is a [List] containing the items
   /// from the source sequence, sampled on a time frame with [duration].
@@ -1243,7 +1242,7 @@ class Observable<T> extends Stream<T> {
   ///       .bufferTime(const Duration(milliseconds: 220))
   ///       .listen(print); // prints [0, 1] [2, 3] [4, 5] ...
   Observable<List<T>> bufferTime(Duration duration) =>
-      transform(new BufferStreamTransformer<T>(onTime(duration)));
+      transform(BufferStreamTransformer<T>(onTime(duration)));
 
   /// Creates an Observable where each item is a [List] containing the items
   /// from the source sequence, sampled on [onStream].
@@ -1254,7 +1253,7 @@ class Observable<T> extends Stream<T> {
   ///       .bufferWhen(new Stream.periodic(const Duration(milliseconds: 220), (int i) => i))
   ///       .listen(print); // prints [0, 1] [2, 3] [4, 5] ...
   Observable<List<T>> bufferWhen<O>(Stream<O> other) =>
-      transform(new BufferStreamTransformer<T>(onStream(other)));
+      transform(BufferStreamTransformer<T>(onStream(other)));
 
   ///
   /// Adapt this stream to be a `Stream<R>`.
@@ -1264,7 +1263,7 @@ class Observable<T> extends Stream<T> {
   /// each data event emitted by this stream is also an instance of [R].
   ///
   @override
-  Observable<R> cast<R>() => new Observable<R>(_stream.cast<R>());
+  Observable<R> cast<R>() => Observable<R>(_stream.cast<R>());
 
   /// Maps each emitted item to a new [Stream] using the given mapper, then
   /// subscribes to each new stream one after the next until all values are
@@ -1285,7 +1284,7 @@ class Observable<T> extends Stream<T> {
   ///         new Observable.timer(i, new Duration(minutes: i))
   ///       .listen(print); // prints 4, 3, 2, 1
   Observable<S> concatMap<S>(Stream<S> mapper(T value)) =>
-      new Observable<S>(_stream.asyncExpand(mapper));
+      Observable<S>(_stream.asyncExpand(mapper));
 
   /// Returns an Observable that emits all items from the current Observable,
   /// then emits all items from the given observable, one after the next.
@@ -1295,12 +1294,12 @@ class Observable<T> extends Stream<T> {
   ///     new Observable.timer(1, new Duration(seconds: 10))
   ///         .concatWith([new Observable.just(2)])
   ///         .listen(print); // prints 1, 2
-  Observable<T> concatWith(Iterable<Stream<T>> other) => new Observable<T>(
-      new ConcatStream<T>(<Stream<T>>[_stream]..addAll(other)));
+  Observable<T> concatWith(Iterable<Stream<T>> other) =>
+      Observable<T>(ConcatStream<T>(<Stream<T>>[_stream]..addAll(other)));
 
   @override
   AsObservableFuture<bool> contains(Object needle) =>
-      new AsObservableFuture<bool>(_stream.contains(needle));
+      AsObservableFuture<bool>(_stream.contains(needle));
 
   /// Creates an Observable that will only emit items from the source sequence
   /// if a particular time span has passed without the source sequence emitting
@@ -1317,7 +1316,7 @@ class Observable<T> extends Stream<T> {
   ///       .debounce(new Duration(seconds: 1))
   ///       .listen(print); // prints 100
   Observable<T> debounce(Duration duration) =>
-      transform(new DebounceStreamTransformer<T>(duration));
+      transform(DebounceStreamTransformer<T>(duration));
 
   /// Emit items from the source Stream, or a single default item if the source
   /// Stream emits nothing.
@@ -1326,7 +1325,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     new Observable.empty().defaultIfEmpty(10).listen(print); // prints 10
   Observable<T> defaultIfEmpty(T defaultValue) =>
-      transform(new DefaultIfEmptyStreamTransformer<T>(defaultValue));
+      transform(DefaultIfEmptyStreamTransformer<T>(defaultValue));
 
   /// The Delay operator modifies its source Observable by pausing for
   /// a particular increment of time (that you specify) before emitting
@@ -1342,7 +1341,7 @@ class Observable<T> extends Stream<T> {
   ///       .delay(new Duration(seconds: 1))
   ///       .listen(print); // [after one second delay] prints 1, 2, 3, 4 immediately
   Observable<T> delay(Duration duration) =>
-      transform(new DelayStreamTransformer<T>(duration));
+      transform(DelayStreamTransformer<T>(duration));
 
   /// Converts the onData, onDone, and onError [Notification] objects from a
   /// materialized stream into normal onData, onDone, and onError events.
@@ -1366,7 +1365,7 @@ class Observable<T> extends Stream<T> {
   ///         .listen(null, onError: (e, s) { print(e) }); // Prints Exception
   Observable<S> dematerialize<S>() {
     return cast<Notification<S>>()
-        .transform(new DematerializeStreamTransformer<S>());
+        .transform(DematerializeStreamTransformer<S>());
   }
 
   /// WARNING: More commonly known as distinctUntilChanged in other Rx
@@ -1386,7 +1385,7 @@ class Observable<T> extends Stream<T> {
   /// [Interactive marble diagram](http://rxmarbles.com/#distinctUntilChanged)
   @override
   Observable<T> distinct([bool equals(T previous, T next)]) =>
-      new Observable<T>(_stream.distinct(equals));
+      Observable<T>(_stream.distinct(equals));
 
   /// WARNING: More commonly known as distinct in other Rx implementations.
   /// Creates an Observable where data events are skipped if they have already
@@ -1402,7 +1401,7 @@ class Observable<T> extends Stream<T> {
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#distinct)
   Observable<T> distinctUnique({bool equals(T e1, T e2), int hashCode(T e)}) =>
-      transform(new DistinctUniqueStreamTransformer<T>(
+      transform(DistinctUniqueStreamTransformer<T>(
           equals: equals, hashCode: hashCode));
 
   /// Invokes the given callback function when the stream subscription is
@@ -1417,7 +1416,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     subscription.cancel(); // prints "hi"
   Observable<T> doOnCancel(void onCancel()) =>
-      transform(new DoStreamTransformer<T>(onCancel: onCancel));
+      transform(DoStreamTransformer<T>(onCancel: onCancel));
 
   /// Invokes the given callback function when the stream emits an item. In
   /// other implementations, this is called doOnNext.
@@ -1428,7 +1427,7 @@ class Observable<T> extends Stream<T> {
   ///       .doOnData(print)
   ///       .listen(null); // prints 1, 2, 3
   Observable<T> doOnData(void onData(T event)) =>
-      transform(new DoStreamTransformer<T>(onData: onData));
+      transform(DoStreamTransformer<T>(onData: onData));
 
   /// Invokes the given callback function when the stream finishes emitting
   /// items. In other implementations, this is called doOnComplete(d).
@@ -1439,7 +1438,7 @@ class Observable<T> extends Stream<T> {
   ///       .doOnDone(() => print("all set"))
   ///       .listen(null); // prints "all set"
   Observable<T> doOnDone(void onDone()) =>
-      transform(new DoStreamTransformer<T>(onDone: onDone));
+      transform(DoStreamTransformer<T>(onDone: onDone));
 
   /// Invokes the given callback function when the stream emits data, emits
   /// an error, or emits done. The callback receives a [Notification] object.
@@ -1454,7 +1453,7 @@ class Observable<T> extends Stream<T> {
   ///       .doOnEach(print)
   ///       .listen(null); // prints Notification{kind: OnData, value: 1, errorAndStackTrace: null}, Notification{kind: OnDone, value: null, errorAndStackTrace: null}
   Observable<T> doOnEach(void onEach(Notification<T> notification)) =>
-      transform(new DoStreamTransformer<T>(onEach: onEach));
+      transform(DoStreamTransformer<T>(onEach: onEach));
 
   /// Invokes the given callback function when the stream emits an error.
   ///
@@ -1464,7 +1463,7 @@ class Observable<T> extends Stream<T> {
   ///       .doOnError((error, stacktrace) => print("oh no"))
   ///       .listen(null); // prints "Oh no"
   Observable<T> doOnError(Function onError) =>
-      transform(new DoStreamTransformer<T>(onError: onError));
+      transform(DoStreamTransformer<T>(onError: onError));
 
   /// Invokes the given callback function when the stream is first listened to.
   ///
@@ -1474,7 +1473,7 @@ class Observable<T> extends Stream<T> {
   ///       .doOnListen(() => print("Is someone there?"))
   ///       .listen(null); // prints "Is someone there?"
   Observable<T> doOnListen(void onListen()) =>
-      transform(new DoStreamTransformer<T>(onListen: onListen));
+      transform(DoStreamTransformer<T>(onListen: onListen));
 
   /// Invokes the given callback function when the stream subscription is
   /// paused.
@@ -1487,7 +1486,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     subscription.pause(); // prints "Gimme a minute please"
   Observable<T> doOnPause(void onPause(Future<dynamic> resumeSignal)) =>
-      transform(new DoStreamTransformer<T>(onPause: onPause));
+      transform(DoStreamTransformer<T>(onPause: onPause));
 
   /// Invokes the given callback function when the stream subscription
   /// resumes receiving items.
@@ -1501,19 +1500,19 @@ class Observable<T> extends Stream<T> {
   ///     subscription.pause();
   ///     subscription.resume(); "Let's do this!"
   Observable<T> doOnResume(void onResume()) =>
-      transform(new DoStreamTransformer<T>(onResume: onResume));
+      transform(DoStreamTransformer<T>(onResume: onResume));
 
   @override
   AsObservableFuture<S> drain<S>([S futureValue]) =>
-      new AsObservableFuture<S>(_stream.drain(futureValue));
+      AsObservableFuture<S>(_stream.drain(futureValue));
 
   @override
   AsObservableFuture<T> elementAt(int index) =>
-      new AsObservableFuture<T>(_stream.elementAt(index));
+      AsObservableFuture<T>(_stream.elementAt(index));
 
   @override
   AsObservableFuture<bool> every(bool test(T element)) =>
-      new AsObservableFuture<bool>(_stream.every(test));
+      AsObservableFuture<bool>(_stream.every(test));
 
   /// Converts items from the source stream into a new Stream using a given
   /// mapper. It ignores all items from the source stream until the new stream
@@ -1529,7 +1528,7 @@ class Observable<T> extends Stream<T> {
   ///         new Observable.timer(i, new Duration(milliseconds: 75)))
   ///       .listen(print); // prints 0, 2
   Observable<S> exhaustMap<S>(Stream<S> mapper(T value)) =>
-      transform(new ExhaustMapStreamTransformer<T, S>(mapper));
+      transform(ExhaustMapStreamTransformer<T, S>(mapper));
 
   /// Creates an Observable from this stream that converts each element into
   /// zero or more events.
@@ -1542,15 +1541,15 @@ class Observable<T> extends Stream<T> {
   /// individually call convert and expand the events.
   @override
   Observable<S> expand<S>(Iterable<S> convert(T value)) =>
-      new Observable<S>(_stream.expand(convert));
+      Observable<S>(_stream.expand(convert));
 
   @override
-  AsObservableFuture<T> get first => new AsObservableFuture<T>(_stream.first);
+  AsObservableFuture<T> get first => AsObservableFuture<T>(_stream.first);
 
   @override
   AsObservableFuture<T> firstWhere(bool test(T element),
           {dynamic defaultValue(), T orElse()}) =>
-      new AsObservableFuture<T>(_stream.firstWhere(test, orElse: orElse));
+      AsObservableFuture<T>(_stream.firstWhere(test, orElse: orElse));
 
   /// Converts each emitted item into a new Stream using the given mapper
   /// function. The newly created Stream will be be listened to and begin
@@ -1567,7 +1566,7 @@ class Observable<T> extends Stream<T> {
   ///         new Observable.timer(i, new Duration(minutes: i))
   ///       .listen(print); // prints 1, 2, 3, 4
   Observable<S> flatMap<S>(Stream<S> mapper(T value)) =>
-      transform(new FlatMapStreamTransformer<T, S>(mapper));
+      transform(FlatMapStreamTransformer<T, S>(mapper));
 
   /// Converts each item into a new Stream. The Stream must return an
   /// Iterable. Then, each item from the Iterable will be emitted one by one.
@@ -1583,17 +1582,17 @@ class Observable<T> extends Stream<T> {
   ///         new Observable.just([i])
   ///       .listen(print); // prints 1, 2, 3, 4
   Observable<S> flatMapIterable<S>(Stream<Iterable<S>> mapper(T value)) =>
-      transform(new FlatMapStreamTransformer<T, Iterable<S>>(mapper))
+      transform(FlatMapStreamTransformer<T, Iterable<S>>(mapper))
           .expand((Iterable<S> iterable) => iterable);
 
   @override
   AsObservableFuture<S> fold<S>(
           S initialValue, S combine(S previous, T element)) =>
-      new AsObservableFuture<S>(_stream.fold(initialValue, combine));
+      AsObservableFuture<S>(_stream.fold(initialValue, combine));
 
   @override
   AsObservableFuture<dynamic> forEach(void action(T element)) =>
-      new AsObservableFuture<dynamic>(_stream.forEach(action));
+      AsObservableFuture<dynamic>(_stream.forEach(action));
 
   /// The GroupBy operator divides an [Observable] that emits items into
   /// an [Observable] that emits [GroupByObservable],
@@ -1606,7 +1605,7 @@ class Observable<T> extends Stream<T> {
   ///
   /// All items with the same key are emitted by the same [GroupByObservable].
   Observable<GroupByObservable<T, S>> groupBy<S>(S grouper(T value)) =>
-      transform(new GroupByStreamTransformer<T, S>(grouper));
+      transform(GroupByStreamTransformer<T, S>(grouper));
 
   /// Creates a wrapper Stream that intercepts some errors from this stream.
   ///
@@ -1635,7 +1634,7 @@ class Observable<T> extends Stream<T> {
   /// individually perform the test and handle the error.
   @override
   Observable<T> handleError(Function onError, {bool test(dynamic error)}) =>
-      new Observable<T>(_stream.handleError(onError, test: test));
+      Observable<T>(_stream.handleError(onError, test: test));
 
   /// Creates an Observable where all emitted items are ignored, only the
   /// error / completed notifications are passed
@@ -1648,7 +1647,7 @@ class Observable<T> extends Stream<T> {
   ///    ])
   ///    .listen(print, onError: print); // prints Exception
   Observable<T> ignoreElements() =>
-      transform(new IgnoreElementsStreamTransformer<T>());
+      transform(IgnoreElementsStreamTransformer<T>());
 
   /// Creates an Observable that emits each item in the Stream after a given
   /// duration.
@@ -1659,7 +1658,7 @@ class Observable<T> extends Stream<T> {
   ///       .interval(new Duration(seconds: 1))
   ///       .listen((i) => print("$i sec"); // prints 1 sec, 2 sec, 3 sec
   Observable<T> interval(Duration duration) =>
-      transform(new IntervalStreamTransformer<T>(duration));
+      transform(IntervalStreamTransformer<T>(duration));
 
   @override
   bool get isBroadcast {
@@ -1668,19 +1667,19 @@ class Observable<T> extends Stream<T> {
 
   @override
   AsObservableFuture<bool> get isEmpty =>
-      new AsObservableFuture<bool>(_stream.isEmpty);
+      AsObservableFuture<bool>(_stream.isEmpty);
 
   @override
   AsObservableFuture<String> join([String separator = ""]) =>
-      new AsObservableFuture<String>(_stream.join(separator));
+      AsObservableFuture<String>(_stream.join(separator));
 
   @override
-  AsObservableFuture<T> get last => new AsObservableFuture<T>(_stream.last);
+  AsObservableFuture<T> get last => AsObservableFuture<T>(_stream.last);
 
   @override
   AsObservableFuture<T> lastWhere(bool test(T element),
           {Object defaultValue(), T orElse()}) =>
-      new AsObservableFuture<T>(_stream.lastWhere(test, orElse: orElse));
+      AsObservableFuture<T>(_stream.lastWhere(test, orElse: orElse));
 
   /// Adds a subscription to this stream. Returns a [StreamSubscription] which
   /// handles events from the stream using the provided [onData], [onError] and
@@ -1727,8 +1726,7 @@ class Observable<T> extends Stream<T> {
   }
 
   @override
-  AsObservableFuture<int> get length =>
-      new AsObservableFuture<int>(_stream.length);
+  AsObservableFuture<int> get length => AsObservableFuture<int>(_stream.length);
 
   /// Maps values from a source sequence through a function and emits the
   /// returned values.
@@ -1738,7 +1736,7 @@ class Observable<T> extends Stream<T> {
   /// error.
   @override
   Observable<S> map<S>(S convert(T event)) =>
-      new Observable<S>(_stream.map(convert));
+      Observable<S>(_stream.map(convert));
 
   /// Emits the given constant value on the output Observable every time the source Observable emits a value.
   ///
@@ -1748,7 +1746,7 @@ class Observable<T> extends Stream<T> {
   ///       .mapTo(true)
   ///       .listen(print); // prints true, true, true, true
   Observable<S> mapTo<S>(S value) =>
-      transform(new MapToStreamTransformer<T, S>(value));
+      transform(MapToStreamTransformer<T, S>(value));
 
   /// Converts the onData, on Done, and onError events into [Notification]
   /// objects that are passed into the downstream onData listener.
@@ -1766,7 +1764,7 @@ class Observable<T> extends Stream<T> {
   ///         .materialize()
   ///         .listen((i) => print(i)); // Prints onError Notification
   Observable<Notification<T>> materialize() =>
-      transform(new MaterializeStreamTransformer<T>());
+      transform(MaterializeStreamTransformer<T>());
 
   /// Converts a Stream into a Future that completes with the largest item emitted
   /// by the Stream.
@@ -1787,7 +1785,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     print(max); // prints "looooooong"
   AsObservableFuture<T> max([Comparator<T> comparator]) =>
-      new AsObservableFuture<T>(new StreamMaxFuture<T>(_stream, comparator));
+      AsObservableFuture<T>(StreamMaxFuture<T>(_stream, comparator));
 
   /// Combines the items emitted by multiple streams into a single stream of
   /// items. The items are emitted in the order they are emitted by their
@@ -1798,8 +1796,8 @@ class Observable<T> extends Stream<T> {
   ///     new Observable.timer(1, new Duration(seconds: 10))
   ///         .mergeWith([new Observable.just(2)])
   ///         .listen(print); // prints 2, 1
-  Observable<T> mergeWith(Iterable<Stream<T>> streams) => new Observable<T>(
-      new MergeStream<T>(<Stream<T>>[_stream]..addAll(streams)));
+  Observable<T> mergeWith(Iterable<Stream<T>> streams) =>
+      Observable<T>(MergeStream<T>(<Stream<T>>[_stream]..addAll(streams)));
 
   /// Converts a Stream into a Future that completes with the smallest item
   /// emitted by the Stream.
@@ -1820,7 +1818,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     print(min); // prints "short"
   AsObservableFuture<T> min([Comparator<T> comparator]) =>
-      new AsObservableFuture<T>(new StreamMinFuture<T>(_stream, comparator));
+      AsObservableFuture<T>(StreamMinFuture<T>(_stream, comparator));
 
   /// Filters a sequence so that only events of a given type pass
   ///
@@ -1851,7 +1849,7 @@ class Observable<T> extends Stream<T> {
   ///     const TypeToken<Map<Int, String>> kMapIntString =
   ///       const TypeToken<Map<Int, String>>();
   Observable<S> ofType<S>(TypeToken<S> typeToken) =>
-      transform(new OfTypeStreamTransformer<T, S>(typeToken));
+      transform(OfTypeStreamTransformer<T, S>(typeToken));
 
   /// Intercepts error events and switches to the given recovery stream in
   /// that case
@@ -1869,7 +1867,7 @@ class Observable<T> extends Stream<T> {
   ///       .onErrorResumeNext(new Observable.fromIterable([1, 2, 3]))
   ///       .listen(print); // prints 1, 2, 3
   Observable<T> onErrorResumeNext(Stream<T> recoveryStream) => transform(
-      new OnErrorResumeStreamTransformer<T>((dynamic e) => recoveryStream));
+      OnErrorResumeStreamTransformer<T>((dynamic e) => recoveryStream));
 
   /// Intercepts error events and switches to a recovery stream created by the
   /// provided [recoveryFn].
@@ -1893,7 +1891,7 @@ class Observable<T> extends Stream<T> {
   ///           new Observable.just(e is StateError ? 1 : 0)
   ///       .listen(print); // prints 0
   Observable<T> onErrorResume(Stream<T> Function(dynamic error) recoveryFn) =>
-      transform(new OnErrorResumeStreamTransformer<T>(recoveryFn));
+      transform(OnErrorResumeStreamTransformer<T>(recoveryFn));
 
   /// instructs an Observable to emit a particular item when it encounters an
   /// error, and then terminate normally
@@ -1911,8 +1909,8 @@ class Observable<T> extends Stream<T> {
   ///       .onErrorReturn(1)
   ///       .listen(print); // prints 1
   Observable<T> onErrorReturn(T returnValue) =>
-      transform(new OnErrorResumeStreamTransformer<T>(
-          (dynamic e) => new Observable<T>.just(returnValue)));
+      transform(OnErrorResumeStreamTransformer<T>(
+          (dynamic e) => Observable<T>.just(returnValue)));
 
   /// instructs an Observable to emit a particular item created by the
   /// [returnFn] when it encounters an error, and then terminate normally.
@@ -1934,8 +1932,8 @@ class Observable<T> extends Stream<T> {
   ///       .onErrorReturnWith((e) => e is Exception ? 1 : 0)
   ///       .listen(print); // prints 1
   Observable<T> onErrorReturnWith(T Function(dynamic error) returnFn) =>
-      transform(new OnErrorResumeStreamTransformer<T>(
-          (dynamic e) => new Observable<T>.just(returnFn(e))));
+      transform(OnErrorResumeStreamTransformer<T>(
+          (dynamic e) => Observable<T>.just(returnFn(e))));
 
   /// Triggers on the second and subsequent triggerings of the input observable.
   /// The Nth triggering of the input observable passes the arguments from the N-1th and Nth triggering as a pair.
@@ -1946,16 +1944,16 @@ class Observable<T> extends Stream<T> {
   ///       .pairwise()
   ///       .listen(print); // prints [1, 2], [2, 3]
   Observable<List<T>> pairwise() =>
-      transform(new BufferStreamTransformer<T>(onCount<T, List<T>>(2, 1),
+      transform(BufferStreamTransformer<T>(onCount<T, List<T>>(2, 1),
           exhaustBufferOnDone: false));
 
   @override
   AsObservableFuture<dynamic> pipe(StreamConsumer<T> streamConsumer) =>
-      new AsObservableFuture<dynamic>(_stream.pipe(streamConsumer));
+      AsObservableFuture<dynamic>(_stream.pipe(streamConsumer));
 
   @override
   AsObservableFuture<T> reduce(T combine(T previous, T element)) =>
-      new AsObservableFuture<T>(_stream.reduce(combine));
+      AsObservableFuture<T>(_stream.reduce(combine));
 
   /// Returns an Observable that, when the specified sample stream emits
   /// an item or completes, emits the most recently emitted item (if any)
@@ -1968,7 +1966,7 @@ class Observable<T> extends Stream<T> {
   ///       .sample(new Observable.timer(1, new Duration(seconds: 1))
   ///       .listen(print); // prints 3
   Observable<T> sample(Stream<dynamic> sampleStream) =>
-      transform(new SampleStreamTransformer<T>(sampleStream));
+      transform(SampleStreamTransformer<T>(sampleStream));
 
   /// Applies an accumulator function over an observable sequence and returns
   /// each intermediate result. The optional seed value is used as the initial
@@ -1981,14 +1979,14 @@ class Observable<T> extends Stream<T> {
   ///        .listen(print); // prints 1, 3, 6
   Observable<S> scan<S>(S accumulator(S accumulated, T value, int index),
           [S seed]) =>
-      transform(new ScanStreamTransformer<T, S>(accumulator, seed));
+      transform(ScanStreamTransformer<T, S>(accumulator, seed));
 
   @override
-  AsObservableFuture<T> get single => new AsObservableFuture<T>(_stream.single);
+  AsObservableFuture<T> get single => AsObservableFuture<T>(_stream.single);
 
   @override
   AsObservableFuture<T> singleWhere(bool test(T element), {T orElse()}) =>
-      new AsObservableFuture<T>(_stream.singleWhere(test, orElse: orElse));
+      AsObservableFuture<T>(_stream.singleWhere(test, orElse: orElse));
 
   /// Skips the first count data events from this stream.
   ///
@@ -1996,7 +1994,7 @@ class Observable<T> extends Stream<T> {
   /// broadcast stream, the events are only counted from the time the returned
   /// stream is listened to.
   @override
-  Observable<T> skip(int count) => new Observable<T>(_stream.skip(count));
+  Observable<T> skip(int count) => Observable<T>(_stream.skip(count));
 
   /// Starts emitting items only after the given stream emits an item.
   ///
@@ -2009,7 +2007,7 @@ class Observable<T> extends Stream<T> {
   ///       .skipUntil(new Observable.timer(true, new Duration(minutes: 1)))
   ///       .listen(print); // prints 2;
   Observable<T> skipUntil<S>(Stream<S> otherStream) =>
-      transform(new SkipUntilStreamTransformer<T, S>(otherStream));
+      transform(SkipUntilStreamTransformer<T, S>(otherStream));
 
   /// Skip data events from this stream while they are matched by test.
   ///
@@ -2023,7 +2021,7 @@ class Observable<T> extends Stream<T> {
   /// stream is listened to.
   @override
   Observable<T> skipWhile(bool test(T element)) =>
-      new Observable<T>(_stream.skipWhile(test));
+      Observable<T>(_stream.skipWhile(test));
 
   /// Prepends a value to the source Observable.
   ///
@@ -2031,7 +2029,7 @@ class Observable<T> extends Stream<T> {
   ///
   ///     new Observable.just(2).startWith(1).listen(print); // prints 1, 2
   Observable<T> startWith(T startValue) =>
-      transform(new StartWithStreamTransformer<T>(startValue));
+      transform(StartWithStreamTransformer<T>(startValue));
 
   /// Prepends a sequence of values to the source Observable.
   ///
@@ -2040,7 +2038,7 @@ class Observable<T> extends Stream<T> {
   ///     new Observable.just(3).startWithMany([1, 2])
   ///       .listen(print); // prints 1, 2, 3
   Observable<T> startWithMany(List<T> startValues) =>
-      transform(new StartWithManyStreamTransformer<T>(startValues));
+      transform(StartWithManyStreamTransformer<T>(startValues));
 
   /// When the original observable emits no items, this operator subscribes to
   /// the given fallback stream and emits items from that observable instead.
@@ -2067,7 +2065,7 @@ class Observable<T> extends Stream<T> {
   ///     Observable<Data> getThatData =
   ///         memory.switchIfEmpty(disk).switchIfEmpty(network);
   Observable<T> switchIfEmpty(Stream<T> fallbackStream) =>
-      transform(new SwitchIfEmptyStreamTransformer<T>(fallbackStream));
+      transform(SwitchIfEmptyStreamTransformer<T>(fallbackStream));
 
   /// Converts each emitted item into a new Stream using the given mapper
   /// function. The newly created Stream will be be listened to and begin
@@ -2086,7 +2084,7 @@ class Observable<T> extends Stream<T> {
   ///         new Observable.timer(i, new Duration(minutes: i))
   ///       .listen(print); // prints 1
   Observable<S> switchMap<S>(Stream<S> mapper(T value)) =>
-      transform(new SwitchMapStreamTransformer<T, S>(mapper));
+      transform(SwitchMapStreamTransformer<T, S>(mapper));
 
   /// Provides at most the first `n` values of this stream.
   /// Forwards the first n data events of this stream, and all error events, to
@@ -2106,7 +2104,7 @@ class Observable<T> extends Stream<T> {
   /// broadcast stream, the events are only counted from the time the returned
   /// stream is listened to
   @override
-  Observable<T> take(int count) => new Observable<T>(_stream.take(count));
+  Observable<T> take(int count) => Observable<T>(_stream.take(count));
 
   /// Returns the values from the source observable sequence until the other
   /// observable sequence produces a value.
@@ -2120,7 +2118,7 @@ class Observable<T> extends Stream<T> {
   ///       .takeUntil(new Observable.timer(3, new Duration(seconds: 10)))
   ///       .listen(print); // prints 1
   Observable<T> takeUntil<S>(Stream<S> otherStream) =>
-      transform(new TakeUntilStreamTransformer<T, S>(otherStream));
+      transform(TakeUntilStreamTransformer<T, S>(otherStream));
 
   /// Forwards data events while test is successful.
   ///
@@ -2140,7 +2138,7 @@ class Observable<T> extends Stream<T> {
   /// stream is listened to.
   @override
   Observable<T> takeWhile(bool test(T element)) =>
-      new Observable<T>(_stream.takeWhile(test));
+      Observable<T>(_stream.takeWhile(test));
 
   /// Returns an Observable that emits only the first item emitted by the source
   /// Observable during sequential time windows of a specified duration.
@@ -2151,7 +2149,7 @@ class Observable<T> extends Stream<T> {
   ///       .throttle(new Duration(seconds: 1))
   ///       .listen(print); // prints 1
   Observable<T> throttle(Duration duration) =>
-      transform(new ThrottleStreamTransformer<T>(duration));
+      transform(ThrottleStreamTransformer<T>(duration));
 
   /// Records the time interval between consecutive values in an observable
   /// sequence.
@@ -2163,7 +2161,7 @@ class Observable<T> extends Stream<T> {
   ///       .timeInterval()
   ///       .listen(print); // prints TimeInterval{interval: 0:00:01, value: 1}
   Observable<TimeInterval<T>> timeInterval() =>
-      transform(new TimeIntervalStreamTransformer<T>());
+      transform(TimeIntervalStreamTransformer<T>());
 
   /// The Timeout operator allows you to abort an Observable with an onError
   /// termination if that Observable fails to emit any items during a specified
@@ -2172,7 +2170,7 @@ class Observable<T> extends Stream<T> {
   @override
   Observable<T> timeout(Duration timeLimit,
           {void onTimeout(EventSink<T> sink)}) =>
-      new Observable<T>(_stream.timeout(timeLimit, onTimeout: onTimeout));
+      Observable<T>(_stream.timeout(timeLimit, onTimeout: onTimeout));
 
   /// Wraps each item emitted by the source Observable in a [Timestamped] object
   /// that includes the emitted item and the time when the item was emitted.
@@ -2183,25 +2181,24 @@ class Observable<T> extends Stream<T> {
   ///        .timestamp()
   ///        .listen((i) => print(i)); // prints 'TimeStamp{timestamp: XXX, value: 1}';
   Observable<Timestamped<T>> timestamp() {
-    return transform(new TimestampStreamTransformer<T>());
+    return transform(TimestampStreamTransformer<T>());
   }
 
   @override
   Observable<S> transform<S>(StreamTransformer<T, S> streamTransformer) =>
-      new Observable<S>(super.transform(streamTransformer));
+      Observable<S>(super.transform(streamTransformer));
 
   @override
   AsObservableFuture<List<T>> toList() =>
-      new AsObservableFuture<List<T>>(_stream.toList());
+      AsObservableFuture<List<T>>(_stream.toList());
 
   @override
   AsObservableFuture<Set<T>> toSet() =>
-      new AsObservableFuture<Set<T>>(_stream.toSet());
+      AsObservableFuture<Set<T>>(_stream.toSet());
 
   /// Filters the elements of an observable sequence based on the test.
   @override
-  Observable<T> where(bool test(T event)) =>
-      new Observable<T>(_stream.where(test));
+  Observable<T> where(bool test(T event)) => Observable<T>(_stream.where(test));
 
   /// Creates an Observable where each item is a [Stream] containing the items
   /// from the source sequence, batched by the [sampler].
@@ -2249,7 +2246,7 @@ class Observable<T> extends Stream<T> {
   /// You can create your own sampler by extending [StreamView]
   /// should the above samplers be insufficient for your use case.
   Observable<Stream<T>> window(SamplerBuilder<T, Stream<T>> sampler) =>
-      transform(new WindowStreamTransformer<T>((Stream<T> stream,
+      transform(WindowStreamTransformer<T>((Stream<T> stream,
               OnDataTransform<T, Stream<T>> bufferHandler,
               OnDataTransform<Stream<T>, Stream<T>> scheduleHandler) =>
           sampler(stream, bufferHandler, scheduleHandler)));
@@ -2281,8 +2278,7 @@ class Observable<T> extends Stream<T> {
   ///       .flatMap((stream) => stream)
   ///       .listen(print); // prints new Stream emitted, 1, 2, 3 new Stream emitted 3, 4, 5 new Stream emitted 5 done!
   Observable<Stream<T>> windowCount(int count, [int startBufferEvery = 0]) =>
-      transform(
-          new WindowStreamTransformer<T>(onCount(count, startBufferEvery)));
+      transform(WindowStreamTransformer<T>(onCount(count, startBufferEvery)));
 
   /// Creates an Observable where each item is a [Stream] containing the items
   /// from the source sequence, batched whenever [onFutureHandler] completes.
@@ -2295,7 +2291,7 @@ class Observable<T> extends Stream<T> {
   ///       .flatMap((s) => s)
   ///       .listen(print); // prints next window 0, 1, next window 2, 3, ...
   Observable<Stream<T>> windowFuture<O>(Future<O> onFutureHandler()) =>
-      transform(new WindowStreamTransformer<T>(onFuture(onFutureHandler)));
+      transform(WindowStreamTransformer<T>(onFuture(onFutureHandler)));
 
   /// Creates an Observable where each item is a [Stream] containing the items
   /// from the source sequence, batched whenever [onTestHandler] passes.
@@ -2308,7 +2304,7 @@ class Observable<T> extends Stream<T> {
   ///       .flatMap((s) => s)
   ///       .listen(print); // prints next window 0, next window 1, 2 next window 3, 4,  ...
   Observable<Stream<T>> windowTest(bool onTestHandler(T event)) =>
-      transform(new WindowStreamTransformer<T>(onTest(onTestHandler)));
+      transform(WindowStreamTransformer<T>(onTest(onTestHandler)));
 
   /// Creates an Observable where each item is a [Stream] containing the items
   /// from the source sequence, sampled on a time frame with [duration].
@@ -2321,7 +2317,7 @@ class Observable<T> extends Stream<T> {
   ///       .flatMap((s) => s)
   ///       .listen(print); // prints next window 0, 1, next window 2, 3, ...
   Observable<Stream<T>> windowTime(Duration duration) =>
-      transform(new WindowStreamTransformer<T>(onTime(duration)));
+      transform(WindowStreamTransformer<T>(onTime(duration)));
 
   /// Creates an Observable where each item is a [Stream] containing the items
   /// from the source sequence, sampled on [onStream].
@@ -2334,7 +2330,7 @@ class Observable<T> extends Stream<T> {
   ///       .flatMap((s) => s)
   ///       .listen(print); // prints next window 0, 1, next window 2, 3, ...
   Observable<Stream<T>> windowWhen<O>(Stream<O> other) =>
-      transform(new WindowStreamTransformer<T>(onStream(other)));
+      transform(WindowStreamTransformer<T>(onStream(other)));
 
   /// Creates an Observable that emits when the source stream emits, combining
   /// the latest values from the two streams using the provided function.
@@ -2351,8 +2347,7 @@ class Observable<T> extends Stream<T> {
   ///       .listen(print); // prints 4 (due to the async nature of streams)
   Observable<R> withLatestFrom<S, R>(
           Stream<S> latestFromStream, R fn(T t, S s)) =>
-      transform(
-          new WithLatestFromStreamTransformer<T, S, R>(latestFromStream, fn));
+      transform(WithLatestFromStreamTransformer<T, S, R>(latestFromStream, fn));
 
   /// Returns an Observable that combines the current stream together with
   /// another stream using a given zipper function.

--- a/lib/src/streams/amb.dart
+++ b/lib/src/streams/amb.dart
@@ -30,9 +30,9 @@ class AmbStream<T> extends Stream<T> {
 
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {
-      throw new ArgumentError('streams cannot be null');
+      throw ArgumentError('streams cannot be null');
     } else if (streams.isEmpty) {
-      throw new ArgumentError('provide at least 1 stream');
+      throw ArgumentError('provide at least 1 stream');
     }
 
     final subscriptions = <StreamSubscription<T>>[];
@@ -40,7 +40,7 @@ class AmbStream<T> extends Stream<T> {
 
     StreamController<T> controller;
 
-    controller = new StreamController<T>(
+    controller = StreamController<T>(
         sync: true,
         onListen: () {
           void doUpdate(int i, T value) {
@@ -78,7 +78,7 @@ class AmbStream<T> extends Stream<T> {
                 subscriptions.map((StreamSubscription<T> subscription) {
               if (subscription != null) return subscription.cancel();
 
-              return new Future<dynamic>.value();
+              return Future<dynamic>.value();
             }).where((Future<dynamic> cancelFuture) => cancelFuture != null)));
 
     return controller;

--- a/lib/src/streams/concat.dart
+++ b/lib/src/streams/concat.dart
@@ -31,17 +31,17 @@ class ConcatStream<T> extends Stream<T> {
 
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {
-      throw new ArgumentError('Streams cannot be null');
+      throw ArgumentError('Streams cannot be null');
     } else if (streams.isEmpty) {
-      throw new ArgumentError('At least 1 stream needs to be provided');
+      throw ArgumentError('At least 1 stream needs to be provided');
     } else if (streams.any((Stream<T> stream) => stream == null)) {
-      throw new ArgumentError('One of the provided streams is null');
+      throw ArgumentError('One of the provided streams is null');
     }
 
     StreamController<T> controller;
     StreamSubscription<T> subscription;
 
-    controller = new StreamController<T>(
+    controller = StreamController<T>(
         sync: true,
         onListen: () {
           final len = streams.length;

--- a/lib/src/streams/concat_eager.dart
+++ b/lib/src/streams/concat_eager.dart
@@ -33,23 +33,23 @@ class ConcatEagerStream<T> extends Stream<T> {
 
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {
-      throw new ArgumentError('streams cannot be null');
+      throw ArgumentError('streams cannot be null');
     } else if (streams.isEmpty) {
-      throw new ArgumentError('at least 1 stream needs to be provided');
+      throw ArgumentError('at least 1 stream needs to be provided');
     } else if (streams.any((Stream<T> stream) => stream == null)) {
-      throw new ArgumentError('One of the provided streams is null');
+      throw ArgumentError('One of the provided streams is null');
     }
 
-    final subscriptions = new List<StreamSubscription<T>>(streams.length);
+    final subscriptions = List<StreamSubscription<T>>(streams.length);
     final completeEvents =
-        streams != null ? new List<Completer<dynamic>>(streams.length) : null;
+        streams != null ? List<Completer<dynamic>>(streams.length) : null;
     StreamController<T> controller;
 
-    controller = new StreamController<T>(
+    controller = StreamController<T>(
         sync: true,
         onListen: () {
           for (var i = 0, len = streams.length; i < len; i++) {
-            completeEvents[i] = new Completer<dynamic>();
+            completeEvents[i] = Completer<dynamic>();
 
             subscriptions[i] = streams.elementAt(i).listen(controller.add,
                 onError: controller.addError, onDone: () {

--- a/lib/src/streams/defer.dart
+++ b/lib/src/streams/defer.dart
@@ -23,14 +23,14 @@ class DeferStream<T> extends Stream<T> {
   @override
   bool get isBroadcast => _isReusable;
 
-  DeferStream(this._streamFactory, {bool reusable: false})
+  DeferStream(this._streamFactory, {bool reusable = false})
       : _isReusable = reusable;
 
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
     if (_isUsed && !_isReusable)
-      throw new StateError("Stream has already been listened to.");
+      throw StateError("Stream has already been listened to.");
     _isUsed = true;
 
     return _streamFactory().listen(onData,

--- a/lib/src/streams/error.dart
+++ b/lib/src/streams/error.dart
@@ -11,7 +11,7 @@ import 'dart:async';
 ///     new ErrorStream(new ArgumentError());
 class ErrorStream<T> extends Stream<T> {
   final Object error;
-  StreamController<T> controller = new StreamController<T>();
+  StreamController<T> controller = StreamController<T>();
 
   ErrorStream(this.error);
 

--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -27,21 +27,20 @@ class MergeStream<T> extends Stream<T> {
 
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {
-      throw new ArgumentError('streams cannot be null');
+      throw ArgumentError('streams cannot be null');
     } else if (streams.isEmpty) {
-      throw new ArgumentError('at least 1 stream needs to be provided');
+      throw ArgumentError('at least 1 stream needs to be provided');
     } else if (streams.any((Stream<T> stream) => stream == null)) {
-      throw new ArgumentError('One of the provided streams is null');
+      throw ArgumentError('One of the provided streams is null');
     }
 
-    final subscriptions = new List<StreamSubscription<T>>(streams.length);
+    final subscriptions = List<StreamSubscription<T>>(streams.length);
     StreamController<T> controller;
 
-    controller = new StreamController<T>(
+    controller = StreamController<T>(
         sync: true,
         onListen: () {
-          final completedStatus =
-              new List.generate(streams.length, (_) => false);
+          final completedStatus = List.generate(streams.length, (_) => false);
 
           for (var i = 0, len = streams.length; i < len; i++) {
             var stream = streams.elementAt(i);

--- a/lib/src/streams/never.dart
+++ b/lib/src/streams/never.dart
@@ -13,7 +13,7 @@ import 'dart:async';
 ///     new NeverStream().listen(print); // Neither prints nor terminates
 class NeverStream<T> extends Stream<T> {
   // ignore: close_sinks
-  StreamController<T> controller = new StreamController<T>();
+  StreamController<T> controller = StreamController<T>();
 
   NeverStream();
 

--- a/lib/src/streams/race.dart
+++ b/lib/src/streams/race.dart
@@ -27,9 +27,9 @@ class RaceStream<T> extends Stream<T> {
 
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {
-      throw new ArgumentError('streams cannot be null');
+      throw ArgumentError('streams cannot be null');
     } else if (streams.isEmpty) {
-      throw new ArgumentError('provide at least 1 stream');
+      throw ArgumentError('provide at least 1 stream');
     }
 
     final subscriptions = <StreamSubscription<T>>[];
@@ -37,7 +37,7 @@ class RaceStream<T> extends Stream<T> {
 
     StreamController<T> controller;
 
-    controller = new StreamController<T>(
+    controller = StreamController<T>(
         sync: true,
         onListen: () {
           void doUpdate(int i, T value) {
@@ -75,7 +75,7 @@ class RaceStream<T> extends Stream<T> {
                 subscriptions.map((StreamSubscription<T> subscription) {
               if (subscription != null) return subscription.cancel();
 
-              return new Future<dynamic>.value();
+              return Future<dynamic>.value();
             }).where((Future<dynamic> cancelFuture) => cancelFuture != null)));
 
     return controller;

--- a/lib/src/streams/range.dart
+++ b/lib/src/streams/range.dart
@@ -24,7 +24,7 @@ class RangeStream extends Stream<int> {
   static Stream<int> buildStream(int startInclusive, int endInclusive) {
     final length = (endInclusive - startInclusive).abs() + 1;
 
-    return new Stream.fromIterable(new List.generate(
+    return Stream.fromIterable(List.generate(
         length,
         (int i) => startInclusive > endInclusive
             ? startInclusive - i

--- a/lib/src/streams/repeat.dart
+++ b/lib/src/streams/repeat.dart
@@ -28,10 +28,10 @@ class RepeatStream<T> extends Stream<T> {
     void onDone(),
     bool cancelOnError,
   }) {
-    if (_isUsed) throw new StateError("Stream has already been listened to.");
+    if (_isUsed) throw StateError("Stream has already been listened to.");
     _isUsed = true;
 
-    controller = new StreamController<T>(
+    controller = StreamController<T>(
         sync: true,
         onListen: maybeRepeatNext,
         onPause: ([Future<dynamic> resumeSignal]) =>

--- a/lib/src/streams/retry.dart
+++ b/lib/src/streams/retry.dart
@@ -39,10 +39,10 @@ class RetryStream<T> extends Stream<T> {
     void onDone(),
     bool cancelOnError,
   }) {
-    if (_isUsed) throw new StateError("Stream has already been listened to.");
+    if (_isUsed) throw StateError("Stream has already been listened to.");
     _isUsed = true;
 
-    controller = new StreamController<T>(
+    controller = StreamController<T>(
         sync: true,
         onListen: retry,
         onPause: ([Future<dynamic> resumeSignal]) =>
@@ -64,14 +64,14 @@ class RetryStream<T> extends Stream<T> {
       subscription.cancel();
 
       if (count == retryStep) {
-        controller.addError(new RetryError(
+        controller.addError(RetryError(
           'Received an error after attempting $count retries',
-          _errors..add(new ErrorAndStacktrace(e, s)),
+          _errors..add(ErrorAndStacktrace(e, s)),
         ));
         controller.close();
       } else {
         retryStep++;
-        _errors.add(new ErrorAndStacktrace(e, s));
+        _errors.add(ErrorAndStacktrace(e, s));
         retry();
       }
     }, onDone: controller.close, cancelOnError: false);

--- a/lib/src/streams/retry_when.dart
+++ b/lib/src/streams/retry_when.dart
@@ -76,10 +76,10 @@ class RetryWhenStream<T> extends Stream<T> {
     void onDone(),
     bool cancelOnError,
   }) {
-    if (_isUsed) throw new StateError('Stream has already been listened to.');
+    if (_isUsed) throw StateError('Stream has already been listened to.');
     _isUsed = true;
 
-    controller = new StreamController<T>(
+    controller = StreamController<T>(
       sync: true,
       onListen: retry,
       onPause: ([Future<dynamic> resumeSignal]) =>
@@ -106,14 +106,14 @@ class RetryWhenStream<T> extends Stream<T> {
         sub = retryWhenFactory(e, s).listen(
           (dynamic event) {
             sub.cancel();
-            _errors.add(new ErrorAndStacktrace(e, s));
+            _errors.add(ErrorAndStacktrace(e, s));
             retry();
           },
           onError: (dynamic e, StackTrace s) {
             sub.cancel();
-            controller.addError(new RetryError(
+            controller.addError(RetryError(
               'Received an error after attempting to retry.',
-              _errors..add(new ErrorAndStacktrace(e, s)),
+              _errors..add(ErrorAndStacktrace(e, s)),
             ));
             controller.close();
           },

--- a/lib/src/streams/switch_latest.dart
+++ b/lib/src/streams/switch_latest.dart
@@ -59,7 +59,7 @@ class SwitchLatestStream<T> extends Stream<T> {
     StreamSubscription<T> otherSubscription;
     var leftClosed = false, rightClosed = false, hasMainEvent = false;
 
-    controller = new StreamController<T>(
+    controller = StreamController<T>(
         sync: true,
         onListen: () {
           subscription = streams.listen(

--- a/lib/src/streams/timer.dart
+++ b/lib/src/streams/timer.dart
@@ -9,7 +9,7 @@ import 'dart:async';
 class TimerStream<T> extends Stream<T> {
   final T value;
   final Duration duration;
-  final StreamController<T> controller = new StreamController<T>();
+  final StreamController<T> controller = StreamController<T>();
 
   TimerStream(this.value, this.duration);
 
@@ -19,7 +19,7 @@ class TimerStream<T> extends Stream<T> {
     final subscription = controller.stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
-    new Timer(duration, () {
+    Timer(duration, () {
       controller.add(value);
       controller.close();
     });

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -49,25 +49,25 @@ class BehaviorSubject<T> extends Subject<T> implements ValueObservable<T> {
   factory BehaviorSubject({
     void onListen(),
     void onCancel(),
-    bool sync: false,
+    bool sync = false,
   }) {
     // ignore: close_sinks
-    final controller = new StreamController<T>.broadcast(
+    final controller = StreamController<T>.broadcast(
       onListen: onListen,
       onCancel: onCancel,
       sync: sync,
     );
 
-    final wrapper = new _Wrapper<T>();
+    final wrapper = _Wrapper<T>();
 
-    return new BehaviorSubject<T>._(
+    return BehaviorSubject<T>._(
         controller,
-        new Observable<T>.defer(() {
+        Observable<T>.defer(() {
           if (wrapper.latestIsError) {
             scheduleMicrotask(() => controller.addError(
                 wrapper.latestError, wrapper.latestStackTrace));
           } else if (wrapper.latestIsValue) {
-            return new Observable<T>(controller.stream)
+            return Observable<T>(controller.stream)
                 .startWith(wrapper.latestValue);
           }
 
@@ -80,26 +80,26 @@ class BehaviorSubject<T> extends Subject<T> implements ValueObservable<T> {
     T seedValue, {
     void onListen(),
     void onCancel(),
-    bool sync: false,
+    bool sync = false,
   }) {
     // ignore: close_sinks
-    final controller = new StreamController<T>.broadcast(
+    final controller = StreamController<T>.broadcast(
       onListen: onListen,
       onCancel: onCancel,
       sync: sync,
     );
 
-    final wrapper = new _Wrapper<T>.seeded(seedValue);
+    final wrapper = _Wrapper<T>.seeded(seedValue);
 
-    return new BehaviorSubject<T>._(
+    return BehaviorSubject<T>._(
         controller,
-        new Observable<T>.defer(() {
+        Observable<T>.defer(() {
           if (wrapper.latestIsError) {
             scheduleMicrotask(() => controller.addError(
                 wrapper.latestError, wrapper.latestStackTrace));
           }
 
-          return new Observable<T>(controller.stream)
+          return Observable<T>(controller.stream)
               .startWith(wrapper.latestValue);
         }, reusable: true),
         wrapper);

--- a/lib/src/subjects/publish_subject.dart
+++ b/lib/src/subjects/publish_subject.dart
@@ -29,17 +29,18 @@ class PublishSubject<T> extends Subject<T> {
   PublishSubject._(StreamController<T> controller, Observable<T> observable)
       : super(controller, observable);
 
-  factory PublishSubject({void onListen(), void onCancel(), bool sync: false}) {
+  factory PublishSubject(
+      {void onListen(), void onCancel(), bool sync = false}) {
     // ignore: close_sinks
-    final controller = new StreamController<T>.broadcast(
+    final controller = StreamController<T>.broadcast(
       onListen: onListen,
       onCancel: onCancel,
       sync: sync,
     );
 
-    return new PublishSubject<T>._(
+    return PublishSubject<T>._(
       controller,
-      new Observable<T>(controller.stream),
+      Observable<T>(controller.stream),
     );
   }
 }

--- a/lib/src/subjects/replay_subject.dart
+++ b/lib/src/subjects/replay_subject.dart
@@ -51,21 +51,21 @@ class ReplaySubject<T> extends Subject<T> implements ReplayObservable<T> {
     int maxSize,
     void onListen(),
     void onCancel(),
-    bool sync: false,
+    bool sync = false,
   }) {
     // ignore: close_sinks
-    final controller = new StreamController<T>.broadcast(
+    final controller = StreamController<T>.broadcast(
       onListen: onListen,
       onCancel: onCancel,
       sync: sync,
     );
 
-    final queue = new Queue<T>();
+    final queue = Queue<T>();
 
-    return new ReplaySubject<T>._(
+    return ReplaySubject<T>._(
       controller,
-      new Observable<T>.defer(
-          () => new Observable<T>(controller.stream)
+      Observable<T>.defer(
+          () => Observable<T>(controller.stream)
               .startWithMany(queue.toList(growable: false)),
           reusable: true),
       queue,

--- a/lib/src/subjects/subject.dart
+++ b/lib/src/subjects/subject.dart
@@ -22,7 +22,7 @@ abstract class Subject<T> extends Observable<T> implements StreamController<T> {
         super(observable);
 
   @override
-  StreamSink<T> get sink => new _StreamSinkWrapper<T>(this);
+  StreamSink<T> get sink => _StreamSinkWrapper<T>(this);
 
   @override
   ControllerCallback get onListen => controller.onListen;
@@ -37,19 +37,19 @@ abstract class Subject<T> extends Observable<T> implements StreamController<T> {
 
   @override
   ControllerCallback get onPause =>
-      throw new UnsupportedError("Subjects do not support pause callbacks");
+      throw UnsupportedError("Subjects do not support pause callbacks");
 
   @override
   set onPause(void onPauseHandler()) =>
-      throw new UnsupportedError("Subjects do not support pause callbacks");
+      throw UnsupportedError("Subjects do not support pause callbacks");
 
   @override
   ControllerCallback get onResume =>
-      throw new UnsupportedError("Subjects do not support resume callbacks");
+      throw UnsupportedError("Subjects do not support resume callbacks");
 
   @override
   set onResume(void onResumeHandler()) =>
-      throw new UnsupportedError("Subjects do not support resume callbacks");
+      throw UnsupportedError("Subjects do not support resume callbacks");
 
   @override
   ControllerCancelCallback get onCancel => controller.onCancel;
@@ -74,7 +74,7 @@ abstract class Subject<T> extends Observable<T> implements StreamController<T> {
   @override
   void addError(Object error, [StackTrace stackTrace]) {
     if (_isAddingStreamItems) {
-      throw new StateError(
+      throw StateError(
           "You cannot add an error while items are being added from addStream");
     }
 
@@ -93,13 +93,13 @@ abstract class Subject<T> extends Observable<T> implements StreamController<T> {
   void onAddError(Object error, [StackTrace stackTrace]) {}
 
   @override
-  Future<dynamic> addStream(Stream<T> source, {bool cancelOnError: true}) {
+  Future<dynamic> addStream(Stream<T> source, {bool cancelOnError = true}) {
     if (_isAddingStreamItems) {
-      throw new StateError(
+      throw StateError(
           "You cannot add items while items are being added from addStream");
     }
 
-    final completer = new Completer<T>();
+    final completer = Completer<T>();
     _isAddingStreamItems = true;
 
     source.listen((T event) {
@@ -122,7 +122,7 @@ abstract class Subject<T> extends Observable<T> implements StreamController<T> {
   @override
   void add(T event) {
     if (_isAddingStreamItems) {
-      throw new StateError(
+      throw StateError(
           "You cannot add items while items are being added from addStream");
     }
 
@@ -143,7 +143,7 @@ abstract class Subject<T> extends Observable<T> implements StreamController<T> {
   @override
   Future<dynamic> close() {
     if (_isAddingStreamItems) {
-      throw new StateError(
+      throw StateError(
           "You cannot close the subject while items are being added from addStream");
     }
 

--- a/lib/src/transformers/buffer.dart
+++ b/lib/src/transformers/buffer.dart
@@ -51,8 +51,7 @@ class BufferStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
       SamplerBuilder<T, List<T>> scheduler, bool exhaustBufferOnDone) {
     assertSampler(scheduler);
 
-    return new StreamTransformer<T, List<T>>(
-        (Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, List<T>>((Stream<T> input, bool cancelOnError) {
       StreamController<List<T>> controller;
       StreamSubscription<List<T>> subscription;
       var buffer = <T>[];
@@ -61,12 +60,12 @@ class BufferStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
         if (controller.isClosed) return;
 
         if (exhaustBufferOnDone && buffer.isNotEmpty)
-          controller.add(new List<T>.from(buffer));
+          controller.add(List<T>.from(buffer));
 
         controller.close();
       }
 
-      controller = new StreamController<List<T>>(
+      controller = StreamController<List<T>>(
           sync: true,
           onListen: () {
             try {
@@ -80,7 +79,7 @@ class BufferStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
               }, (_, EventSink<List<T>> sink, [int startBufferEvery = 0]) {
                 startBufferEvery ?? 0;
 
-                sink.add(new List<T>.unmodifiable(buffer));
+                sink.add(List<T>.unmodifiable(buffer));
                 buffer =
                     startBufferEvery > 0 && startBufferEvery < buffer.length
                         ? buffer.sublist(startBufferEvery)
@@ -104,7 +103,7 @@ class BufferStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
 
   static void assertSampler<T>(SamplerBuilder<T, List<T>> scheduler) {
     if (scheduler == null) {
-      throw new ArgumentError('scheduler cannot be null');
+      throw ArgumentError('scheduler cannot be null');
     }
   }
 }

--- a/lib/src/transformers/debounce.dart
+++ b/lib/src/transformers/debounce.dart
@@ -24,13 +24,13 @@ class DebounceStreamTransformer<T> extends StreamTransformerBase<T, T> {
   Stream<T> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, T> _buildTransformer<T>(Duration duration) {
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       T lastEvent;
       StreamController<T> controller;
       StreamSubscription<T> subscription;
       Timer timer;
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input.listen(
@@ -40,7 +40,7 @@ class DebounceStreamTransformer<T> extends StreamTransformerBase<T, T> {
                   try {
                     _cancelTimerIfActive(timer);
 
-                    timer = new Timer(duration, () {
+                    timer = Timer(duration, () {
                       controller.add(lastEvent);
                       lastEvent = null;
                     });

--- a/lib/src/transformers/default_if_empty.dart
+++ b/lib/src/transformers/default_if_empty.dart
@@ -18,12 +18,12 @@ class DefaultIfEmptyStreamTransformer<T> extends StreamTransformerBase<T, T> {
   Stream<T> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, T> _buildTransformer<T>(T defaultValue) {
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
       var hasEvent = false;
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input.listen(

--- a/lib/src/transformers/delay.dart
+++ b/lib/src/transformers/delay.dart
@@ -23,13 +23,13 @@ class DelayStreamTransformer<T> extends StreamTransformerBase<T, T> {
   Stream<T> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, T> _buildTransformer<T>(Duration duration) {
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       var onDoneCalled = false, hasNoEvents = true;
       var timers = <Timer>[];
       StreamController<T> controller;
       StreamSubscription<T> subscription;
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input.listen(
@@ -38,7 +38,7 @@ class DelayStreamTransformer<T> extends StreamTransformerBase<T, T> {
 
                   try {
                     Timer timer;
-                    timer = new Timer(duration, () {
+                    timer = Timer(duration, () {
                       controller.add(value);
 
                       timers.remove(timer);

--- a/lib/src/transformers/dematerialize.dart
+++ b/lib/src/transformers/dematerialize.dart
@@ -32,12 +32,12 @@ class DematerializeStreamTransformer<T>
   Stream<T> bind(Stream<Notification<T>> stream) => transformer.bind(stream);
 
   static StreamTransformer<Notification<T>, T> _buildTransformer<T>() {
-    return new StreamTransformer<Notification<T>, T>(
+    return StreamTransformer<Notification<T>, T>(
         (Stream<Notification<T>> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<Notification<T>> subscription;
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input.listen((Notification<T> notification) {

--- a/lib/src/transformers/distinct_unique.dart
+++ b/lib/src/transformers/distinct_unique.dart
@@ -32,12 +32,12 @@ class DistinctUniqueStreamTransformer<T> extends StreamTransformerBase<T, T> {
 
   static StreamTransformer<T, T> _buildTransformer<T>(
       bool equals(T e1, T e2), int hashCode(T e)) {
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
-      var collection = new HashSet<T>(equals: equals, hashCode: hashCode);
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+      var collection = HashSet<T>(equals: equals, hashCode: hashCode);
       StreamController<T> controller;
       StreamSubscription<T> subscription;
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input.listen((T value) {

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -82,12 +82,12 @@ class DoStreamTransformer<T> extends StreamTransformerBase<T, T> {
         onListen == null &&
         onPause == null &&
         onResume == null) {
-      throw new ArgumentError("Must provide at least one handler");
+      throw ArgumentError("Must provide at least one handler");
     }
 
     final subscriptions = <Stream<dynamic>, StreamSubscription<dynamic>>{};
 
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       final VoidFunc onListenLocal = () {
         if (onListen != null) {
@@ -111,7 +111,7 @@ class DoStreamTransformer<T> extends StreamTransformerBase<T, T> {
                 }
                 if (onEach != null) {
                   try {
-                    onEach(new Notification<T>.onData(value));
+                    onEach(Notification<T>.onData(value));
                   } catch (e, s) {
                     controller.addError(e, s);
                   }
@@ -128,7 +128,7 @@ class DoStreamTransformer<T> extends StreamTransformerBase<T, T> {
                 }
                 if (onEach != null) {
                   try {
-                    onEach(new Notification<T>.onError(e, s));
+                    onEach(Notification<T>.onError(e, s));
                   } catch (e, s) {
                     controller.addError(e, s);
                   }
@@ -145,7 +145,7 @@ class DoStreamTransformer<T> extends StreamTransformerBase<T, T> {
                 }
                 if (onEach != null) {
                   try {
-                    onEach(new Notification<T>.onDone());
+                    onEach(Notification<T>.onDone());
                   } catch (e, s) {
                     controller.addError(e, s);
                   }
@@ -173,22 +173,22 @@ class DoStreamTransformer<T> extends StreamTransformerBase<T, T> {
         }
         final cancelResultFuture = onCancelResult is Future
             ? onCancelResult
-            : new Future<dynamic>.value(onCancelResult);
+            : Future<dynamic>.value(onCancelResult);
         final cancelFuture =
-            subscriptions[input].cancel() ?? new Future<dynamic>.value();
+            subscriptions[input].cancel() ?? Future<dynamic>.value();
 
         return Future.wait<dynamic>([cancelFuture, cancelResultFuture])
             .whenComplete(() => subscriptions.remove(input));
       };
 
       if (input.isBroadcast) {
-        controller = new StreamController<T>.broadcast(
+        controller = StreamController<T>.broadcast(
           sync: true,
           onListen: onListenLocal,
           onCancel: onCancelLocal,
         );
       } else {
-        controller = new StreamController<T>(
+        controller = StreamController<T>(
           sync: true,
           onListen: onListenLocal,
           onCancel: onCancelLocal,

--- a/lib/src/transformers/exhaust_map.dart
+++ b/lib/src/transformers/exhaust_map.dart
@@ -26,13 +26,13 @@ class ExhaustMapStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
       Stream<S> mapper(T value)) {
-    return new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
       StreamController<S> controller;
       StreamSubscription<T> inputSubscription;
       StreamSubscription<S> outputSubscription;
       var inputClosed = false, outputIsEmitting = false;
 
-      controller = new StreamController<S>(
+      controller = StreamController<S>(
         sync: true,
         onListen: () {
           inputSubscription = input.listen(

--- a/lib/src/transformers/flat_map.dart
+++ b/lib/src/transformers/flat_map.dart
@@ -26,14 +26,14 @@ class FlatMapStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
       Stream<S> mapper(T value)) {
-    return new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
       final subscriptions = <StreamSubscription<S>>[];
       StreamController<S> controller;
       StreamSubscription<T> subscription;
       StreamSubscription<S> otherSubscription;
       var closeAfterNextEvent = false, hasMainEvent = false, openStreams = 0;
 
-      controller = new StreamController<S>(
+      controller = StreamController<S>(
           sync: true,
           onListen: () {
             subscription = input.listen(
@@ -81,9 +81,8 @@ class FlatMapStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
                 otherSubscription.resume());
           },
           onCancel: () {
-            final list =
-                new List<StreamSubscription<dynamic>>.from(subscriptions)
-                  ..add(subscription);
+            final list = List<StreamSubscription<dynamic>>.from(subscriptions)
+              ..add(subscription);
 
             return Future.wait<dynamic>(list
                 .map((StreamSubscription<dynamic> subscription) =>

--- a/lib/src/transformers/flat_map_latest.dart
+++ b/lib/src/transformers/flat_map_latest.dart
@@ -31,13 +31,13 @@ class FlatMapLatestStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
       Stream<S> mapper(T value)) {
-    return new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
       StreamController<S> controller;
       StreamSubscription<T> subscription;
       StreamSubscription<S> otherSubscription;
       var leftClosed = false, rightClosed = false, hasMainEvent = false;
 
-      controller = new StreamController<S>(
+      controller = StreamController<S>(
           sync: true,
           onListen: () {
             subscription = input.listen(

--- a/lib/src/transformers/group_by.dart
+++ b/lib/src/transformers/group_by.dart
@@ -25,22 +25,22 @@ class GroupByStreamTransformer<T, S>
 
   static StreamTransformer<T, GroupByObservable<T, S>> _buildTransformer<T, S>(
       S Function(T) grouper) {
-    return new StreamTransformer<T, GroupByObservable<T, S>>(
+    return StreamTransformer<T, GroupByObservable<T, S>>(
         (Stream<T> input, bool cancelOnError) {
       final mapper = <S, StreamController<T>>{};
       StreamController<GroupByObservable<T, S>> controller;
       StreamSubscription<T> subscription;
 
       final controllerBuilder = (S forKey) => () {
-            final groupedController = new StreamController<T>();
+            final groupedController = StreamController<T>();
 
-            controller.add(
-                new GroupByObservable<T, S>(forKey, groupedController.stream));
+            controller
+                .add(GroupByObservable<T, S>(forKey, groupedController.stream));
 
             return groupedController;
           };
 
-      controller = new StreamController<GroupByObservable<T, S>>(
+      controller = StreamController<GroupByObservable<T, S>>(
           sync: true,
           onListen: () {
             subscription = input.listen(

--- a/lib/src/transformers/ignore_elements.dart
+++ b/lib/src/transformers/ignore_elements.dart
@@ -19,11 +19,11 @@ class IgnoreElementsStreamTransformer<T> extends StreamTransformerBase<T, T> {
   Stream<T> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, T> _buildTransformer<T>() {
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input.listen(null,

--- a/lib/src/transformers/interval.dart
+++ b/lib/src/transformers/interval.dart
@@ -18,18 +18,18 @@ class IntervalStreamTransformer<T> extends StreamTransformerBase<T, T> {
   Stream<T> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, T> _buildTransformer<T>(Duration duration) {
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input.listen((T value) {
               try {
-                final completer = new Completer<T>();
+                final completer = Completer<T>();
 
-                new Timer(duration, () => completer.complete(value));
+                Timer(duration, () => completer.complete(value));
 
                 subscription.pause(completer.future.then<T>((T event) {
                   controller.add(event);

--- a/lib/src/transformers/map_to.dart
+++ b/lib/src/transformers/map_to.dart
@@ -16,11 +16,11 @@ class MapToStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
   Stream<T> bind(Stream<S> stream) => transformer.bind(stream);
 
   static StreamTransformer<S, T> _buildTransformer<S, T>(T value) =>
-      new StreamTransformer<S, T>((Stream<S> input, bool cancelOnError) {
+      StreamTransformer<S, T>((Stream<S> input, bool cancelOnError) {
         StreamController<T> controller;
         StreamSubscription<S> subscription;
 
-        controller = new StreamController<T>(
+        controller = StreamController<T>(
             sync: true,
             onListen: () {
               subscription = input.listen((_) => controller.add(value),

--- a/lib/src/transformers/materialize.dart
+++ b/lib/src/transformers/materialize.dart
@@ -24,24 +24,24 @@ class MaterializeStreamTransformer<T>
   Stream<Notification<T>> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, Notification<T>> _buildTransformer<T>() {
-    return new StreamTransformer<T, Notification<T>>(
+    return StreamTransformer<T, Notification<T>>(
         (Stream<T> input, bool cancelOnError) {
       StreamController<Notification<T>> controller;
       StreamSubscription<T> subscription;
 
-      controller = new StreamController<Notification<T>>(
+      controller = StreamController<Notification<T>>(
           sync: true,
           onListen: () {
             subscription = input.listen((T value) {
               try {
-                controller.add(new Notification<T>.onData(value));
+                controller.add(Notification<T>.onData(value));
               } catch (e, s) {
                 controller.addError(e, s);
               }
             }, onError: (dynamic e, StackTrace s) {
-              controller.add(new Notification<T>.onError(e, s));
+              controller.add(Notification<T>.onError(e, s));
             }, onDone: () {
-              controller.add(new Notification<T>.onDone());
+              controller.add(Notification<T>.onDone());
 
               controller.close();
             }, cancelOnError: cancelOnError);

--- a/lib/src/transformers/of_type.dart
+++ b/lib/src/transformers/of_type.dart
@@ -41,11 +41,11 @@ class OfTypeStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
       TypeToken<S> typeToken) {
-    return new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
       StreamController<S> controller;
       StreamSubscription<T> subscription;
 
-      controller = new StreamController<S>(
+      controller = StreamController<S>(
           sync: true,
           onListen: () {
             subscription = input.listen((T value) {

--- a/lib/src/transformers/on_error_resume.dart
+++ b/lib/src/transformers/on_error_resume.dart
@@ -30,7 +30,7 @@ class OnErrorResumeStreamTransformer<T> extends StreamTransformerBase<T, T> {
   static StreamTransformer<T, T> _buildTransformer<T>(
     Stream<T> Function(dynamic error) recoveryFn,
   ) {
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamSubscription<T> inputSubscription;
       StreamSubscription<T> recoverySubscription;
       StreamController<T> controller;
@@ -42,7 +42,7 @@ class OnErrorResumeStreamTransformer<T> extends StreamTransformerBase<T, T> {
         }
       }
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             inputSubscription = input.listen(

--- a/lib/src/transformers/on_error_resume_next.dart
+++ b/lib/src/transformers/on_error_resume_next.dart
@@ -28,7 +28,7 @@ class OnErrorResumeNextStreamTransformer<T>
 
   static StreamTransformer<T, T> _buildTransformer<T>(
       Stream<T> recoveryStream) {
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamSubscription<T> inputSubscription;
       StreamSubscription<T> recoverySubscription;
       StreamController<T> controller;
@@ -40,7 +40,7 @@ class OnErrorResumeNextStreamTransformer<T>
         }
       }
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             inputSubscription =

--- a/lib/src/transformers/sample.dart
+++ b/lib/src/transformers/sample.dart
@@ -14,7 +14,7 @@ class SampleStreamTransformer<T> extends StreamTransformerBase<T, T> {
   final StreamTransformer<T, T> transformer;
 
   SampleStreamTransformer(Stream<dynamic> sampleStream,
-      {bool sampleOnValueOnly: true})
+      {bool sampleOnValueOnly = true})
       : transformer = _buildTransformer(sampleStream,
             sampleOnValueOnly: sampleOnValueOnly);
 
@@ -23,8 +23,8 @@ class SampleStreamTransformer<T> extends StreamTransformerBase<T, T> {
 
   static StreamTransformer<T, T> _buildTransformer<T>(
       Stream<dynamic> sampleStream,
-      {bool sampleOnValueOnly: true}) {
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+      {bool sampleOnValueOnly = true}) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
       StreamSubscription<dynamic> sampleSubscription;
@@ -50,7 +50,7 @@ class SampleStreamTransformer<T> extends StreamTransformerBase<T, T> {
         }
       }
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             try {

--- a/lib/src/transformers/scan.dart
+++ b/lib/src/transformers/scan.dart
@@ -25,7 +25,7 @@ class ScanStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
     var index = 0;
     var acc = seed;
 
-    return new StreamTransformer<T, S>.fromHandlers(
+    return StreamTransformer<T, S>.fromHandlers(
         handleData: (T data, EventSink<S> sink) {
           acc = accumulator(acc, data, index++);
 

--- a/lib/src/transformers/skip_until.dart
+++ b/lib/src/transformers/skip_until.dart
@@ -22,10 +22,10 @@ class SkipUntilStreamTransformer<T, S> extends StreamTransformerBase<T, T> {
   static StreamTransformer<T, T> _buildTransformer<T, S>(
       Stream<S> otherStream) {
     if (otherStream == null) {
-      throw new ArgumentError('otherStream cannot be null');
+      throw ArgumentError('otherStream cannot be null');
     }
 
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
       StreamSubscription<S> otherSubscription;
@@ -37,7 +37,7 @@ class SkipUntilStreamTransformer<T, S> extends StreamTransformerBase<T, T> {
         controller.close();
       }
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input.listen((T data) {

--- a/lib/src/transformers/start_with.dart
+++ b/lib/src/transformers/start_with.dart
@@ -17,11 +17,11 @@ class StartWithStreamTransformer<T> extends StreamTransformerBase<T, T> {
   Stream<T> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, T> _buildTransformer<T>(T startValue) {
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             try {

--- a/lib/src/transformers/start_with_many.dart
+++ b/lib/src/transformers/start_with_many.dart
@@ -18,14 +18,14 @@ class StartWithManyStreamTransformer<T> extends StreamTransformerBase<T, T> {
 
   static StreamTransformer<T, T> _buildTransformer<T>(Iterable<T> startValues) {
     if (startValues == null) {
-      throw new ArgumentError('startValues cannot be null');
+      throw ArgumentError('startValues cannot be null');
     }
 
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             startValues.forEach(controller.add);

--- a/lib/src/transformers/switch_if_empty.dart
+++ b/lib/src/transformers/switch_if_empty.dart
@@ -36,10 +36,10 @@ class SwitchIfEmptyStreamTransformer<T> extends StreamTransformerBase<T, T> {
   static StreamTransformer<T, T> _buildTransformer<T>(
       Stream<T> fallbackStream) {
     if (fallbackStream == null) {
-      throw new ArgumentError('fallbackStream cannot be null');
+      throw ArgumentError('fallbackStream cannot be null');
     }
 
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> defaultSubscription;
       StreamSubscription<T> switchSubscription;
@@ -52,7 +52,7 @@ class SwitchIfEmptyStreamTransformer<T> extends StreamTransformerBase<T, T> {
         switchSubscription?.cancel();
       }
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             defaultSubscription = input.listen(

--- a/lib/src/transformers/switch_map.dart
+++ b/lib/src/transformers/switch_map.dart
@@ -28,13 +28,13 @@ class SwitchMapStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
 
   static StreamTransformer<T, S> _buildTransformer<T, S>(
       Stream<S> mapper(T value)) {
-    return new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
       StreamController<S> controller;
       StreamSubscription<T> subscription;
       StreamSubscription<S> otherSubscription;
       var leftClosed = false, rightClosed = false, hasMainEvent = false;
 
-      controller = new StreamController<S>(
+      controller = StreamController<S>(
           sync: true,
           onListen: () {
             subscription = input.listen(

--- a/lib/src/transformers/take_until.dart
+++ b/lib/src/transformers/take_until.dart
@@ -24,9 +24,9 @@ class TakeUntilStreamTransformer<T, S> extends StreamTransformerBase<T, T> {
   static StreamTransformer<T, T> _buildTransformer<T, S>(
       Stream<S> otherStream) {
     if (otherStream == null) {
-      throw new ArgumentError("take until stream cannot be null");
+      throw ArgumentError("take until stream cannot be null");
     }
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
       StreamSubscription<S> otherSubscription;
@@ -37,7 +37,7 @@ class TakeUntilStreamTransformer<T, S> extends StreamTransformerBase<T, T> {
         controller.close();
       }
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input.listen(controller.add,

--- a/lib/src/transformers/throttle.dart
+++ b/lib/src/transformers/throttle.dart
@@ -19,10 +19,10 @@ class ThrottleStreamTransformer<T> extends StreamTransformerBase<T, T> {
 
   static StreamTransformer<T, T> _buildTransformer<T>(Duration duration) {
     if (duration == null) {
-      throw new ArgumentError('duration cannot be null');
+      throw ArgumentError('duration cannot be null');
     }
 
-    return new StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, T>((Stream<T> input, bool cancelOnError) {
       StreamController<T> controller;
       StreamSubscription<T> subscription;
       Timer _timer;
@@ -32,7 +32,7 @@ class ThrottleStreamTransformer<T> extends StreamTransformerBase<T, T> {
         if (_timer != null && _timer.isActive) return false;
 
         try {
-          _timer = new Timer(duration, () {
+          _timer = Timer(duration, () {
             if (_closeAfterNextEvent && !controller.isClosed)
               controller.close();
           });
@@ -43,7 +43,7 @@ class ThrottleStreamTransformer<T> extends StreamTransformerBase<T, T> {
         return true;
       }
 
-      controller = new StreamController<T>(
+      controller = StreamController<T>(
           sync: true,
           onListen: () {
             subscription = input

--- a/lib/src/transformers/time_interval.dart
+++ b/lib/src/transformers/time_interval.dart
@@ -19,15 +19,15 @@ class TimeIntervalStreamTransformer<T>
   Stream<TimeInterval<T>> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, TimeInterval<T>> _buildTransformer<T>() {
-    return new StreamTransformer<T, TimeInterval<T>>(
+    return StreamTransformer<T, TimeInterval<T>>(
         (Stream<T> input, bool cancelOnError) {
       StreamController<TimeInterval<T>> controller;
       StreamSubscription<T> subscription;
 
-      controller = new StreamController<TimeInterval<T>>(
+      controller = StreamController<TimeInterval<T>>(
           sync: true,
           onListen: () {
-            var stopwatch = new Stopwatch()..start();
+            var stopwatch = Stopwatch()..start();
             int ems;
 
             subscription = input.listen(
@@ -37,13 +37,13 @@ class TimeIntervalStreamTransformer<T>
                   stopwatch.stop();
 
                   try {
-                    controller.add(new TimeInterval<T>(
-                        value, new Duration(microseconds: ems)));
+                    controller.add(
+                        TimeInterval<T>(value, Duration(microseconds: ems)));
                   } catch (e, s) {
                     controller.addError(e, s);
                   }
 
-                  stopwatch = new Stopwatch()..start();
+                  stopwatch = Stopwatch()..start();
                 },
                 onError: controller.addError,
                 onDone: () {

--- a/lib/src/transformers/timestamp.dart
+++ b/lib/src/transformers/timestamp.dart
@@ -18,16 +18,16 @@ class TimestampStreamTransformer<T>
   Stream<Timestamped<T>> bind(Stream<T> stream) => transformer.bind(stream);
 
   static StreamTransformer<T, Timestamped<T>> _buildTransformer<T>() {
-    return new StreamTransformer<T, Timestamped<T>>(
+    return StreamTransformer<T, Timestamped<T>>(
         (Stream<T> input, bool cancelOnError) {
       StreamController<Timestamped<T>> controller;
       StreamSubscription<Timestamped<T>> subscription;
 
-      controller = new StreamController<Timestamped<T>>(
+      controller = StreamController<Timestamped<T>>(
           sync: true,
           onListen: () {
             subscription = input
-                .map((T value) => new Timestamped<T>(new DateTime.now(), value))
+                .map((T value) => Timestamped<T>(DateTime.now(), value))
                 .listen(controller.add,
                     onError: controller.addError,
                     onDone: controller.close,

--- a/lib/src/transformers/window.dart
+++ b/lib/src/transformers/window.dart
@@ -61,7 +61,7 @@ class WindowStreamTransformer<T> extends StreamTransformerBase<T, Stream<T>> {
       SamplerBuilder<T, Stream<T>> scheduler, bool exhaustBufferOnDone) {
     assertSampler(scheduler);
 
-    return new StreamTransformer<T, Stream<T>>(
+    return StreamTransformer<T, Stream<T>>(
         (Stream<T> input, bool cancelOnError) {
       StreamController<Stream<T>> controller;
       StreamSubscription<Stream<T>> subscription;
@@ -71,23 +71,23 @@ class WindowStreamTransformer<T> extends StreamTransformerBase<T, Stream<T>> {
         if (controller.isClosed) return;
 
         if (exhaustBufferOnDone && buffer.isNotEmpty)
-          controller.add(new Stream<T>.fromIterable(buffer));
+          controller.add(Stream<T>.fromIterable(buffer));
 
         controller.close();
       }
 
-      controller = new StreamController<Stream<T>>(
+      controller = StreamController<Stream<T>>(
           sync: true,
           onListen: () {
             try {
               subscription = scheduler(input, (T data,
                   EventSink<Stream<T>> sink, [int startBufferEvery = 0]) {
                 buffer.add(data);
-                sink.add(new Stream<T>.fromIterable(buffer));
+                sink.add(Stream<T>.fromIterable(buffer));
               }, (_, EventSink<Stream<T>> sink, [int startBufferEvery = 0]) {
                 startBufferEvery ?? 0;
 
-                sink.add(new Stream<T>.fromIterable(buffer));
+                sink.add(Stream<T>.fromIterable(buffer));
                 buffer =
                     startBufferEvery > 0 && startBufferEvery < buffer.length
                         ? buffer.sublist(startBufferEvery)
@@ -111,7 +111,7 @@ class WindowStreamTransformer<T> extends StreamTransformerBase<T, Stream<T>> {
 
   static void assertSampler<T>(SamplerBuilder<T, Stream<T>> scheduler) {
     if (scheduler == null) {
-      throw new ArgumentError('scheduler cannot be null');
+      throw ArgumentError('scheduler cannot be null');
     }
   }
 }

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -27,18 +27,18 @@ class WithLatestFromStreamTransformer<T, S, R>
   static StreamTransformer<T, R> _buildTransformer<T, S, R>(
       Stream<S> latestFromStream, R fn(T t, S s)) {
     if (latestFromStream == null) {
-      throw new ArgumentError('latestFromStream cannot be null');
+      throw ArgumentError('latestFromStream cannot be null');
     } else if (fn == null) {
-      throw new ArgumentError('combiner cannot be null');
+      throw ArgumentError('combiner cannot be null');
     }
 
-    return new StreamTransformer<T, R>((Stream<T> input, bool cancelOnError) {
+    return StreamTransformer<T, R>((Stream<T> input, bool cancelOnError) {
       StreamController<R> controller;
       StreamSubscription<T> subscription;
       StreamSubscription<S> latestFromSubscription;
       S latestValue;
 
-      controller = new StreamController<R>(
+      controller = StreamController<R>(
           sync: true,
           onListen: () {
             subscription = input.listen((T value) {

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -16,7 +16,7 @@ class CompositeSubscription {
   bool _isDisposed = false;
 
   final List<StreamSubscription<dynamic>> _subscriptionsList =
-      new List<StreamSubscription<dynamic>>();
+      List<StreamSubscription<dynamic>>();
 
   /// Checks if this composite is disposed. If it is, the composite can't be used again
   /// and will throw an error if you try to add more subscriptions to it.

--- a/lib/src/utils/notification.dart
+++ b/lib/src/utils/notification.dart
@@ -16,13 +16,13 @@ class Notification<T> {
   Notification(this.kind, this.value, this.error, this.stackTrace);
 
   factory Notification.onData(T value) =>
-      new Notification<T>(Kind.OnData, value, null, null);
+      Notification<T>(Kind.OnData, value, null, null);
 
   factory Notification.onDone() =>
-      new Notification<T>(Kind.OnDone, null, null, null);
+      Notification<T>(Kind.OnDone, null, null, null);
 
   factory Notification.onError(dynamic e, StackTrace s) =>
-      new Notification<T>(Kind.OnError, null, e, s);
+      Notification<T>(Kind.OnError, null, e, s);
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/utils/type_token.dart
+++ b/lib/src/utils/type_token.dart
@@ -24,19 +24,19 @@ class TypeToken<S> {
 }
 
 /// Filter the observable to only Booleans
-const TypeToken<bool> kBool = const TypeToken<bool>();
+const TypeToken<bool> kBool = TypeToken<bool>();
 
 /// Filter the observable to only Doubles
-const TypeToken<double> kDouble = const TypeToken<double>();
+const TypeToken<double> kDouble = TypeToken<double>();
 
 /// Filter the observable to only Integers
-const TypeToken<int> kInt = const TypeToken<int>();
+const TypeToken<int> kInt = TypeToken<int>();
 
 /// Filter the observable to only Numbers
-const TypeToken<num> kNum = const TypeToken<num>();
+const TypeToken<num> kNum = TypeToken<num>();
 
 /// Filter the observable to only Strings
-const TypeToken<String> kString = const TypeToken<String>();
+const TypeToken<String> kString = TypeToken<String>();
 
 /// Filter the observable to only Symbols
-const TypeToken<Symbol> kSymbol = const TypeToken<Symbol>();
+const TypeToken<Symbol> kSymbol = TypeToken<Symbol>();

--- a/test/benchmarks/benchmark_utils.dart
+++ b/test/benchmarks/benchmark_utils.dart
@@ -1,4 +1,4 @@
 import 'package:rxdart/rxdart.dart';
 
 Observable<int> range() =>
-    new Observable<int>.fromIterable(<int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    Observable<int>.fromIterable(<int>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/test/benchmarks/combine_latest_benchmark.dart
+++ b/test/benchmarks/combine_latest_benchmark.dart
@@ -8,7 +8,7 @@ void main() => CombineLatestBenchmark.main();
 class CombineLatestBenchmark extends BenchmarkBase {
   CombineLatestBenchmark() : super("combineLatest");
 
-  static void main() => new CombineLatestBenchmark().report();
+  static void main() => CombineLatestBenchmark().report();
 
   @override
   void run() {

--- a/test/benchmarks/debounce_benchmark.dart
+++ b/test/benchmarks/debounce_benchmark.dart
@@ -7,7 +7,7 @@ void main() => DebounceBenchmark.main();
 class DebounceBenchmark extends BenchmarkBase {
   DebounceBenchmark() : super("debounce");
 
-  static void main() => new DebounceBenchmark().report();
+  static void main() => DebounceBenchmark().report();
 
   @override
   void run() {

--- a/test/benchmarks/flat_map_benchmark.dart
+++ b/test/benchmarks/flat_map_benchmark.dart
@@ -7,7 +7,7 @@ void main() => FlatMapBenchmark.main();
 class FlatMapBenchmark extends BenchmarkBase {
   FlatMapBenchmark() : super("flatMap");
 
-  static void main() => new FlatMapBenchmark().report();
+  static void main() => FlatMapBenchmark().report();
 
   @override
   void run() {

--- a/test/benchmarks/flat_map_latest_benchmark.dart
+++ b/test/benchmarks/flat_map_latest_benchmark.dart
@@ -7,7 +7,7 @@ void main() => SwitchMapBenchmark.main();
 class SwitchMapBenchmark extends BenchmarkBase {
   SwitchMapBenchmark() : super("switchMap");
 
-  static void main() => new SwitchMapBenchmark().report();
+  static void main() => SwitchMapBenchmark().report();
 
   @override
   void run() {

--- a/test/benchmarks/map_benchmark.dart
+++ b/test/benchmarks/map_benchmark.dart
@@ -7,7 +7,7 @@ void main() => MapBenchmark.main();
 class MapBenchmark extends BenchmarkBase {
   MapBenchmark() : super("map");
 
-  static void main() => new MapBenchmark().report();
+  static void main() => MapBenchmark().report();
 
   @override
   void run() {

--- a/test/benchmarks/merge_benchmark.dart
+++ b/test/benchmarks/merge_benchmark.dart
@@ -10,10 +10,10 @@ void main() => MergeBenchmark.main();
 class MergeBenchmark extends BenchmarkBase {
   MergeBenchmark() : super("merge");
 
-  static void main() => new MergeBenchmark().report();
+  static void main() => MergeBenchmark().report();
 
   @override
   void run() {
-    new Observable<int>.merge(<Stream<int>>[range(), range()]).listen(null);
+    Observable<int>.merge(<Stream<int>>[range(), range()]).listen(null);
   }
 }

--- a/test/benchmarks/plain_benchmark.dart
+++ b/test/benchmarks/plain_benchmark.dart
@@ -7,7 +7,7 @@ void main() => PlainBenchmark.main();
 class PlainBenchmark extends BenchmarkBase {
   const PlainBenchmark() : super("plain");
 
-  static void main() => new PlainBenchmark().report();
+  static void main() => PlainBenchmark().report();
 
   @override
   void run() {

--- a/test/benchmarks/start_with_benchmark.dart
+++ b/test/benchmarks/start_with_benchmark.dart
@@ -7,7 +7,7 @@ void main() => StartWithBenchmark.main();
 class StartWithBenchmark extends BenchmarkBase {
   StartWithBenchmark() : super("startWith");
 
-  static void main() => new StartWithBenchmark().report();
+  static void main() => StartWithBenchmark().report();
 
   @override
   void run() {

--- a/test/benchmarks/zip_benchmark.dart
+++ b/test/benchmarks/zip_benchmark.dart
@@ -8,7 +8,7 @@ void main() => ZipBenchmark.main();
 class ZipBenchmark extends BenchmarkBase {
   ZipBenchmark() : super("zip");
 
-  static void main() => new ZipBenchmark().report();
+  static void main() => ZipBenchmark().report();
 
   @override
   void run() {

--- a/test/futures/as_observable_future_test.dart
+++ b/test/futures/as_observable_future_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('AsObservableFuture.asObservable', () async {
-    final future = new AsObservableFuture<int>(new Future<int>.value(1));
+    final future = AsObservableFuture<int>(Future<int>.value(1));
 
     await expectLater(future.asObservable(), emits(1));
   });

--- a/test/futures/stream_max_test.dart
+++ b/test/futures/stream_max_test.dart
@@ -7,54 +7,53 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.max', () async {
-    await expectLater(new Observable<int>(_getStream()).max(), completion(9));
+    await expectLater(Observable<int>(_getStream()).max(), completion(9));
   });
 
   test('rx.Observable.max.with.comparator', () async {
     await expectLater(
-        new Observable<String>.fromIterable(<String>["one", "two", "three"])
+        Observable<String>.fromIterable(<String>["one", "two", "three"])
             .max((String a, String b) => a.length - b.length),
         completion("three"));
   });
 
   test('returns an AsObservableFuture', () async {
     await expectLater(
-        new Observable<String>.fromIterable(<String>["one", "two", "three"])
+        Observable<String>.fromIterable(<String>["one", "two", "three"])
             .max((String a, String b) => a.length - b.length),
-        new TypeMatcher<AsObservableFuture<String>>());
+        TypeMatcher<AsObservableFuture<String>>());
   });
 
   group('MaxFuture', () {
     test('emits the maximum value from a list without a comparator', () async {
-      await expectLater(new StreamMaxFuture<int>(_getStream()), completion(9));
+      await expectLater(StreamMaxFuture<int>(_getStream()), completion(9));
     });
 
     test('emits the maximum value from a list with a comparator', () async {
-      final stream = new Stream.fromIterable(const ["one", "two", "three"]);
+      final stream = Stream.fromIterable(const ["one", "two", "three"]);
 
       final Comparator<String> stringLengthComparator =
           (String a, String b) => a.length - b.length;
 
-      await expectLater(
-          new StreamMaxFuture<String>(stream, stringLengthComparator),
+      await expectLater(StreamMaxFuture<String>(stream, stringLengthComparator),
           completion("three"));
     });
 
     test('throws the exception when encountered in the stream', () async {
-      final Stream<int> stream = new ConcatStream<int>(<Stream<int>>[
-        new Stream<int>.fromIterable(<int>[1]),
-        new ErrorStream<int>(new Exception())
+      final Stream<int> stream = ConcatStream<int>(<Stream<int>>[
+        Stream<int>.fromIterable(<int>[1]),
+        ErrorStream<int>(Exception())
       ]);
 
-      await expectLater(new StreamMaxFuture<int>(stream), throwsException);
+      await expectLater(StreamMaxFuture<int>(stream), throwsException);
     });
 
     test('rx.Observable.max.error.comparator', () async {
-      final stream = new Stream.fromIterable(
-          [new ErrorComparator(), new ErrorComparator()]);
+      final stream =
+          Stream.fromIterable([ErrorComparator(), ErrorComparator()]);
 
       await expectLater(
-          new StreamMaxFuture<ErrorComparator>(stream), throwsException);
+          StreamMaxFuture<ErrorComparator>(stream), throwsException);
     });
   });
 }
@@ -62,9 +61,9 @@ void main() {
 class ErrorComparator implements Comparable<ErrorComparator> {
   @override
   int compareTo(ErrorComparator other) {
-    throw new Exception();
+    throw Exception();
   }
 }
 
 Stream<int> _getStream() =>
-    new Stream<int>.fromIterable(const <int>[2, 3, 3, 5, 2, 9, 1, 2, 0]);
+    Stream<int>.fromIterable(const <int>[2, 3, 3, 5, 2, 9, 1, 2, 0]);

--- a/test/futures/stream_min_test.dart
+++ b/test/futures/stream_min_test.dart
@@ -7,54 +7,53 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.min', () async {
-    await expectLater(new Observable<int>(_getStream()).min(), completion(0));
+    await expectLater(Observable<int>(_getStream()).min(), completion(0));
   });
 
   test('rx.Observable.min.with.comparator', () async {
     await expectLater(
-        new Observable<String>.fromIterable(<String>["one", "two", "three"])
+        Observable<String>.fromIterable(<String>["one", "two", "three"])
             .min((String a, String b) => a.length - b.length),
         completion("one"));
   });
 
   test('returns an AsObservableFuture', () async {
     await expectLater(
-        new Observable<String>.fromIterable(<String>["one", "two", "three"])
+        Observable<String>.fromIterable(<String>["one", "two", "three"])
             .min((String a, String b) => a.length - b.length),
-        new TypeMatcher<AsObservableFuture<String>>());
+        TypeMatcher<AsObservableFuture<String>>());
   });
 
   group('MinFuture', () {
     test('emits the minimum value from a list without a comparator', () async {
-      await expectLater(new StreamMinFuture<int>(_getStream()), completion(0));
+      await expectLater(StreamMinFuture<int>(_getStream()), completion(0));
     });
 
     test('emits the minimum value from a list with a comparator', () async {
-      final stream = new Stream.fromIterable(const ["one", "two", "three"]);
+      final stream = Stream.fromIterable(const ["one", "two", "three"]);
 
       final Comparator<String> stringLengthComparator =
           (String a, String b) => a.length - b.length;
 
-      await expectLater(
-          new StreamMinFuture<String>(stream, stringLengthComparator),
+      await expectLater(StreamMinFuture<String>(stream, stringLengthComparator),
           completion("one"));
     });
 
     test('throws the exception when encountered in the stream', () async {
-      final Stream<int> stream = new ConcatStream<int>(<Stream<int>>[
-        new Stream<int>.fromIterable(<int>[1]),
-        new ErrorStream<int>(new Exception())
+      final Stream<int> stream = ConcatStream<int>(<Stream<int>>[
+        Stream<int>.fromIterable(<int>[1]),
+        ErrorStream<int>(Exception())
       ]);
 
-      await expectLater(new StreamMinFuture<int>(stream), throwsException);
+      await expectLater(StreamMinFuture<int>(stream), throwsException);
     });
 
     test('rx.Observable.min.error.comparator', () async {
-      final stream = new Stream.fromIterable(
-          [new ErrorComparator(), new ErrorComparator()]);
+      final stream =
+          Stream.fromIterable([ErrorComparator(), ErrorComparator()]);
 
       await expectLater(
-          new StreamMinFuture<ErrorComparator>(stream), throwsException);
+          StreamMinFuture<ErrorComparator>(stream), throwsException);
     });
   });
 }
@@ -62,9 +61,9 @@ void main() {
 class ErrorComparator implements Comparable<ErrorComparator> {
   @override
   int compareTo(ErrorComparator other) {
-    throw new Exception();
+    throw Exception();
   }
 }
 
 Stream<int> _getStream() =>
-    new Stream<int>.fromIterable(const <int>[2, 3, 3, 5, 2, 9, 1, 2, 0]);
+    Stream<int>.fromIterable(const <int>[2, 3, 3, 5, 2, 9, 1, 2, 0]);

--- a/test/futures/wrapped_future_test.dart
+++ b/test/futures/wrapped_future_test.dart
@@ -5,14 +5,14 @@ import 'package:test/test.dart';
 
 void main() {
   test('AsObservableFuture.asObservable', () async {
-    final future = new AsObservableFuture<int>(new Future.value(1));
+    final future = AsObservableFuture<int>(Future.value(1));
 
     await expectLater(future.asObservable(), emits(1));
   });
 
   group('WrappedFuture', () {
     test('can be converted to a stream', () async {
-      final future = new AsObservableFuture(new Future.value(1));
+      final future = AsObservableFuture(Future.value(1));
 
       await expectLater(future.asStream(), emits(1));
     });
@@ -20,7 +20,7 @@ void main() {
     test('properly handles catchError', () async {
       var catchErrorCalled = false;
 
-      await new AsObservableFuture<int>(new Future<int>.error(new Exception()))
+      await AsObservableFuture<int>(Future<int>.error(Exception()))
           .catchError((dynamic e, dynamic s) {
         catchErrorCalled = true;
       });
@@ -31,7 +31,7 @@ void main() {
     test('handles then', () async {
       var thenCalled = false;
 
-      await new AsObservableFuture<int>(new Future.value(1)).then((int i) {
+      await AsObservableFuture<int>(Future.value(1)).then((int i) {
         thenCalled = true;
       });
 
@@ -40,16 +40,15 @@ void main() {
 
     test('handles timeout', () async {
       await expectLater(
-          new AsObservableFuture<int>(
-                  new Future<int>.delayed(new Duration(minutes: 1)))
-              .timeout(new Duration(milliseconds: 1)),
-          throwsA(new TypeMatcher<TimeoutException>()));
+          AsObservableFuture<int>(Future<int>.delayed(Duration(minutes: 1)))
+              .timeout(Duration(milliseconds: 1)),
+          throwsA(TypeMatcher<TimeoutException>()));
     });
 
     test('handles whenComplete callbacks', () async {
       var whenCompleteCalled = false;
 
-      await new AsObservableFuture(new Future.value(1)).whenComplete(() {
+      await AsObservableFuture(Future.value(1)).whenComplete(() {
         whenCompleteCalled = true;
       });
 

--- a/test/observables/publish_connectable_observable_test.dart
+++ b/test/observables/publish_connectable_observable_test.dart
@@ -12,8 +12,8 @@ void main() {
       final stream = MockStream<int>();
       final observable = PublishConnectableObservable(stream);
 
-      when(stream.listen(any, onError: anyNamed('onError'))).thenReturn(
-          new Stream<int>.fromIterable(const [1, 2, 3]).listen(null));
+      when(stream.listen(any, onError: anyNamed('onError')))
+          .thenReturn(Stream<int>.fromIterable(const [1, 2, 3]).listen(null));
 
       verifyNever(stream.listen(any, onError: anyNamed('onError')));
 
@@ -42,7 +42,7 @@ void main() {
     });
 
     test('multicasts a single-subscription stream', () async {
-      final observable = new PublishConnectableObservable(
+      final observable = PublishConnectableObservable(
         Stream.fromIterable(const [1, 2, 3]),
       ).autoConnect();
 

--- a/test/observables/replay_connectable_observable_test.dart
+++ b/test/observables/replay_connectable_observable_test.dart
@@ -13,7 +13,7 @@ void main() {
       final observable = ReplayConnectableObservable(stream);
 
       when(stream.listen(any, onError: anyNamed('onError')))
-          .thenReturn(new Stream.fromIterable(const [1, 2, 3]).listen(null));
+          .thenReturn(Stream.fromIterable(const [1, 2, 3]).listen(null));
 
       verifyNever(stream.listen(any, onError: anyNamed('onError')));
 
@@ -64,7 +64,7 @@ void main() {
     });
 
     test('multicasts a single-subscription stream', () async {
-      final Observable<int> observable = new ReplayConnectableObservable<int>(
+      final Observable<int> observable = ReplayConnectableObservable<int>(
         Stream<int>.fromIterable(<int>[1, 2, 3]),
       ).autoConnect();
 
@@ -74,7 +74,7 @@ void main() {
     });
 
     test('replays the max number of items', () async {
-      final Observable<int> observable = new ReplayConnectableObservable<int>(
+      final Observable<int> observable = ReplayConnectableObservable<int>(
         Stream<int>.fromIterable(<int>[1, 2, 3]),
         maxSize: 2,
       ).autoConnect();

--- a/test/observables/value_connectable_observable_test.dart
+++ b/test/observables/value_connectable_observable_test.dart
@@ -13,7 +13,7 @@ void main() {
       final observable = ValueConnectableObservable(stream);
 
       when(stream.listen(any, onError: anyNamed('onError')))
-          .thenReturn(new Stream.fromIterable(const [1, 2, 3]).listen(null));
+          .thenReturn(Stream.fromIterable(const [1, 2, 3]).listen(null));
 
       verifyNever(stream.listen(any, onError: anyNamed('onError')));
 
@@ -63,7 +63,7 @@ void main() {
     });
 
     test('multicasts a single-subscription stream', () async {
-      final observable = new ValueConnectableObservable(
+      final observable = ValueConnectableObservable(
         Stream.fromIterable(const [1, 2, 3]),
       ).autoConnect();
 
@@ -73,7 +73,7 @@ void main() {
     });
 
     test('replays the latest item', () async {
-      final observable = new ValueConnectableObservable(
+      final observable = ValueConnectableObservable(
         Stream.fromIterable(const [1, 2, 3]),
       ).autoConnect();
 
@@ -87,9 +87,9 @@ void main() {
     });
 
     test('replays the seeded item', () async {
-      final observable = new ValueConnectableObservable.seeded(
-              StreamController<int>().stream, 3)
-          .autoConnect();
+      final observable =
+          ValueConnectableObservable.seeded(StreamController<int>().stream, 3)
+              .autoConnect();
 
       expect(observable, emitsInOrder(const <int>[3]));
       expect(observable, emitsInOrder(const <int>[3]));
@@ -101,7 +101,7 @@ void main() {
     });
 
     test('replays the seeded null item', () async {
-      final observable = new ValueConnectableObservable.seeded(
+      final observable = ValueConnectableObservable.seeded(
               StreamController<int>().stream, null)
           .autoConnect();
 

--- a/test/streams/combine_latest_test.dart
+++ b/test/streams/combine_latest_test.dart
@@ -3,14 +3,14 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Stream<int> get streamA => new Stream<int>.periodic(
-    const Duration(milliseconds: 1), (int count) => count).take(3);
+Stream<int> get streamA =>
+    Stream<int>.periodic(const Duration(milliseconds: 1), (int count) => count)
+        .take(3);
 
-Stream<int> get streamB =>
-    new Stream<int>.fromIterable(const <int>[1, 2, 3, 4]);
+Stream<int> get streamB => Stream<int>.fromIterable(const <int>[1, 2, 3, 4]);
 
 Stream<bool> get streamC {
-  final controller = new StreamController<bool>()
+  final controller = StreamController<bool>()
     ..add(true)
     ..close();
 
@@ -83,8 +83,7 @@ void main() {
     ];
     var count = 0;
 
-    var a = new Observable.fromIterable(const [1, 2]),
-        b = new Observable.just(2);
+    var a = Observable.fromIterable(const [1, 2]), b = Observable.just(2);
 
     final observable = Observable.combineLatest2(
         a, b, (int first, int second) => [first, second]);
@@ -95,10 +94,10 @@ void main() {
   });
 
   test('rx.Observable.combineLatest2.throws', () async {
-    var a = new Observable.just(1), b = new Observable.just(2);
+    var a = Observable.just(1), b = Observable.just(2);
 
     final observable = Observable.combineLatest2(a, b, (int first, int second) {
-      throw new Exception();
+      throw Exception();
     });
 
     observable.listen(null, onError: expectAsync2((Exception e, StackTrace s) {
@@ -109,9 +108,9 @@ void main() {
   test('rx.Observable.combineLatest3', () async {
     const expected = [1, "2", 3.0];
 
-    var a = new Observable<int>.just(1),
-        b = new Observable<String>.just("2"),
-        c = new Observable<double>.just(3.0);
+    var a = Observable<int>.just(1),
+        b = Observable<String>.just("2"),
+        c = Observable<double>.just(3.0);
 
     final observable = Observable.combineLatest3(a, b, c,
         (int first, String second, double third) => [first, second, third]);
@@ -124,10 +123,10 @@ void main() {
   test('rx.Observable.combineLatest4', () async {
     const expected = [1, 2, 3, 4];
 
-    var a = new Observable.just(1),
-        b = new Observable<int>.just(2),
-        c = new Observable<int>.just(3),
-        d = new Observable<int>.just(4);
+    var a = Observable.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4);
 
     final observable = Observable.combineLatest4(
         a,
@@ -145,11 +144,11 @@ void main() {
   test('rx.Observable.combineLatest5', () async {
     const expected = [1, 2, 3, 4, 5];
 
-    var a = new Observable<int>.just(1),
-        b = new Observable<int>.just(2),
-        c = new Observable<int>.just(3),
-        d = new Observable<int>.just(4),
-        e = new Observable<int>.just(5);
+    var a = Observable<int>.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4),
+        e = Observable<int>.just(5);
 
     final observable = Observable.combineLatest5(
         a,
@@ -168,12 +167,12 @@ void main() {
   test('rx.Observable.combineLatest6', () async {
     const expected = [1, 2, 3, 4, 5, 6];
 
-    var a = new Observable<int>.just(1),
-        b = new Observable<int>.just(2),
-        c = new Observable<int>.just(3),
-        d = new Observable<int>.just(4),
-        e = new Observable<int>.just(5),
-        f = new Observable<int>.just(6);
+    var a = Observable<int>.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4),
+        e = Observable<int>.just(5),
+        f = Observable<int>.just(6);
 
     Stream<List<int>> observable = Observable.combineLatest6(
         a,
@@ -193,13 +192,13 @@ void main() {
   test('rx.Observable.combineLatest7', () async {
     const expected = [1, 2, 3, 4, 5, 6, 7];
 
-    var a = new Observable<int>.just(1),
-        b = new Observable<int>.just(2),
-        c = new Observable<int>.just(3),
-        d = new Observable<int>.just(4),
-        e = new Observable<int>.just(5),
-        f = new Observable<int>.just(6),
-        g = new Observable<int>.just(7);
+    var a = Observable<int>.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4),
+        e = Observable<int>.just(5),
+        f = Observable<int>.just(6),
+        g = Observable<int>.just(7);
 
     final observable = Observable.combineLatest7(
         a,
@@ -221,14 +220,14 @@ void main() {
   test('rx.Observable.combineLatest8', () async {
     const expected = [1, 2, 3, 4, 5, 6, 7, 8];
 
-    var a = new Observable<int>.just(1),
-        b = new Observable<int>.just(2),
-        c = new Observable<int>.just(3),
-        d = new Observable<int>.just(4),
-        e = new Observable<int>.just(5),
-        f = new Observable<int>.just(6),
-        g = new Observable<int>.just(7),
-        h = new Observable<int>.just(8);
+    var a = Observable<int>.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4),
+        e = Observable<int>.just(5),
+        f = Observable<int>.just(6),
+        g = Observable<int>.just(7),
+        h = Observable<int>.just(8);
 
     final observable = Observable.combineLatest8(
         a,
@@ -251,15 +250,15 @@ void main() {
   test('rx.Observable.combineLatest9', () async {
     const expected = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-    var a = new Observable<int>.just(1),
-        b = new Observable<int>.just(2),
-        c = new Observable<int>.just(3),
-        d = new Observable<int>.just(4),
-        e = new Observable<int>.just(5),
-        f = new Observable<int>.just(6),
-        g = new Observable<int>.just(7),
-        h = new Observable<int>.just(8),
-        i = new Observable<int>.just(9);
+    var a = Observable<int>.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4),
+        e = Observable<int>.just(5),
+        f = Observable<int>.just(6),
+        g = Observable<int>.just(7),
+        h = Observable<int>.just(8),
+        i = Observable<int>.just(9);
 
     final observable = Observable.combineLatest9(
         a,
@@ -304,11 +303,8 @@ void main() {
   });
 
   test('rx.Observable.combineLatest.error.shouldThrowA', () async {
-    final observableWithError = Observable.combineLatest4(
-        new Observable.just(1),
-        new Observable.just(1),
-        new Observable.just(1),
-        new ErrorStream<int>(new Exception()),
+    final observableWithError = Observable.combineLatest4(Observable.just(1),
+        Observable.just(1), Observable.just(1), ErrorStream<int>(Exception()),
         (int a_value, int b_value, int c_value, dynamic _) {
       return '$a_value $b_value $c_value $_';
     });
@@ -321,9 +317,9 @@ void main() {
 
   test('rx.Observable.combineLatest.error.shouldThrowB', () async {
     final observableWithError = Observable.combineLatest3(
-        new Observable.just(1), new Observable.just(1), new Observable.just(1),
+        Observable.just(1), Observable.just(1), Observable.just(1),
         (int a_value, int b_value, int c_value) {
-      throw new Exception('oh noes!');
+      throw Exception('oh noes!');
     });
 
     observableWithError.listen(null,
@@ -349,11 +345,11 @@ void main() {
   });*/
 
   test('rx.Observable.combineLatest.pause.resume', () async {
-    final first = new Stream.periodic(const Duration(milliseconds: 10),
+    final first = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [1, 2, 3, 4][index]),
-        second = new Stream.periodic(const Duration(milliseconds: 10),
+        second = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [5, 6, 7, 8][index]),
-        last = new Stream.periodic(const Duration(milliseconds: 10),
+        last = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [9, 10, 11, 12][index]);
 
     StreamSubscription<Iterable<num>> subscription;
@@ -368,7 +364,6 @@ void main() {
       subscription.cancel();
     }, count: 1));
 
-    subscription
-        .pause(new Future<Null>.delayed(const Duration(milliseconds: 80)));
+    subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
   });
 }

--- a/test/streams/concat_eager_test.dart
+++ b/test/streams/concat_eager_test.dart
@@ -4,16 +4,16 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 List<Stream<int>> _getStreams() {
-  var a = new Stream.fromIterable(const [0, 1, 2]),
-      b = new Stream.fromIterable(const [3, 4, 5]);
+  var a = Stream.fromIterable(const [0, 1, 2]),
+      b = Stream.fromIterable(const [3, 4, 5]);
 
   return [a, b];
 }
 
 List<Stream<int>> _getStreamsIncludingEmpty() {
-  var a = new Stream.fromIterable(const [0, 1, 2]),
-      b = new Stream.fromIterable(const [3, 4, 5]),
-      c = new Observable<int>.empty();
+  var a = Stream.fromIterable(const [0, 1, 2]),
+      b = Stream.fromIterable(const [3, 4, 5]),
+      c = Observable<int>.empty();
 
   return [c, a, b];
 }
@@ -23,7 +23,7 @@ void main() {
     const expectedOutput = [0, 1, 2, 3, 4, 5];
     var count = 0;
 
-    final observable = new Observable.concatEager(_getStreams());
+    final observable = Observable.concatEager(_getStreams());
 
     observable.listen(expectAsync1((result) {
       // test to see if the combined output matches
@@ -32,7 +32,7 @@ void main() {
   });
 
   test('rx.Observable.concatEager.single.subscription', () async {
-    final observable = new Observable.concatEager(_getStreams());
+    final observable = Observable.concatEager(_getStreams());
 
     observable.listen(null);
     await expectLater(() => observable.listen((_) {}), throwsA(isStateError));
@@ -42,7 +42,7 @@ void main() {
     const expectedOutput = [0, 1, 2, 3, 4, 5];
     var count = 0;
 
-    final observable = new Observable.concatEager(_getStreamsIncludingEmpty());
+    final observable = Observable.concatEager(_getStreamsIncludingEmpty());
 
     observable.listen(expectAsync1((result) {
       // test to see if the combined output matches
@@ -52,12 +52,12 @@ void main() {
 
   test('rx.Observable.concatEager.withBroadcastStreams', () async {
     const expectedOutput = [1, 2, 3, 4, 99, 98, 97, 96, 999, 998, 997];
-    final ctrlA = new StreamController<int>.broadcast(),
-        ctrlB = new StreamController<int>.broadcast(),
-        ctrlC = new StreamController<int>.broadcast();
+    final ctrlA = StreamController<int>.broadcast(),
+        ctrlB = StreamController<int>.broadcast(),
+        ctrlC = StreamController<int>.broadcast();
     var x = 0, y = 100, z = 1000, count = 0;
 
-    new Timer.periodic(const Duration(milliseconds: 10), (_) {
+    Timer.periodic(const Duration(milliseconds: 10), (_) {
       ctrlA.add(++x);
       ctrlB.add(--y);
 
@@ -74,7 +74,7 @@ void main() {
     });
 
     final observable =
-        new Observable.concatEager([ctrlA.stream, ctrlB.stream, ctrlC.stream]);
+        Observable.concatEager([ctrlA.stream, ctrlB.stream, ctrlC.stream]);
 
     observable.listen(expectAsync1((result) {
       // test to see if the combined output matches
@@ -84,7 +84,7 @@ void main() {
 
   test('rx.Observable.concatEager.asBroadcastStream', () async {
     final observable =
-        new Observable.concatEager(_getStreams()).asBroadcastStream();
+        Observable.concatEager(_getStreams()).asBroadcastStream();
 
     // listen twice on same stream
     observable.listen(null);
@@ -94,8 +94,8 @@ void main() {
   });
 
   test('rx.Observable.concatEager.error.shouldThrowA', () async {
-    final observableWithError = new Observable.concatEager(
-        _getStreams()..add(new ErrorStream<int>(new Exception())));
+    final observableWithError = Observable.concatEager(
+        _getStreams()..add(ErrorStream<int>(Exception())));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -104,37 +104,35 @@ void main() {
   });
 
   test('rx.Observable.concatEager.error.shouldThrowB', () {
-    expect(() => new Observable<int>.concatEager(null), throwsArgumentError);
+    expect(() => Observable<int>.concatEager(null), throwsArgumentError);
   });
 
   test('rx.Observable.concatEager.error.shouldThrowC', () {
-    expect(
-        () => new Observable<int>.concatEager(const []), throwsArgumentError);
+    expect(() => Observable<int>.concatEager(const []), throwsArgumentError);
   });
 
   test('rx.Observable.concatEager.error.shouldThrowD', () {
-    expect(() => new Observable.concatEager([new Observable.just(1), null]),
+    expect(() => Observable.concatEager([Observable.just(1), null]),
         throwsArgumentError);
   });
 
   test('rx.Observable.concatEager.pause.resume', () async {
-    final first = new Stream.periodic(const Duration(milliseconds: 10),
+    final first = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [1, 2, 3, 4][index]),
-        second = new Stream.periodic(const Duration(milliseconds: 10),
+        second = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [5, 6, 7, 8][index]),
-        last = new Stream.periodic(const Duration(milliseconds: 10),
+        last = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [9, 10, 11, 12][index]);
 
     StreamSubscription<num> subscription;
     // ignore: deprecated_member_use
-    subscription = new Observable.concatEager([first, second, last])
+    subscription = Observable.concatEager([first, second, last])
         .listen(expectAsync1((value) {
       expect(value, 1);
 
       subscription.cancel();
     }, count: 1));
 
-    subscription
-        .pause(new Future<Null>.delayed(const Duration(milliseconds: 80)));
+    subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
   });
 }

--- a/test/streams/concat_test.dart
+++ b/test/streams/concat_test.dart
@@ -4,16 +4,16 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 List<Stream<int>> _getStreams() {
-  var a = new Stream.fromIterable(const [0, 1, 2]),
-      b = new Stream.fromIterable(const [3, 4, 5]);
+  var a = Stream.fromIterable(const [0, 1, 2]),
+      b = Stream.fromIterable(const [3, 4, 5]);
 
   return [a, b];
 }
 
 List<Stream<int>> _getStreamsIncludingEmpty() {
-  var a = new Stream.fromIterable(const [0, 1, 2]),
-      b = new Stream.fromIterable(const [3, 4, 5]),
-      c = new Observable<int>.empty();
+  var a = Stream.fromIterable(const [0, 1, 2]),
+      b = Stream.fromIterable(const [3, 4, 5]),
+      c = Observable<int>.empty();
 
   return [c, a, b];
 }
@@ -23,7 +23,7 @@ void main() {
     const expectedOutput = [0, 1, 2, 3, 4, 5];
     var count = 0;
 
-    final observable = new Observable.concat(_getStreams());
+    final observable = Observable.concat(_getStreams());
 
     observable.listen(expectAsync1((result) {
       // test to see if the combined output matches
@@ -32,7 +32,7 @@ void main() {
   });
 
   test('rx.Observable.concatEager.single.subscription', () async {
-    final observable = new Observable.concat(_getStreams());
+    final observable = Observable.concat(_getStreams());
 
     observable.listen(null);
     await expectLater(() => observable.listen(null), throwsA(isStateError));
@@ -42,7 +42,7 @@ void main() {
     const expectedOutput = [0, 1, 2, 3, 4, 5];
     var count = 0;
 
-    final observable = new Observable.concat(_getStreamsIncludingEmpty());
+    final observable = Observable.concat(_getStreamsIncludingEmpty());
 
     observable.listen(expectAsync1((result) {
       // test to see if the combined output matches
@@ -51,13 +51,13 @@ void main() {
   });
 
   test('rx.Observable.concat.withBroadcastStreams', () async {
-    const expectedOutput = const [1, 2, 3, 4];
-    final ctrlA = new StreamController<int>.broadcast(),
-        ctrlB = new StreamController<int>.broadcast(),
-        ctrlC = new StreamController<int>.broadcast();
+    const expectedOutput = [1, 2, 3, 4];
+    final ctrlA = StreamController<int>.broadcast(),
+        ctrlB = StreamController<int>.broadcast(),
+        ctrlC = StreamController<int>.broadcast();
     var x = 0, y = 100, z = 1000, count = 0;
 
-    new Timer.periodic(const Duration(milliseconds: 1), (_) {
+    Timer.periodic(const Duration(milliseconds: 1), (_) {
       ctrlA.add(++x);
       ctrlB.add(--y);
 
@@ -74,7 +74,7 @@ void main() {
     });
 
     final observable =
-        new Observable.concat([ctrlA.stream, ctrlB.stream, ctrlC.stream]);
+        Observable.concat([ctrlA.stream, ctrlB.stream, ctrlC.stream]);
 
     observable.listen(expectAsync1((result) {
       // test to see if the combined output matches
@@ -83,7 +83,7 @@ void main() {
   });
 
   test('rx.Observable.concat.asBroadcastStream', () async {
-    final observable = new Observable.concat(_getStreams()).asBroadcastStream();
+    final observable = Observable.concat(_getStreams()).asBroadcastStream();
 
     // listen twice on same stream
     observable.listen(null);
@@ -93,8 +93,8 @@ void main() {
   });
 
   test('rx.Observable.concat.error.shouldThrowA', () async {
-    final observableWithError = new Observable.concat(
-        _getStreams()..add(new ErrorStream<int>(new Exception())));
+    final observableWithError =
+        Observable.concat(_getStreams()..add(ErrorStream<int>(Exception())));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -103,17 +103,17 @@ void main() {
   });
 
   test('rx.Observable.concat.error.shouldThrowB', () {
-    expect(() => new Observable<int>.concat(null), throwsArgumentError);
+    expect(() => Observable<int>.concat(null), throwsArgumentError);
   });
 
   test('rx.Observable.concat.error.shouldThrowC', () {
-    expect(() => new Observable<int>.concat(const []), throwsArgumentError);
+    expect(() => Observable<int>.concat(const []), throwsArgumentError);
   });
 
   test('rx.Observable.concat.error.shouldThrowD', () {
     expect(
         () => [
-              new Observable.concat([new Observable.just(1), null]),
+              Observable.concat([Observable.just(1), null]),
               null
             ],
         throwsArgumentError);

--- a/test/streams/defer_test.dart
+++ b/test/streams/defer_test.dart
@@ -40,8 +40,7 @@ void main() {
   });
 
   test('rx.Observable.defer.error.shouldThrow', () async {
-    final observableWithError =
-        new Observable.defer(() => _getErroneousStream());
+    final observableWithError = Observable.defer(() => _getErroneousStream());
 
     observableWithError.listen(null,
         onError: expectAsync1((Exception e) {
@@ -50,16 +49,15 @@ void main() {
   });
 }
 
-Stream<int> _getDeferStream() =>
-    new Observable.defer(() => new Observable.just(1));
+Stream<int> _getDeferStream() => Observable.defer(() => Observable.just(1));
 
 Stream<int> _getBroadcastDeferStream() =>
-    new Observable.defer(() => new Observable.just(1)).asBroadcastStream();
+    Observable.defer(() => Observable.just(1)).asBroadcastStream();
 
 Stream<int> _getErroneousStream() {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  controller.addError(new Exception());
+  controller.addError(Exception());
   controller.close();
 
   return controller.stream;

--- a/test/streams/empty_test.dart
+++ b/test/streams/empty_test.dart
@@ -5,7 +5,7 @@ void main() {
   test('rx.Observable.empty', () async {
     var onDataCalled = false, onErrorCalled = false;
 
-    final observable = new Observable<int>.empty();
+    final observable = Observable<int>.empty();
 
     observable.listen(
         expectAsync1((_) {

--- a/test/streams/error_test.dart
+++ b/test/streams/error_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('ErrorStream', () async {
-    Stream<int> stream = new ErrorStream<int>(new Exception());
+    Stream<int> stream = ErrorStream<int>(Exception());
 
     await expectLater(
         stream,
@@ -18,7 +18,7 @@ void main() {
   });
 
   test('ErrorStream.single.subscription', () async {
-    Stream<int> stream = new ErrorStream<int>(new Exception());
+    Stream<int> stream = ErrorStream<int>(Exception());
 
     // expect to hit onError in first subscription
     // expect immediate error when trying another subscription
@@ -29,7 +29,7 @@ void main() {
   });
 
   test('rx.Observable.error', () async {
-    final observable = new Observable<int>.error(new Exception());
+    final observable = Observable<int>.error(Exception());
 
     await expectLater(
         observable,

--- a/test/streams/event_transformed_test.dart
+++ b/test/streams/event_transformed_test.dart
@@ -5,9 +5,9 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.eventTransformed', () async {
-    Stream<int> source = new Observable<int>.just(1);
-    Stream<int> observable = new Observable<int>.eventTransformed(
-        source, (EventSink<int> sink) => sink);
+    Stream<int> source = Observable<int>.just(1);
+    Stream<int> observable =
+        Observable<int>.eventTransformed(source, (EventSink<int> sink) => sink);
 
     await expectLater(observable is Observable, isTrue);
   });

--- a/test/streams/from_future_test.dart
+++ b/test/streams/from_future_test.dart
@@ -7,7 +7,7 @@ void main() {
   test('rx.Observable.fromFuture', () async {
     const value = 1;
 
-    final observable = new Observable.fromFuture(new Future.value(value));
+    final observable = Observable.fromFuture(Future.value(value));
 
     observable.listen(expectAsync1((actual) {
       expect(actual, value);

--- a/test/streams/from_iterable_test.dart
+++ b/test/streams/from_iterable_test.dart
@@ -5,7 +5,7 @@ void main() {
   test('rx.Observable.fromIterable', () async {
     const value = 1;
 
-    final observable = new Observable.fromIterable([value]);
+    final observable = Observable.fromIterable([value]);
 
     observable.listen(expectAsync1((actual) {
       expect(actual, value);

--- a/test/streams/just_test.dart
+++ b/test/streams/just_test.dart
@@ -5,7 +5,7 @@ void main() {
   test('rx.Observable.just', () async {
     const value = 1;
 
-    final observable = new Observable.just(value);
+    final observable = Observable.just(value);
 
     observable.listen(expectAsync1((actual) {
       expect(actual, value);

--- a/test/streams/merge_test.dart
+++ b/test/streams/merge_test.dart
@@ -4,30 +4,30 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 List<Stream<int>> _getStreams() {
-  var a = new Stream.periodic(const Duration(milliseconds: 1), (count) => count)
+  var a = Stream.periodic(const Duration(milliseconds: 1), (count) => count)
           .take(3),
-      b = new Stream.fromIterable(const [1, 2, 3, 4]);
+      b = Stream.fromIterable(const [1, 2, 3, 4]);
 
   return [a, b];
 }
 
 void main() {
   test('rx.Observable.merge', () async {
-    final observable = new Observable.merge(_getStreams());
+    final observable = Observable.merge(_getStreams());
 
     await expectLater(
         observable, emitsInOrder(const <int>[1, 2, 3, 4, 0, 1, 2]));
   });
 
   test('rx.Observable.merge.single.subscription', () async {
-    final observable = new Observable.merge(_getStreams());
+    final observable = Observable.merge(_getStreams());
 
     observable.listen(null);
     await expectLater(() => observable.listen(null), throwsA(isStateError));
   });
 
   test('rx.Observable.merge.asBroadcastStream', () async {
-    final observable = new Observable.merge(_getStreams()).asBroadcastStream();
+    final observable = Observable.merge(_getStreams()).asBroadcastStream();
 
     // listen twice on same stream
     observable.listen(null);
@@ -37,8 +37,8 @@ void main() {
   });
 
   test('rx.Observable.merge.error.shouldThrowA', () async {
-    final observableWithError = new Observable.merge(
-        _getStreams()..add(new ErrorStream<int>(new Exception())));
+    final observableWithError =
+        Observable.merge(_getStreams()..add(ErrorStream<int>(Exception())));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -47,36 +47,35 @@ void main() {
   });
 
   test('rx.Observable.merge.error.shouldThrowB', () {
-    expect(() => new Observable<int>.merge(null), throwsArgumentError);
+    expect(() => Observable<int>.merge(null), throwsArgumentError);
   });
 
   test('rx.Observable.merge.error.shouldThrowC', () {
-    expect(() => new Observable<int>.merge(const []), throwsArgumentError);
+    expect(() => Observable<int>.merge(const []), throwsArgumentError);
   });
 
   test('rx.Observable.merge.error.shouldThrowD', () {
-    expect(() => new Observable.merge([new Observable.just(1), null]),
+    expect(() => Observable.merge([Observable.just(1), null]),
         throwsArgumentError);
   });
 
   test('rx.Observable.merge.pause.resume', () async {
-    final first = new Stream.periodic(const Duration(milliseconds: 10),
+    final first = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [1, 2, 3, 4][index]),
-        second = new Stream.periodic(const Duration(milliseconds: 10),
+        second = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [5, 6, 7, 8][index]),
-        last = new Stream.periodic(const Duration(milliseconds: 10),
+        last = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [9, 10, 11, 12][index]);
 
     StreamSubscription<num> subscription;
     // ignore: deprecated_member_use
-    subscription = new Observable.merge([first, second, last])
-        .listen(expectAsync1((value) {
+    subscription =
+        Observable.merge([first, second, last]).listen(expectAsync1((value) {
       expect(value, 1);
 
       subscription.cancel();
     }, count: 1));
 
-    subscription
-        .pause(new Future<Null>.delayed(const Duration(milliseconds: 80)));
+    subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
   });
 }

--- a/test/streams/never_test.dart
+++ b/test/streams/never_test.dart
@@ -8,7 +8,7 @@ void main() {
   test('NeverStream', () async {
     var onDataCalled = false, onDoneCalled = false, onErrorCalled = false;
 
-    final stream = new NeverStream<Null>();
+    final stream = NeverStream<Null>();
 
     final subscription = stream.listen(
         expectAsync1((_) {
@@ -21,7 +21,7 @@ void main() {
           onDataCalled = true;
         }, count: 0));
 
-    await new Future<Null>.delayed(new Duration(milliseconds: 10));
+    await Future<Null>.delayed(Duration(milliseconds: 10));
 
     await subscription.cancel();
 
@@ -33,7 +33,7 @@ void main() {
   });
 
   test('NeverStream.single.subscription', () async {
-    final stream = new NeverStream<Null>();
+    final stream = NeverStream<Null>();
 
     stream.listen(null);
     await expectLater(() => stream.listen(null), throwsA(isStateError));
@@ -42,7 +42,7 @@ void main() {
   test('rx.Observable.never', () async {
     var onDataCalled = false, onDoneCalled = false, onErrorCalled = false;
 
-    final observable = new Observable<Null>.never();
+    final observable = Observable<Null>.never();
 
     final subscription = observable.listen(
         expectAsync1((_) {
@@ -55,7 +55,7 @@ void main() {
           onDataCalled = true;
         }, count: 0));
 
-    await new Future<Null>.delayed(new Duration(milliseconds: 10));
+    await Future<Null>.delayed(Duration(milliseconds: 10));
 
     await subscription.cancel();
 

--- a/test/streams/periodic_test.dart
+++ b/test/streams/periodic_test.dart
@@ -6,8 +6,7 @@ void main() {
     const value = 1;
 
     final observable =
-        new Observable.periodic(new Duration(milliseconds: 1), (_) => value)
-            .take(1);
+        Observable.periodic(Duration(milliseconds: 1), (_) => value).take(1);
 
     observable.listen(expectAsync1((actual) {
       expect(actual, value);

--- a/test/streams/race_test.dart
+++ b/test/streams/race_test.dart
@@ -4,9 +4,9 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 Stream<int> getDelayedStream(int delay, int value) async* {
-  final completer = new Completer<Null>();
+  final completer = Completer<Null>();
 
-  new Timer(new Duration(milliseconds: delay), () => completer.complete());
+  Timer(Duration(milliseconds: delay), () => completer.complete());
 
   await completer.future;
 
@@ -22,7 +22,7 @@ void main() {
         last = getDelayedStream(70, 3);
     var expected = 1;
 
-    new Observable.race([first, second, last]).listen(expectAsync1((result) {
+    Observable.race([first, second, last]).listen(expectAsync1((result) {
       // test to see if the combined output matches
       expect(result.compareTo(expected++), 0);
     }, count: 3));
@@ -31,7 +31,7 @@ void main() {
   test('rx.Observable.race.single.subscription', () async {
     final first = getDelayedStream(50, 1);
 
-    final observable = new Observable.race([first]);
+    final observable = Observable.race([first]);
 
     observable.listen(null);
     await expectLater(() => observable.listen(null), throwsA(isStateError));
@@ -43,7 +43,7 @@ void main() {
         last = getDelayedStream(70, 3);
 
     final observable =
-        new Observable.race([first, second, last]).asBroadcastStream();
+        Observable.race([first, second, last]).asBroadcastStream();
 
     // listen twice on same stream
     observable.listen(null);
@@ -53,16 +53,16 @@ void main() {
   });
 
   test('rx.Observable.race.shouldThrowA', () {
-    expect(() => new Observable<Null>.race(null), throwsArgumentError);
+    expect(() => Observable<Null>.race(null), throwsArgumentError);
   });
 
   test('rx.Observable.race.shouldThrowB', () {
-    expect(() => new Observable<Null>.race(const []), throwsArgumentError);
+    expect(() => Observable<Null>.race(const []), throwsArgumentError);
   });
 
   test('rx.Observable.race.shouldThrowC', () async {
     final observable =
-        new Observable.race([new ErrorStream<Null>(new Exception('oh noes!'))]);
+        Observable.race([ErrorStream<Null>(Exception('oh noes!'))]);
 
     // listen twice on same stream
     observable.listen(null,
@@ -78,13 +78,12 @@ void main() {
     StreamSubscription<int> subscription;
     // ignore: deprecated_member_use
     subscription =
-        new Observable.race([first, second, last]).listen(expectAsync1((value) {
+        Observable.race([first, second, last]).listen(expectAsync1((value) {
       expect(value, 1);
 
       subscription.cancel();
     }, count: 1));
 
-    subscription
-        .pause(new Future<Null>.delayed(const Duration(milliseconds: 80)));
+    subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
   });
 }

--- a/test/streams/range_test.dart
+++ b/test/streams/range_test.dart
@@ -6,7 +6,7 @@ void main() {
     final expected = const [1, 2, 3];
     var count = 0;
 
-    final stream = new RangeStream(1, 3);
+    final stream = RangeStream(1, 3);
 
     stream.listen(expectAsync1((actual) {
       expect(actual, expected[count++]);
@@ -14,14 +14,14 @@ void main() {
   });
 
   test('RangeStream.single.subscription', () async {
-    final stream = new RangeStream(1, 5);
+    final stream = RangeStream(1, 5);
 
     stream.listen(null);
     await expectLater(() => stream.listen(null), throwsA(isStateError));
   });
 
   test('RangeStream.single', () async {
-    final stream = new RangeStream(1, 1);
+    final stream = RangeStream(1, 1);
 
     stream.listen(expectAsync1((actual) {
       expect(actual, 1);
@@ -32,7 +32,7 @@ void main() {
     final expected = const [3, 2, 1];
     var count = 0;
 
-    final stream = new RangeStream(3, 1);
+    final stream = RangeStream(3, 1);
 
     stream.listen(expectAsync1((actual) {
       expect(actual, expected[count++]);

--- a/test/streams/repeat_test.dart
+++ b/test/streams/repeat_test.dart
@@ -15,26 +15,25 @@ void main() {
   test('RepeatStream', () async {
     const retries = 3;
 
-    await expectLater(new RepeatStream(_getRepeatStream('A'), retries),
+    await expectLater(RepeatStream(_getRepeatStream('A'), retries),
         emitsInOrder(<dynamic>['A0', 'A1', 'A2', emitsDone]));
   });
 
   test('RepeatStream.onDone', () async {
     const retries = 0;
 
-    await expectLater(
-        new RepeatStream(_getRepeatStream('A'), retries), emitsDone);
+    await expectLater(RepeatStream(_getRepeatStream('A'), retries), emitsDone);
   });
 
   test('RepeatStream.infinite.repeats', () async {
     await expectLater(
-        new RepeatStream(_getRepeatStream('A')), emitsThrough('A100'));
+        RepeatStream(_getRepeatStream('A')), emitsThrough('A100'));
   });
 
   test('RepeatStream.single.subscription', () async {
     const retries = 3;
 
-    final stream = new RepeatStream(_getRepeatStream('A'), retries);
+    final stream = RepeatStream(_getRepeatStream('A'), retries);
 
     try {
       stream.listen(null);
@@ -48,7 +47,7 @@ void main() {
     const retries = 3;
 
     final stream =
-        new RepeatStream(_getRepeatStream('A'), retries).asBroadcastStream();
+        RepeatStream(_getRepeatStream('A'), retries).asBroadcastStream();
 
     // listen twice on same stream
     stream.listen(null);
@@ -58,16 +57,15 @@ void main() {
   });
 
   test('RepeatStream.error.shouldThrow', () async {
-    final observableWithError =
-        new RepeatStream(_getErroneusRepeatStream('A'), 2);
+    final observableWithError = RepeatStream(_getErroneusRepeatStream('A'), 2);
 
     await expectLater(
         observableWithError,
         emitsInOrder(<dynamic>[
           'A0',
-          emitsError(new TypeMatcher<Error>()),
+          emitsError(TypeMatcher<Error>()),
           'A0',
-          emitsError(new TypeMatcher<Error>()),
+          emitsError(TypeMatcher<Error>()),
           emitsDone
         ]));
   });
@@ -76,7 +74,7 @@ void main() {
     StreamSubscription<String> subscription;
     const retries = 3;
 
-    subscription = new RepeatStream(_getRepeatStream('A'), retries)
+    subscription = RepeatStream(_getRepeatStream('A'), retries)
         .listen(expectAsync1((result) {
       expect(result, 'A0');
 
@@ -96,7 +94,7 @@ Stream<String> Function(int) _getRepeatStream(String symbol) =>
 
 Stream<String> Function(int) _getErroneusRepeatStream(String symbol) =>
     (int repeatIndex) {
-      return new Observable.just('A0')
+      return Observable.just('A0')
           // Emit the error
-          .concatWith([new ErrorStream<String>(new Error())]);
+          .concatWith([ErrorStream<String>(Error())]);
     };

--- a/test/streams/retry_test.dart
+++ b/test/streams/retry_test.dart
@@ -9,40 +9,40 @@ void main() {
   test('rx.Observable.retry', () async {
     const retries = 3;
 
-    await expectLater(new Observable.retry(_getRetryStream(retries), retries),
+    await expectLater(Observable.retry(_getRetryStream(retries), retries),
         emitsInOrder(<dynamic>[1, emitsDone]));
   });
 
   test('RetryStream', () async {
     const retries = 3;
 
-    await expectLater(new RetryStream<int>(_getRetryStream(retries), retries),
+    await expectLater(RetryStream<int>(_getRetryStream(retries), retries),
         emitsInOrder(<dynamic>[1, emitsDone]));
   });
 
   test('RetryStream.onDone', () async {
     const retries = 3;
 
-    await expectLater(new RetryStream(_getRetryStream(retries), retries),
+    await expectLater(RetryStream(_getRetryStream(retries), retries),
         emitsInOrder(<dynamic>[1, emitsDone]));
   });
 
   test('RetryStream.infinite.retries', () async {
-    await expectLater(new RetryStream(_getRetryStream(1000)),
+    await expectLater(RetryStream(_getRetryStream(1000)),
         emitsInOrder(<dynamic>[1, emitsDone]));
   });
 
   test('RetryStream.emits.original.items', () async {
     const retries = 3;
 
-    await expectLater(new RetryStream(_getStreamWithExtras(retries), retries),
+    await expectLater(RetryStream(_getStreamWithExtras(retries), retries),
         emitsInOrder(<dynamic>[1, 1, 1, 2, emitsDone]));
   });
 
   test('RetryStream.single.subscription', () async {
     const retries = 3;
 
-    final stream = new RetryStream(_getRetryStream(retries), retries);
+    final stream = RetryStream(_getRetryStream(retries), retries);
 
     try {
       stream.listen(null);
@@ -56,7 +56,7 @@ void main() {
     const retries = 3;
 
     final stream =
-        new RetryStream(_getRetryStream(retries), retries).asBroadcastStream();
+        RetryStream(_getRetryStream(retries), retries).asBroadcastStream();
 
     // listen twice on same stream
     stream.listen(null);
@@ -66,16 +66,16 @@ void main() {
   });
 
   test('RetryStream.error.shouldThrow', () async {
-    final observableWithError = new RetryStream(_getRetryStream(3), 2);
+    final observableWithError = RetryStream(_getRetryStream(3), 2);
 
     await expectLater(
         observableWithError,
         emitsInOrder(
-            <Matcher>[emitsError(new TypeMatcher<RetryError>()), emitsDone]));
+            <Matcher>[emitsError(TypeMatcher<RetryError>()), emitsDone]));
   });
 
   test('RetryStream.error.capturesErrors', () async {
-    final observableWithError = new RetryStream(_getRetryStream(3), 2);
+    final observableWithError = RetryStream(_getRetryStream(3), 2);
 
     await expectLater(
         observableWithError,
@@ -95,7 +95,7 @@ void main() {
     StreamSubscription<int> subscription;
     const retries = 3;
 
-    subscription = new RetryStream(_getRetryStream(retries), retries)
+    subscription = RetryStream(_getRetryStream(retries), retries)
         .listen(expectAsync1((result) {
       expect(result, 1);
 
@@ -113,9 +113,9 @@ StreamFactory<int> _getRetryStream(int failCount) {
   return () {
     if (count < failCount) {
       count++;
-      return new ErrorStream<int>(new Error());
+      return ErrorStream<int>(Error());
     } else {
-      return new Observable.just(1);
+      return Observable.just(1);
     }
   };
 }
@@ -128,13 +128,13 @@ StreamFactory<int> _getStreamWithExtras(int failCount) {
       count++;
 
       // Emit first item
-      return new Observable.just(1)
+      return Observable.just(1)
           // Emit the error
-          .concatWith([new ErrorStream<int>(new Error())])
+          .concatWith([ErrorStream<int>(Error())])
           // Emit an extra item, testing that it is not included
-          .concatWith([new Observable.just(1)]);
+          .concatWith([Observable.just(1)]);
     } else {
-      return new Observable.just(2);
+      return Observable.just(2);
     }
   };
 }

--- a/test/streams/retry_when_test.dart
+++ b/test/streams/retry_when_test.dart
@@ -7,28 +7,28 @@ import 'package:test/test.dart';
 void main() {
   test('rx.Observable.retryWhen', () {
     expect(
-      new Observable.retryWhen(_sourceStream(3), _alwaysThrow),
+      Observable.retryWhen(_sourceStream(3), _alwaysThrow),
       emitsInOrder(<dynamic>[0, 1, 2, emitsDone]),
     );
   });
 
   test('RetryWhenStream', () {
     expect(
-      new RetryWhenStream(_sourceStream(3), _alwaysThrow),
+      RetryWhenStream(_sourceStream(3), _alwaysThrow),
       emitsInOrder(<dynamic>[0, 1, 2, emitsDone]),
     );
   });
 
   test('RetryWhenStream.onDone', () {
     expect(
-      new RetryWhenStream(_sourceStream(3), _alwaysThrow),
+      RetryWhenStream(_sourceStream(3), _alwaysThrow),
       emitsInOrder(<dynamic>[0, 1, 2, emitsDone]),
     );
   });
 
   test('RetryWhenStream.infinite.retries', () {
     expect(
-      new RetryWhenStream(_sourceStream(1000, 2), _neverThrow).take(6),
+      RetryWhenStream(_sourceStream(1000, 2), _neverThrow).take(6),
       emitsInOrder(<dynamic>[0, 1, 0, 1, 0, 1, emitsDone]),
     );
   });
@@ -37,13 +37,13 @@ void main() {
     const retries = 3;
 
     expect(
-      new RetryWhenStream(_getStreamWithExtras(retries), _neverThrow).take(6),
+      RetryWhenStream(_getStreamWithExtras(retries), _neverThrow).take(6),
       emitsInOrder(<dynamic>[1, 1, 1, 2, emitsDone]),
     );
   });
 
   test('RetryWhenStream.single.subscription', () {
-    final stream = new RetryWhenStream(_sourceStream(3), _neverThrow);
+    final stream = RetryWhenStream(_sourceStream(3), _neverThrow);
     try {
       stream.listen(null);
       stream.listen(null);
@@ -54,7 +54,7 @@ void main() {
 
   test('RetryWhenStream.asBroadcastStream', () {
     final stream =
-        new RetryWhenStream(_sourceStream(3), _neverThrow).asBroadcastStream();
+        RetryWhenStream(_sourceStream(3), _neverThrow).asBroadcastStream();
 
     // listen twice on same stream
     stream.listen(null);
@@ -65,17 +65,17 @@ void main() {
 
   test('RetryWhenStream.error.shouldThrow', () {
     final observableWithError =
-        new RetryWhenStream(_sourceStream(3, 0), _alwaysThrow);
+        RetryWhenStream(_sourceStream(3, 0), _alwaysThrow);
 
     expect(
         observableWithError,
         emitsInOrder(
-            <dynamic>[emitsError(new TypeMatcher<RetryError>()), emitsDone]));
+            <dynamic>[emitsError(TypeMatcher<RetryError>()), emitsDone]));
   });
 
   test('RetryWhenStream.error.capturesErrors', () async {
     final observableWithError =
-        new RetryWhenStream(_sourceStream(3, 0), _alwaysThrow);
+        RetryWhenStream(_sourceStream(3, 0), _alwaysThrow);
 
     await expectLater(
         observableWithError,
@@ -94,7 +94,7 @@ void main() {
   test('RetryWhenStream.pause.resume', () async {
     StreamSubscription<int> subscription;
 
-    subscription = new RetryWhenStream(_sourceStream(3), _neverThrow)
+    subscription = RetryWhenStream(_sourceStream(3), _neverThrow)
         .listen(expectAsync1((result) {
       expect(result, 0);
 
@@ -108,15 +108,15 @@ void main() {
 
 StreamFactory<int> _sourceStream(int i, [int throwAt]) {
   return throwAt == null
-      ? () => new Observable.fromIterable(range(i))
-      : () => new Observable.fromIterable(range(i))
+      ? () => Observable.fromIterable(range(i))
+      : () => Observable.fromIterable(range(i))
           .map((i) => i == throwAt ? throw i : i);
 }
 
 Stream<void> _alwaysThrow(dynamic e, StackTrace s) =>
-    new Observable<void>.error(new Error());
+    Observable<void>.error(Error());
 
-Stream<void> _neverThrow(dynamic e, StackTrace s) => new Observable.just('');
+Stream<void> _neverThrow(dynamic e, StackTrace s) => Observable.just('');
 
 StreamFactory<int> _getStreamWithExtras(int failCount) {
   var count = 0;
@@ -126,13 +126,13 @@ StreamFactory<int> _getStreamWithExtras(int failCount) {
       count++;
 
       // Emit first item
-      return new Observable.just(1)
+      return Observable.just(1)
           // Emit the error
-          .concatWith([new ErrorStream<int>(new Error())])
+          .concatWith([ErrorStream<int>(Error())])
           // Emit an extra item, testing that it is not included
-          .concatWith([new Observable.just(1)]);
+          .concatWith([Observable.just(1)]);
     } else {
-      return new Observable.just(2);
+      return Observable.just(2);
     }
   };
 }
@@ -167,12 +167,12 @@ Iterable<int> range(int start_or_stop, [int stop, int step]) sync* {
   stop ??= start_or_stop;
   step ??= 1;
 
-  if (step == 0) throw new ArgumentError('step cannot be 0');
+  if (step == 0) throw ArgumentError('step cannot be 0');
   if (step > 0 && stop < start)
-    throw new ArgumentError('if step is positive,'
+    throw ArgumentError('if step is positive,'
         ' stop must be greater than start');
   if (step < 0 && stop > start)
-    throw new ArgumentError('if step is negative,'
+    throw ArgumentError('if step is negative,'
         ' stop must be less than start');
 
   for (var value = start; step < 0 ? value > stop : value < stop; value += step)

--- a/test/streams/stream_test.dart
+++ b/test/streams/stream_test.dart
@@ -4,7 +4,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 Stream<int> _getStream() {
-  final a = new Stream.fromIterable(const [1, 2, 3, 4]);
+  final a = Stream.fromIterable(const [1, 2, 3, 4]);
 
   return a;
 }
@@ -14,7 +14,7 @@ void main() {
     const expectedOutput = [1, 2, 3, 4];
     var count = 0;
 
-    final stream = new Observable(_getStream());
+    final stream = Observable(_getStream());
 
     await expectLater(stream is Stream<int>, true);
     await expectLater(stream is Observable<int>, true);
@@ -26,7 +26,7 @@ void main() {
   });
 
   test('rx.Observable.stream.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream());
+    final stream = Observable(_getStream().asBroadcastStream());
 
     // listen twice on same stream
     stream.listen(null);
@@ -36,8 +36,7 @@ void main() {
   });
 
   test('rx.Observable.stream.error.shouldThrow', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()));
+    final observableWithError = Observable(ErrorStream<void>(Exception()));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {

--- a/test/streams/switch_latest_test.dart
+++ b/test/streams/switch_latest_test.dart
@@ -7,9 +7,9 @@ void main() {
   group('SwitchLatest', () {
     test('emits all values from an emitted Stream', () {
       expect(
-        new Observable.switchLatest(
-          new Observable.just(
-            new Stream.fromIterable(const ['A', 'B', 'C']),
+        Observable.switchLatest(
+          Observable.just(
+            Stream.fromIterable(const ['A', 'B', 'C']),
           ),
         ),
         emitsInOrder(<dynamic>['A', 'B', 'C', emitsDone]),
@@ -18,15 +18,15 @@ void main() {
 
     test('only emits values from the latest emitted stream', () {
       expect(
-        new Observable.switchLatest(testObservable),
+        Observable.switchLatest(testObservable),
         emits('C'),
       );
     });
 
     test('emits errors from the higher order Stream to the listener', () {
       expect(
-        new Observable.switchLatest(
-          new Observable<Stream<void>>.error(new Exception()),
+        Observable.switchLatest(
+          Observable<Stream<void>>.error(Exception()),
         ),
         emitsError(isException),
       );
@@ -34,29 +34,29 @@ void main() {
 
     test('emits errors from the emitted Stream to the listener', () {
       expect(
-        new Observable.switchLatest(errorObservable),
+        Observable.switchLatest(errorObservable),
         emitsError(isException),
       );
     });
 
     test('closes after the last event from the last emitted Stream', () {
       expect(
-        new Observable.switchLatest(testObservable),
+        Observable.switchLatest(testObservable),
         emitsThrough(emitsDone),
       );
     });
 
     test('closes if the higher order stream is empty', () {
       expect(
-        new Observable.switchLatest(
-          new Observable<Stream<void>>.empty(),
+        Observable.switchLatest(
+          Observable<Stream<void>>.empty(),
         ),
         emitsThrough(emitsDone),
       );
     });
 
     test('is single subscription', () {
-      final stream = new SwitchLatestStream(testObservable);
+      final stream = SwitchLatestStream(testObservable);
 
       expect(stream, emits('C'));
       expect(() => stream.listen(null), throwsStateError);
@@ -64,8 +64,8 @@ void main() {
 
     test('can be paused and resumed', () {
       // ignore: cancel_subscriptions
-      final subscription = new Observable.switchLatest(testObservable)
-          .listen(expectAsync1((result) {
+      final subscription =
+          Observable.switchLatest(testObservable).listen(expectAsync1((result) {
         expect(result, 'C');
       }));
 
@@ -75,14 +75,14 @@ void main() {
   });
 }
 
-Observable<Stream<String>> get testObservable => new Observable.fromIterable([
-      new Observable.timer('A', new Duration(seconds: 2)),
-      new Observable.timer('B', new Duration(seconds: 1)),
-      new Observable.just('C'),
+Observable<Stream<String>> get testObservable => Observable.fromIterable([
+      Observable.timer('A', Duration(seconds: 2)),
+      Observable.timer('B', Duration(seconds: 1)),
+      Observable.just('C'),
     ]);
 
-Observable<Stream<String>> get errorObservable => new Observable.fromIterable([
-      new Observable.timer('A', new Duration(seconds: 2)),
-      new Observable.timer('B', new Duration(seconds: 1)),
-      new Observable.error(new Exception()),
+Observable<Stream<String>> get errorObservable => Observable.fromIterable([
+      Observable.timer('A', Duration(seconds: 2)),
+      Observable.timer('B', Duration(seconds: 1)),
+      Observable.error(Exception()),
     ]);

--- a/test/streams/timer_test.dart
+++ b/test/streams/timer_test.dart
@@ -7,13 +7,13 @@ void main() {
   test('TimerStream', () async {
     const value = 1;
 
-    final stream = new TimerStream(value, new Duration(milliseconds: 1));
+    final stream = TimerStream(value, Duration(milliseconds: 1));
 
     await expectLater(stream, emitsInOrder(<dynamic>[value, emitsDone]));
   });
 
   test('TimerStream.single.subscription', () async {
-    final stream = new TimerStream(1, new Duration(milliseconds: 1));
+    final stream = TimerStream(1, Duration(milliseconds: 1));
 
     stream.listen(null);
     await expectLater(() => stream.listen(null), throwsA(isStateError));
@@ -23,7 +23,7 @@ void main() {
     const value = 1;
     StreamSubscription<int> subscription;
 
-    final stream = new TimerStream(value, new Duration(milliseconds: 1));
+    final stream = TimerStream(value, Duration(milliseconds: 1));
 
     subscription = stream.listen(expectAsync1((actual) {
       expect(actual, value);
@@ -39,7 +39,7 @@ void main() {
     const value = 1;
     StreamSubscription<int> subscription;
 
-    final stream = new TimerStream(value, new Duration(milliseconds: 1));
+    final stream = TimerStream(value, Duration(milliseconds: 1));
 
     subscription = stream.listen(
         expectAsync1((_) {
@@ -58,8 +58,7 @@ void main() {
   test('rx.Observable.timer', () async {
     const value = 1;
 
-    final observable =
-        new Observable.timer(value, new Duration(milliseconds: 5));
+    final observable = Observable.timer(value, Duration(milliseconds: 5));
 
     observable.listen(expectAsync1((actual) {
       expect(actual, value);

--- a/test/streams/zip_test.dart
+++ b/test/streams/zip_test.dart
@@ -38,7 +38,7 @@ void main() {
     ];
     var count = 0;
 
-    final testStream = new StreamController<bool>()
+    final testStream = StreamController<bool>()
       ..add(true)
       ..add(false)
       ..add(true)
@@ -47,9 +47,9 @@ void main() {
       ..close(); // ignore: unawaited_futures
 
     final observable = Observable.zip3(
-        new Stream.periodic(const Duration(milliseconds: 1), (count) => count)
+        Stream.periodic(const Duration(milliseconds: 1), (count) => count)
             .take(4),
-        new Stream.fromIterable(const [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        Stream.fromIterable(const [1, 2, 3, 4, 5, 6, 7, 8, 9]),
         testStream.stream,
         (int a, int b, bool c) => [a, b, c]);
 
@@ -66,8 +66,7 @@ void main() {
     const expected = [1, 2];
 
     // A purposely emits 2 items, b only 1
-    final a = new Observable.fromIterable(const [1, 2]),
-        b = new Observable.just(2);
+    final a = Observable.fromIterable(const [1, 2]), b = Observable.just(2);
 
     final observable =
         Observable.zip2(a, b, (int first, int second) => [first, second]);
@@ -84,9 +83,9 @@ void main() {
     // Verify the ability to pass through various types with safety
     const expected = [1, "2", 3.0];
 
-    final a = new Observable.just(1),
-        b = new Observable.just("2"),
-        c = new Observable.just(3.0);
+    final a = Observable.just(1),
+        b = Observable.just("2"),
+        c = Observable.just(3.0);
 
     final observable = Observable.zip3(a, b, c,
         (int first, String second, double third) => [first, second, third]);
@@ -99,10 +98,10 @@ void main() {
   test('rx.Observable.zip4', () async {
     const expected = [1, 2, 3, 4];
 
-    final a = new Observable.just(1),
-        b = new Observable.just(2),
-        c = new Observable.just(3),
-        d = new Observable.just(4);
+    final a = Observable.just(1),
+        b = Observable.just(2),
+        c = Observable.just(3),
+        d = Observable.just(4);
 
     final observable = Observable.zip4(
         a,
@@ -120,11 +119,11 @@ void main() {
   test('rx.Observable.zip5', () async {
     const expected = [1, 2, 3, 4, 5];
 
-    final a = new Observable.just(1),
-        b = new Observable.just(2),
-        c = new Observable.just(3),
-        d = new Observable.just(4),
-        e = new Observable.just(5);
+    final a = Observable.just(1),
+        b = Observable.just(2),
+        c = Observable.just(3),
+        d = Observable.just(4),
+        e = Observable.just(5);
 
     final observable = Observable.zip5(
         a,
@@ -143,12 +142,12 @@ void main() {
   test('rx.Observable.zip6', () async {
     const expected = [1, 2, 3, 4, 5, 6];
 
-    final a = new Observable.just(1),
-        b = new Observable.just(2),
-        c = new Observable.just(3),
-        d = new Observable.just(4),
-        e = new Observable.just(5),
-        f = new Observable.just(6);
+    final a = Observable.just(1),
+        b = Observable.just(2),
+        c = Observable.just(3),
+        d = Observable.just(4),
+        e = Observable.just(5),
+        f = Observable.just(6);
 
     final observable = Observable.zip6(
         a,
@@ -168,13 +167,13 @@ void main() {
   test('rx.Observable.zip7', () async {
     const expected = [1, 2, 3, 4, 5, 6, 7];
 
-    final a = new Observable.just(1),
-        b = new Observable.just(2),
-        c = new Observable.just(3),
-        d = new Observable.just(4),
-        e = new Observable.just(5),
-        f = new Observable.just(6),
-        g = new Observable.just(7);
+    final a = Observable.just(1),
+        b = Observable.just(2),
+        c = Observable.just(3),
+        d = Observable.just(4),
+        e = Observable.just(5),
+        f = Observable.just(6),
+        g = Observable.just(7);
 
     final observable = Observable.zip7(
         a,
@@ -196,14 +195,14 @@ void main() {
   test('rx.Observable.zip8', () async {
     const expected = [1, 2, 3, 4, 5, 6, 7, 8];
 
-    final a = new Observable.just(1),
-        b = new Observable.just(2),
-        c = new Observable.just(3),
-        d = new Observable.just(4),
-        e = new Observable.just(5),
-        f = new Observable.just(6),
-        g = new Observable.just(7),
-        h = new Observable.just(8);
+    final a = Observable.just(1),
+        b = Observable.just(2),
+        c = Observable.just(3),
+        d = Observable.just(4),
+        e = Observable.just(5),
+        f = Observable.just(6),
+        g = Observable.just(7),
+        h = Observable.just(8);
 
     Stream<List<int>> observable = Observable.zip8(
         a,
@@ -226,15 +225,15 @@ void main() {
   test('rx.Observable.zip9', () async {
     const expected = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-    final a = new Observable.just(1),
-        b = new Observable.just(2),
-        c = new Observable.just(3),
-        d = new Observable.just(4),
-        e = new Observable.just(5),
-        f = new Observable.just(6),
-        g = new Observable.just(7),
-        h = new Observable.just(8),
-        i = new Observable.just(9);
+    final a = Observable.just(1),
+        b = Observable.just(2),
+        c = Observable.just(3),
+        d = Observable.just(4),
+        e = Observable.just(5),
+        f = Observable.just(6),
+        g = Observable.just(7),
+        h = Observable.just(8),
+        i = Observable.just(9);
 
     Stream<List<int>> observable = Observable.zip9(
         a,
@@ -266,15 +265,15 @@ void main() {
   });
 
   test('rx.Observable.zip.single.subscription', () async {
-    final observable = Observable.zip2(new Observable.just(1),
-        new Observable.just(1), (int a, int b) => a + b);
+    final observable = Observable.zip2(
+        Observable.just(1), Observable.just(1), (int a, int b) => a + b);
 
     observable.listen(null);
     await expectLater(() => observable.listen(null), throwsA(isStateError));
   });
 
   test('rx.Observable.zip.asBroadcastStream', () async {
-    final testStream = new StreamController<bool>()
+    final testStream = StreamController<bool>()
       ..add(true)
       ..add(false)
       ..add(true)
@@ -283,9 +282,9 @@ void main() {
       ..close(); // ignore: unawaited_futures
 
     final observable = Observable.zip3(
-        new Stream.periodic(const Duration(milliseconds: 1), (count) => count)
+        Stream.periodic(const Duration(milliseconds: 1), (count) => count)
             .take(4),
-        new Stream.fromIterable(const [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        Stream.fromIterable(const [1, 2, 3, 4, 5, 6, 7, 8, 9]),
         testStream.stream,
         (int a, int b, bool c) => [a, b, c]).asBroadcastStream();
 
@@ -298,9 +297,9 @@ void main() {
 
   test('rx.Observable.zip.error.shouldThrowA', () async {
     final observableWithError = Observable.zip2(
-      new Observable.just(1),
-      new Observable.just(2),
-      (int a, int b) => throw new Exception(),
+      Observable.just(1),
+      Observable.just(2),
+      (int a, int b) => throw Exception(),
     );
 
     observableWithError.listen(null,
@@ -327,8 +326,8 @@ void main() {
 
   test('rx.Observable.zip.pause.resume.A', () async {
     StreamSubscription<int> subscription;
-    final stream = Observable.zip2(new Observable.just(1),
-        new Observable.just(2), (int a, int b) => a + b);
+    final stream = Observable.zip2(
+        Observable.just(1), Observable.just(2), (int a, int b) => a + b);
 
     subscription = stream.listen(expectAsync1((value) {
       expect(value, 3);
@@ -341,11 +340,11 @@ void main() {
   });
 
   test('rx.Observable.zip.pause.resume.B', () async {
-    final first = new Stream.periodic(const Duration(milliseconds: 10),
+    final first = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [1, 2, 3, 4][index]),
-        second = new Stream.periodic(const Duration(milliseconds: 10),
+        second = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [5, 6, 7, 8][index]),
-        last = new Stream.periodic(const Duration(milliseconds: 10),
+        last = Stream.periodic(const Duration(milliseconds: 10),
             (index) => const [9, 10, 11, 12][index]);
 
     StreamSubscription<Iterable<num>> subscription;
@@ -360,7 +359,6 @@ void main() {
       subscription.cancel();
     }, count: 1));
 
-    subscription
-        .pause(new Future<void>.delayed(const Duration(milliseconds: 80)));
+    subscription.pause(Future<void>.delayed(const Duration(milliseconds: 80)));
   });
 }

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('BehaviorSubject', () {
     test('emits the most recently emitted item to every subscriber', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       subject.add(1);
       subject.add(2);
@@ -23,7 +23,7 @@ void main() {
     test('emits the most recently emitted null item to every subscriber',
         () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       subject.add(1);
       subject.add(2);
@@ -38,7 +38,7 @@ void main() {
         'emits the most recently emitted item to every subscriber that subscribe to the subject directly',
         () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       subject.add(1);
       subject.add(2);
@@ -51,12 +51,12 @@ void main() {
 
     test('emits errors to every subscriber', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       subject.add(1);
       subject.add(2);
       subject.add(3);
-      subject.addError(new Exception('oh noes!'));
+      subject.addError(Exception('oh noes!'));
 
       await expectLater(subject.stream, emitsError(isException));
       await expectLater(subject.stream, emitsError(isException));
@@ -65,11 +65,11 @@ void main() {
 
     test('emits event after error to every subscriber', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       subject.add(1);
       subject.add(2);
-      subject.addError(new Exception('oh noes!'));
+      subject.addError(Exception('oh noes!'));
       subject.add(3);
 
       await expectLater(subject.stream, emits(3));
@@ -79,12 +79,12 @@ void main() {
 
     test('emits errors to every subscriber, ensures value is null', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       subject.add(1);
       subject.add(2);
       subject.add(3);
-      subject.addError(new Exception('oh noes!'));
+      subject.addError(Exception('oh noes!'));
 
       await expectLater(subject.value, isNull);
       await expectLater(subject.value, isNull);
@@ -93,7 +93,7 @@ void main() {
 
     test('can synchronously get the latest value', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       subject.add(1);
       subject.add(2);
@@ -104,7 +104,7 @@ void main() {
 
     test('can synchronously get the latest null value', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       subject.add(1);
       subject.add(2);
@@ -115,7 +115,7 @@ void main() {
 
     test('emits the seed item if no new items have been emitted', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>.seeded(1);
+      final subject = BehaviorSubject<int>.seeded(1);
 
       await expectLater(subject.stream, emits(1));
       await expectLater(subject.stream, emits(1));
@@ -125,7 +125,7 @@ void main() {
     test('emits the null seed item if no new items have been emitted',
         () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>.seeded(null);
+      final subject = BehaviorSubject<int>.seeded(null);
 
       await expectLater(subject.stream, emits(isNull));
       await expectLater(subject.stream, emits(isNull));
@@ -134,27 +134,27 @@ void main() {
 
     test('can synchronously get the initial value', () {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>.seeded(1);
+      final subject = BehaviorSubject<int>.seeded(1);
 
       expect(subject.value, 1);
     });
 
     test('can synchronously get the initial null value', () {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>.seeded(null);
+      final subject = BehaviorSubject<int>.seeded(null);
 
       expect(subject.value, null);
     });
 
     test('initial value is null when no value has been emitted', () {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       expect(subject.value, isNull);
     });
 
     test('emits done event to listeners when the subject is closed', () async {
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       await expectLater(subject.isClosed, isFalse);
 
@@ -167,18 +167,18 @@ void main() {
 
     test('emits error events to subscribers', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
-      scheduleMicrotask(() => subject.addError(new Exception()));
+      scheduleMicrotask(() => subject.addError(Exception()));
 
       await expectLater(subject.stream, emitsError(isException));
     });
 
     test('replays the previously emitted items from addStream', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
-      await subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      await subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
       await expectLater(subject.stream, emits(3));
       await expectLater(subject.stream, emits(3));
@@ -187,9 +187,9 @@ void main() {
 
     test('allows items to be added once addStream is complete', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
-      await subject.addStream(new Stream.fromIterable(const [1, 2]));
+      await subject.addStream(Stream.fromIterable(const [1, 2]));
       subject.add(3);
 
       await expectLater(subject.stream, emits(3));
@@ -198,10 +198,10 @@ void main() {
     test('allows items to be added once addStream is completes with an error',
         () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<void>();
+      final subject = BehaviorSubject<void>();
 
       await expectLater(
-          subject.addStream(new ErrorStream<void>(new Exception()),
+          subject.addStream(ErrorStream<void>(Exception()),
               cancelOnError: true),
           throwsException);
 
@@ -213,11 +213,11 @@ void main() {
     test('does not allow events to be added when addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
       await expectLater(() => subject.add(1), throwsStateError);
     });
@@ -225,23 +225,23 @@ void main() {
     test('does not allow errors to be added when addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
-      await expectLater(() => subject.addError(new Error()), throwsStateError);
+      await expectLater(() => subject.addError(Error()), throwsStateError);
     });
 
     test('does not allow subject to be closed when addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
       await expectLater(() => subject.close(), throwsStateError);
     });
@@ -250,21 +250,20 @@ void main() {
         'does not allow addStream to add items when previous addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
-      await expectLater(
-          () => subject.addStream(new Stream.fromIterable(const [1])),
+      await expectLater(() => subject.addStream(Stream.fromIterable(const [1])),
           throwsStateError);
     });
 
     test('returns onListen callback set in constructor', () async {
       final testOnListen = () {};
       // ignore: close_sinks
-      final subject = new BehaviorSubject<void>(onListen: testOnListen);
+      final subject = BehaviorSubject<void>(onListen: testOnListen);
 
       await expectLater(subject.onListen, testOnListen);
     });
@@ -272,7 +271,7 @@ void main() {
     test('sets onListen callback', () async {
       final testOnListen = () {};
       // ignore: close_sinks
-      final subject = new BehaviorSubject<void>();
+      final subject = BehaviorSubject<void>();
 
       await expectLater(subject.onListen, isNull);
 
@@ -282,9 +281,9 @@ void main() {
     });
 
     test('returns onCancel callback set in constructor', () async {
-      final onCancel = () => new Future<void>.value(null);
+      final onCancel = () => Future<void>.value(null);
       // ignore: close_sinks
-      final subject = new BehaviorSubject<void>(onCancel: onCancel);
+      final subject = BehaviorSubject<void>(onCancel: onCancel);
 
       await expectLater(subject.onCancel, onCancel);
     });
@@ -292,7 +291,7 @@ void main() {
     test('sets onCancel callback', () async {
       final testOnCancel = () {};
       // ignore: close_sinks
-      final subject = new BehaviorSubject<void>();
+      final subject = BehaviorSubject<void>();
 
       await expectLater(subject.onCancel, isNull);
 
@@ -303,7 +302,7 @@ void main() {
 
     test('reports if a listener is present', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       await expectLater(subject.hasListener, isFalse);
 
@@ -314,7 +313,7 @@ void main() {
 
     test('onPause unsupported', () {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       expect(subject.isPaused, isFalse);
       expect(() => subject.onPause, throwsUnsupportedError);
@@ -323,7 +322,7 @@ void main() {
 
     test('onResume unsupported', () {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       expect(() => subject.onResume, throwsUnsupportedError);
       expect(() => subject.onResume = () {}, throwsUnsupportedError);
@@ -331,13 +330,13 @@ void main() {
 
     test('returns controller sink', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
-      await expectLater(subject.sink, new TypeMatcher<EventSink<int>>());
+      await expectLater(subject.sink, TypeMatcher<EventSink<int>>());
     });
 
     test('correctly closes done Future', () async {
-      final subject = new BehaviorSubject<void>();
+      final subject = BehaviorSubject<void>();
 
       scheduleMicrotask(() => subject.close());
 
@@ -346,7 +345,7 @@ void main() {
 
     test('can be listened to multiple times', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject.seeded(1);
+      final subject = BehaviorSubject.seeded(1);
       final stream = subject.stream;
 
       await expectLater(stream, emits(1));
@@ -355,7 +354,7 @@ void main() {
 
     test('always returns the same stream', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       await expectLater(subject.stream, equals(subject.stream));
     });
@@ -363,7 +362,7 @@ void main() {
     test('adding to sink has same behavior as adding to Subject itself',
         () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       subject.sink.add(1);
 
@@ -379,8 +378,8 @@ void main() {
 
     test('is always treated as a broadcast Stream', () async {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
-      final stream = subject.asyncMap((event) => new Future.value(event));
+      final subject = BehaviorSubject<int>();
+      final stream = subject.asyncMap((event) => Future.value(event));
 
       expect(subject.isBroadcast, isTrue);
       expect(stream.isBroadcast, isTrue);
@@ -388,28 +387,28 @@ void main() {
 
     test('hasValue returns false for an empty subject', () {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       expect(subject.hasValue, isFalse);
     });
 
     test('hasValue returns true for a seeded subject with non-null seed', () {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>.seeded(1);
+      final subject = BehaviorSubject<int>.seeded(1);
 
       expect(subject.hasValue, isTrue);
     });
 
     test('hasValue returns true for a seeded subject with null seed', () {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>.seeded(null);
+      final subject = BehaviorSubject<int>.seeded(null);
 
       expect(subject.hasValue, isTrue);
     });
 
     test('hasValue returns true for an unseeded subject after an emission', () {
       // ignore: close_sinks
-      final subject = new BehaviorSubject<int>();
+      final subject = BehaviorSubject<int>();
 
       subject.add(1);
 

--- a/test/subject/publish_subject_test.dart
+++ b/test/subject/publish_subject_test.dart
@@ -10,7 +10,7 @@ void main() {
   group('PublishSubject', () {
     test('emits items to every subscriber', () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       scheduleMicrotask(() {
         subject.add(1);
@@ -27,7 +27,7 @@ void main() {
         'emits items to every subscriber that subscribe directly to the Subject',
         () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       scheduleMicrotask(() {
         subject.add(1);
@@ -40,7 +40,7 @@ void main() {
     });
 
     test('emits done event to listeners when the subject is closed', () async {
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       await expectLater(subject.isClosed, isFalse);
 
@@ -54,7 +54,7 @@ void main() {
     test(
         'emits done event to listeners when the subject is closed (listen directly on Subject)',
         () async {
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       await expectLater(subject.isClosed, isFalse);
 
@@ -67,9 +67,9 @@ void main() {
 
     test('emits error events to subscribers', () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
-      scheduleMicrotask(() => subject.addError(new Exception()));
+      scheduleMicrotask(() => subject.addError(Exception()));
 
       await expectLater(subject.stream, emitsError(isException));
     });
@@ -77,28 +77,28 @@ void main() {
     test('emits error events to subscribers (listen directly on Subject)',
         () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
-      scheduleMicrotask(() => subject.addError(new Exception()));
+      scheduleMicrotask(() => subject.addError(Exception()));
 
       await expectLater(subject, emitsError(isException));
     });
 
     test('emits the items from addStream', () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       scheduleMicrotask(
-          () => subject.addStream(new Stream.fromIterable(const [1, 2, 3])));
+          () => subject.addStream(Stream.fromIterable(const [1, 2, 3])));
 
       await expectLater(subject.stream, emitsInOrder(const <int>[1, 2, 3]));
     });
 
     test('allows items to be added once addStream is complete', () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
-      await subject.addStream(new Stream.fromIterable(const [1, 2]));
+      await subject.addStream(Stream.fromIterable(const [1, 2]));
       scheduleMicrotask(() => subject.add(3));
 
       await expectLater(subject.stream, emits(3));
@@ -107,11 +107,10 @@ void main() {
     test('allows items to be added once addStream is completes with an error',
         () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       await expectLater(
-          subject.addStream(new ErrorStream<int>(new Exception()),
-              cancelOnError: true),
+          subject.addStream(ErrorStream<int>(Exception()), cancelOnError: true),
           throwsException);
 
       scheduleMicrotask(() => subject.add(1));
@@ -122,11 +121,11 @@ void main() {
     test('does not allow events to be added when addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
       await expectLater(() => subject.add(1), throwsStateError);
     });
@@ -134,23 +133,23 @@ void main() {
     test('does not allow errors to be added when addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
-      await expectLater(() => subject.addError(new Error()), throwsStateError);
+      await expectLater(() => subject.addError(Error()), throwsStateError);
     });
 
     test('does not allow subject to be closed when addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
       await expectLater(() => subject.close(), throwsStateError);
     });
@@ -159,21 +158,20 @@ void main() {
         'does not allow addStream to add items when previous addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
-      await expectLater(
-          () => subject.addStream(new Stream.fromIterable(const [1])),
+      await expectLater(() => subject.addStream(Stream.fromIterable(const [1])),
           throwsStateError);
     });
 
     test('returns onListen callback set in constructor', () async {
       final testOnListen = () {};
       // ignore: close_sinks
-      final subject = new PublishSubject<int>(onListen: testOnListen);
+      final subject = PublishSubject<int>(onListen: testOnListen);
 
       await expectLater(subject.onListen, testOnListen);
     });
@@ -181,7 +179,7 @@ void main() {
     test('sets onListen callback', () async {
       final testOnListen = () {};
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       await expectLater(subject.onListen, isNull);
 
@@ -191,9 +189,9 @@ void main() {
     });
 
     test('returns onCancel callback set in constructor', () async {
-      final onCancel = () => new Future<Null>.value(null);
+      final onCancel = () => Future<Null>.value(null);
       // ignore: close_sinks
-      final subject = new PublishSubject<int>(onCancel: onCancel);
+      final subject = PublishSubject<int>(onCancel: onCancel);
 
       await expectLater(subject.onCancel, onCancel);
     });
@@ -201,7 +199,7 @@ void main() {
     test('sets onCancel callback', () async {
       final testOnCancel = () {};
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       await expectLater(subject.onCancel, isNull);
 
@@ -212,7 +210,7 @@ void main() {
 
     test('reports if a listener is present', () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       await expectLater(subject.hasListener, isFalse);
 
@@ -223,7 +221,7 @@ void main() {
 
     test('onPause unsupported', () {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       expect(subject.isPaused, isFalse);
       expect(() => subject.onPause, throwsUnsupportedError);
@@ -232,7 +230,7 @@ void main() {
 
     test('onResume unsupported', () {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       expect(() => subject.onResume, throwsUnsupportedError);
       expect(() => subject.onResume = () {}, throwsUnsupportedError);
@@ -240,13 +238,13 @@ void main() {
 
     test('returns controller sink', () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
-      await expectLater(subject.sink, new TypeMatcher<EventSink<int>>());
+      await expectLater(subject.sink, TypeMatcher<EventSink<int>>());
     });
 
     test('correctly closes done Future', () async {
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       scheduleMicrotask(() => subject.close());
 
@@ -255,7 +253,7 @@ void main() {
 
     test('can be listened to multiple times', () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
       final stream = subject.stream;
 
       scheduleMicrotask(() => subject.add(1));
@@ -267,7 +265,7 @@ void main() {
 
     test('always returns the same stream', () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       await expectLater(subject.stream, equals(subject.stream));
     });
@@ -275,7 +273,7 @@ void main() {
     test('adding to sink has same behavior as adding to Subject itself',
         () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
+      final subject = PublishSubject<int>();
 
       scheduleMicrotask(() {
         subject.sink.add(1);
@@ -290,8 +288,8 @@ void main() {
 
     test('is always treated as a broadcast Stream', () async {
       // ignore: close_sinks
-      final subject = new PublishSubject<int>();
-      final stream = subject.asyncMap((event) => new Future.value(event));
+      final subject = PublishSubject<int>();
+      final stream = subject.asyncMap((event) => Future.value(event));
 
       expect(subject.isBroadcast, isTrue);
       expect(stream.isBroadcast, isTrue);

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('ReplaySubject', () {
     test('replays the previously emitted items to every subscriber', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       subject.add(1);
       subject.add(2);
@@ -24,7 +24,7 @@ void main() {
         'replays the previously emitted items to every subscriber that directly subscribes to the Subject',
         () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       subject.add(1);
       subject.add(2);
@@ -37,7 +37,7 @@ void main() {
 
     test('synchronously get the previous items', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       subject.add(1);
       subject.add(2);
@@ -48,7 +48,7 @@ void main() {
 
     test('replays the most recently emitted items up to a max size', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>(maxSize: 2);
+      final subject = ReplaySubject<int>(maxSize: 2);
 
       subject.add(1); // Should be dropped
       subject.add(2);
@@ -60,7 +60,7 @@ void main() {
     });
 
     test('emits done event to listeners when the subject is closed', () async {
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       await expectLater(subject.isClosed, isFalse);
 
@@ -73,18 +73,18 @@ void main() {
 
     test('emits error events to subscribers', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
-      scheduleMicrotask(() => subject.addError(new Exception()));
+      scheduleMicrotask(() => subject.addError(Exception()));
 
       await expectLater(subject.stream, emitsError(isException));
     });
 
     test('replays the previously emitted items from addStream', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
-      await subject.addStream(new Stream<int>.fromIterable(const [1, 2, 3]));
+      await subject.addStream(Stream<int>.fromIterable(const [1, 2, 3]));
 
       await expectLater(subject.stream, emitsInOrder(const <int>[1, 2, 3]));
       await expectLater(subject.stream, emitsInOrder(const <int>[1, 2, 3]));
@@ -93,9 +93,9 @@ void main() {
 
     test('allows items to be added once addStream is complete', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
-      await subject.addStream(new Stream.fromIterable(const [1, 2]));
+      await subject.addStream(Stream.fromIterable(const [1, 2]));
       subject.add(3);
 
       await expectLater(subject.stream, emitsInOrder(const <int>[1, 2, 3]));
@@ -104,11 +104,10 @@ void main() {
     test('allows items to be added once addStream is completes with an error',
         () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       await expectLater(
-          subject.addStream(new ErrorStream<int>(new Exception()),
-              cancelOnError: true),
+          subject.addStream(ErrorStream<int>(Exception()), cancelOnError: true),
           throwsException);
 
       subject.add(1);
@@ -119,11 +118,11 @@ void main() {
     test('does not allow events to be added when addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
       await expectLater(() => subject.add(1), throwsStateError);
     });
@@ -131,23 +130,23 @@ void main() {
     test('does not allow errors to be added when addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
-      await expectLater(() => subject.addError(new Error()), throwsStateError);
+      await expectLater(() => subject.addError(Error()), throwsStateError);
     });
 
     test('does not allow subject to be closed when addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
       await expectLater(() => subject.close(), throwsStateError);
     });
@@ -156,21 +155,20 @@ void main() {
         'does not allow addStream to add items when previous addStream is active',
         () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       // Purposely don't wait for the future to complete, then try to add items
       // ignore: unawaited_futures
-      subject.addStream(new Stream.fromIterable(const [1, 2, 3]));
+      subject.addStream(Stream.fromIterable(const [1, 2, 3]));
 
-      await expectLater(
-          () => subject.addStream(new Stream.fromIterable(const [1])),
+      await expectLater(() => subject.addStream(Stream.fromIterable(const [1])),
           throwsStateError);
     });
 
     test('returns onListen callback set in constructor', () async {
       final testOnListen = () {};
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>(onListen: testOnListen);
+      final subject = ReplaySubject<int>(onListen: testOnListen);
 
       await expectLater(subject.onListen, testOnListen);
     });
@@ -178,7 +176,7 @@ void main() {
     test('sets onListen callback', () async {
       final testOnListen = () {};
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       await expectLater(subject.onListen, isNull);
 
@@ -188,9 +186,9 @@ void main() {
     });
 
     test('returns onCancel callback set in constructor', () async {
-      final onCancel = () => new Future<void>.value(null);
+      final onCancel = () => Future<void>.value(null);
       // ignore: close_sinks
-      final subject = new ReplaySubject<void>(onCancel: onCancel);
+      final subject = ReplaySubject<void>(onCancel: onCancel);
 
       await expectLater(subject.onCancel, onCancel);
     });
@@ -198,7 +196,7 @@ void main() {
     test('sets onCancel callback', () async {
       final testOnCancel = () {};
       // ignore: close_sinks
-      final subject = new ReplaySubject<void>();
+      final subject = ReplaySubject<void>();
 
       await expectLater(subject.onCancel, isNull);
 
@@ -209,7 +207,7 @@ void main() {
 
     test('reports if a listener is present', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<void>();
+      final subject = ReplaySubject<void>();
 
       await expectLater(subject.hasListener, isFalse);
 
@@ -220,7 +218,7 @@ void main() {
 
     test('onPause unsupported', () {
       // ignore: close_sinks
-      final subject = new ReplaySubject<void>();
+      final subject = ReplaySubject<void>();
 
       expect(subject.isPaused, isFalse);
       expect(() => subject.onPause, throwsUnsupportedError);
@@ -229,7 +227,7 @@ void main() {
 
     test('onResume unsupported', () {
       // ignore: close_sinks
-      final subject = new ReplaySubject<void>();
+      final subject = ReplaySubject<void>();
 
       expect(() => subject.onResume, throwsUnsupportedError);
       expect(() => subject.onResume = () {}, throwsUnsupportedError);
@@ -237,13 +235,13 @@ void main() {
 
     test('returns controller sink', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
-      await expectLater(subject.sink, new TypeMatcher<EventSink<int>>());
+      await expectLater(subject.sink, TypeMatcher<EventSink<int>>());
     });
 
     test('correctly closes done Future', () async {
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       scheduleMicrotask(subject.close);
 
@@ -252,7 +250,7 @@ void main() {
 
     test('can be listened to multiple times', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
       final stream = subject.stream;
 
       subject.add(1);
@@ -264,7 +262,7 @@ void main() {
 
     test('always returns the same stream', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       await expectLater(subject.stream, equals(subject.stream));
     });
@@ -272,7 +270,7 @@ void main() {
     test('adding to sink has same behavior as adding to Subject itself',
         () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
+      final subject = ReplaySubject<int>();
 
       subject.sink.add(1);
       subject.sink.add(2);
@@ -285,8 +283,8 @@ void main() {
 
     test('is always treated as a broadcast Stream', () async {
       // ignore: close_sinks
-      final subject = new ReplaySubject<int>();
-      final stream = subject.asyncMap((event) => new Future.value(event));
+      final subject = ReplaySubject<int>();
+      final stream = subject.asyncMap((event) => Future.value(event));
 
       expect(subject.isBroadcast, isTrue);
       expect(stream.isBroadcast, isTrue);

--- a/test/transformers/any_test.dart
+++ b/test/transformers/any_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.any', () async {
-    final actual = await new Observable.just(1).any((val) => val == 1);
+    final actual = await Observable.just(1).any((val) => val == 1);
 
     await expectLater(actual, true);
   });

--- a/test/transformers/as_broadcast_stream.dart
+++ b/test/transformers/as_broadcast_stream.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.asBroadcastStream', () async {
-    Stream<int> observable = new Observable<int>.just(1).asBroadcastStream();
+    Stream<int> observable = Observable<int>.just(1).asBroadcastStream();
 
     await expectLater(observable.isBroadcast, isTrue);
   });

--- a/test/transformers/async_expand_test.dart
+++ b/test/transformers/async_expand_test.dart
@@ -6,8 +6,8 @@ void main() {
     const expected = [1, 2, 3];
     var count = 0;
 
-    final observable = new Observable.fromIterable(expected)
-        .asyncExpand((value) => new Observable.fromIterable([value]));
+    final observable = Observable.fromIterable(expected)
+        .asyncExpand((value) => Observable.fromIterable([value]));
 
     observable.listen(expectAsync1((actual) {
       expect(actual, expected[count++]);

--- a/test/transformers/async_map_test.dart
+++ b/test/transformers/async_map_test.dart
@@ -7,8 +7,8 @@ void main() {
   test('rx.Observable.asyncMap', () async {
     const expected = 1;
 
-    final observable = new Observable.just(expected)
-        .asyncMap((value) => new Future.value(value));
+    final observable =
+        Observable.just(expected).asyncMap((value) => Future.value(value));
 
     observable.listen(expectAsync1((actual) {
       expect(actual, expected);

--- a/test/transformers/buffer_count_test.dart
+++ b/test/transformers/buffer_count_test.dart
@@ -136,14 +136,14 @@ void main() {
   });
 
   test('rx.Observable.bufferCount.reusable', () async {
-    final transformer = new BufferStreamTransformer<int>(onCount(2));
+    final transformer = BufferStreamTransformer<int>(onCount(2));
     const expectedOutput = [
       [1, 2],
       [3, 4]
     ];
     var countA = 0, countB = 0;
 
-    final streamA = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final streamA = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer);
 
     streamA.listen(expectAsync1((result) {
@@ -153,7 +153,7 @@ void main() {
       countA++;
     }, count: expectedOutput.length));
 
-    final streamB = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final streamB = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer);
 
     streamB.listen(expectAsync1((result) {
@@ -165,9 +165,9 @@ void main() {
   });
 
   test('rx.Observable.bufferCount.asBroadcastStream', () async {
-    final stream = new Observable(
-            new Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
-        .bufferCount(2);
+    final stream =
+        Observable(Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
+            .bufferCount(2);
 
     // listen twice on same stream
     stream.listen(null);
@@ -177,9 +177,9 @@ void main() {
   });
 
   test('rx.Observable.bufferCount.asBroadcastStream.asBuffer', () async {
-    final stream = new Observable(
-            new Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
-        .buffer(onCount(2));
+    final stream =
+        Observable(Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
+            .buffer(onCount(2));
 
     // listen twice on same stream
     stream.listen(null);
@@ -190,7 +190,7 @@ void main() {
 
   test('rx.Observable.bufferCount.error.shouldThrowA', () async {
     final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception())).bufferCount(2);
+        Observable(ErrorStream<void>(Exception())).bufferCount(2);
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -200,8 +200,7 @@ void main() {
 
   test('rx.Observable.bufferCount.error.shouldThrowA.asBuffer', () async {
     final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .buffer(onCount(2));
+        Observable(ErrorStream<void>(Exception())).buffer(onCount(2));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -210,7 +209,7 @@ void main() {
   });
 
   test('rx.Observable.bufferCount.shouldThrow.invalidCount.negative', () {
-    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+    Observable<int>.fromIterable(const [1, 2, 3, 4])
         .bufferCount(-1)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -218,7 +217,7 @@ void main() {
   });
 
   test('rx.Observable.bufferCount.shouldThrow.invalidCount.isNull', () {
-    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+    Observable<int>.fromIterable(const [1, 2, 3, 4])
         .bufferCount(null)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -227,7 +226,7 @@ void main() {
 
   test('rx.Observable.bufferCount.shouldThrow.invalidCount.negative.asBuffer',
       () {
-    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+    Observable<int>.fromIterable(const [1, 2, 3, 4])
         .buffer(onCount(-1))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -236,7 +235,7 @@ void main() {
 
   test('rx.Observable.bufferCount.shouldThrow.invalidCount.isNull.asBuffer',
       () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .buffer(onCount(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -246,7 +245,7 @@ void main() {
   test(
       'rx.Observable.bufferCount.startBufferEvery.shouldThrow.invalidStartBufferEvery',
       () {
-    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+    Observable<int>.fromIterable(const [1, 2, 3, 4])
         .bufferCount(2, -1)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);

--- a/test/transformers/buffer_future_test.dart
+++ b/test/transformers/buffer_future_test.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Observable<int> getStream(int n) => new Observable<int>((int n) async* {
+Observable<int> getStream(int n) => Observable<int>((int n) async* {
       var k = 0;
 
       while (k < n) {
-        await new Future<Null>.delayed(const Duration(milliseconds: 100));
+        await Future<Null>.delayed(const Duration(milliseconds: 100));
 
         yield k++;
       }
@@ -23,7 +23,7 @@ void main() {
 
     getStream(4)
         .bufferFuture(
-            () => new Future<Null>.delayed(const Duration(milliseconds: 220)))
+            () => Future<Null>.delayed(const Duration(milliseconds: 220)))
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
           expect(result, expectedOutput[count++]);
@@ -39,7 +39,7 @@ void main() {
 
     getStream(4)
         .buffer(onFuture(
-            () => new Future<Null>.delayed(const Duration(milliseconds: 220))))
+            () => Future<Null>.delayed(const Duration(milliseconds: 220))))
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
           expect(result, expectedOutput[count++]);
@@ -56,11 +56,11 @@ void main() {
     ];
     var count = 0;
 
-    new Observable.fromFuture(
-            new Future<Null>.delayed(const Duration(milliseconds: 200))
+    Observable.fromFuture(
+            Future<Null>.delayed(const Duration(milliseconds: 200))
                 .then((_) => 'done'))
         .bufferFuture(
-            () => new Future<Null>.delayed(const Duration(milliseconds: 40)))
+            () => Future<Null>.delayed(const Duration(milliseconds: 40)))
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
           expect(result, expectedOutput[count++]);
@@ -78,11 +78,11 @@ void main() {
     ];
     var count = 0;
 
-    new Observable.fromFuture(
-            new Future<Null>.delayed(const Duration(milliseconds: 200))
+    Observable.fromFuture(
+            Future<Null>.delayed(const Duration(milliseconds: 200))
                 .then((_) => 'done'))
         .buffer(onFuture(
-            () => new Future<Null>.delayed(const Duration(milliseconds: 40))))
+            () => Future<Null>.delayed(const Duration(milliseconds: 40))))
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
           expect(result, expectedOutput[count++]);
@@ -91,11 +91,10 @@ void main() {
 
   test('rx.Observable.bufferFuture.shouldClose', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
-        .bufferFuture(
-            () => new Future<Null>.delayed(const Duration(seconds: 3)))
+    Observable(controller.stream)
+        .bufferFuture(() => Future<Null>.delayed(const Duration(seconds: 3)))
         .listen(
             expectAsync1((result) => expect(result, expectedOutput), count: 1),
             onDone: expectAsync0(() => expect(true, isTrue)));
@@ -110,11 +109,11 @@ void main() {
 
   test('rx.Observable.bufferFuture.shouldClose.asBuffer', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
-        .buffer(onFuture(
-            () => new Future<Null>.delayed(const Duration(seconds: 3))))
+    Observable(controller.stream)
+        .buffer(
+            onFuture(() => Future<Null>.delayed(const Duration(seconds: 3))))
         .listen(
             expectAsync1((result) => expect(result, expectedOutput), count: 1),
             onDone: expectAsync0(() => expect(true, isTrue)));
@@ -128,8 +127,8 @@ void main() {
   });
 
   test('rx.Observable.bufferFuture.reusable', () async {
-    final transformer = new BufferStreamTransformer<int>(onFuture(
-        () => new Future<Null>.delayed(const Duration(milliseconds: 220))));
+    final transformer = BufferStreamTransformer<int>(onFuture(
+        () => Future<Null>.delayed(const Duration(milliseconds: 220))));
     const expectedOutput = [
       [0, 1],
       [2, 3]
@@ -153,7 +152,7 @@ void main() {
 
   test('rx.Observable.bufferFuture.asBroadcastStream', () async {
     final stream = getStream(4).asBroadcastStream().bufferFuture(
-        () => new Future<Null>.delayed(const Duration(milliseconds: 220)));
+        () => Future<Null>.delayed(const Duration(milliseconds: 220)));
 
     // listen twice on same stream
     stream.listen(expectAsync1((_) {}, count: 2));
@@ -164,7 +163,7 @@ void main() {
 
   test('rx.Observable.bufferFuture.asBroadcastStream.asBuffer', () async {
     final stream = getStream(4).asBroadcastStream().buffer(onFuture(
-        () => new Future<Null>.delayed(const Duration(milliseconds: 220))));
+        () => Future<Null>.delayed(const Duration(milliseconds: 220))));
 
     // listen twice on same stream
     stream.listen(expectAsync1((_) {}, count: 2));
@@ -174,9 +173,9 @@ void main() {
   });
 
   test('rx.Observable.bufferFuture.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<Null>(new Exception())).bufferFuture(
-            () => new Future<Null>.delayed(const Duration(milliseconds: 220)));
+    final observableWithError = Observable(ErrorStream<Null>(Exception()))
+        .bufferFuture(
+            () => Future<Null>.delayed(const Duration(milliseconds: 220)));
 
     observableWithError.listen(null,
         onError: expectAsync2((Object e, StackTrace s) {
@@ -185,9 +184,9 @@ void main() {
   });
 
   test('rx.Observable.bufferFuture.error.shouldThrowA.asBuffer', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<Null>(new Exception())).buffer(onFuture(
-            () => new Future<Null>.delayed(const Duration(milliseconds: 220))));
+    final observableWithError = Observable(ErrorStream<Null>(Exception()))
+        .buffer(onFuture(
+            () => Future<Null>.delayed(const Duration(milliseconds: 220))));
 
     observableWithError.listen(null,
         onError: expectAsync2((Object e, StackTrace s) {
@@ -196,7 +195,7 @@ void main() {
   });
 
   test('rx.Observable.bufferFuture.error.shouldThrowB', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .bufferFuture<Null>(null)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -204,7 +203,7 @@ void main() {
   });
 
   test('rx.Observable.bufferFuture.error.shouldThrowB.asFuture', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .buffer(onFuture<int, List<int>, void>(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);

--- a/test/transformers/buffer_test.dart
+++ b/test/transformers/buffer_test.dart
@@ -5,8 +5,8 @@ import 'package:test/test.dart';
 /// using [onCount], [onFuture], [onTest], [onTime], [onStream]
 void main() {
   test('rx.Observable.buffer.onNull.shouldThrow', () {
-    new Observable<int>.fromIterable(<int>[1, 2, 3, 4]).buffer(null).listen(
-        null, onError: expectAsync2((NoSuchMethodError e, StackTrace s) {
+    Observable<int>.fromIterable(<int>[1, 2, 3, 4]).buffer(null).listen(null,
+        onError: expectAsync2((NoSuchMethodError e, StackTrace s) {
       expect(e, isNoSuchMethodError);
     }));
   });

--- a/test/transformers/buffer_test_test.dart
+++ b/test/transformers/buffer_test_test.dart
@@ -39,15 +39,14 @@ void main() {
   });
 
   test('rx.Observable.bufferTest.reusable', () async {
-    final transformer =
-        new BufferStreamTransformer<int>(onTest((i) => i % 2 == 0));
+    final transformer = BufferStreamTransformer<int>(onTest((i) => i % 2 == 0));
     const expectedOutput = [
       [1, 2],
       [3, 4]
     ];
     var countA = 0, countB = 0;
 
-    final streamA = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final streamA = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer);
 
     streamA.listen(expectAsync1((result) {
@@ -57,7 +56,7 @@ void main() {
       countA++;
     }, count: 2));
 
-    final streamB = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final streamB = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer);
 
     streamB.listen(expectAsync1((result) {
@@ -69,9 +68,9 @@ void main() {
   });
 
   test('rx.Observable.bufferTest.asBroadcastStream', () async {
-    final stream = new Observable(
-            new Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
-        .bufferTest((i) => i % 2 == 0);
+    final stream =
+        Observable(Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
+            .bufferTest((i) => i % 2 == 0);
 
     // listen twice on same stream
     stream.listen(null);
@@ -81,9 +80,9 @@ void main() {
   });
 
   test('rx.Observable.bufferTest.asBroadcastStream.asBuffer', () async {
-    final stream = new Observable(
-            new Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
-        .buffer(onTest((i) => i % 2 == 0));
+    final stream =
+        Observable(Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
+            .buffer(onTest((i) => i % 2 == 0));
 
     // listen twice on same stream
     stream.listen(null);
@@ -94,8 +93,7 @@ void main() {
 
   test('rx.Observable.bufferTest.error.shouldThrowA', () async {
     final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .bufferTest((i) => i % 2 == 0);
+        Observable(ErrorStream<int>(Exception())).bufferTest((i) => i % 2 == 0);
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -104,9 +102,8 @@ void main() {
   });
 
   test('rx.Observable.bufferTest.error.shouldThrowA.asBuffer', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .buffer(onTest((i) => i % 2 == 0));
+    final observableWithError = Observable(ErrorStream<int>(Exception()))
+        .buffer(onTest((i) => i % 2 == 0));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -115,15 +112,14 @@ void main() {
   });
 
   test('rx.Observable.bufferTest.skip.shouldThrowB', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
-        .bufferTest(null)
-        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
+    Observable.fromIterable(const [1, 2, 3, 4]).bufferTest(null).listen(null,
+        onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
     }));
   });
 
   test('rx.Observable.bufferTest.skip.shouldThrowB.asBuffer', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .buffer(onTest(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);

--- a/test/transformers/buffer_time_test.dart
+++ b/test/transformers/buffer_time_test.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Observable<int> getStream(int n) => new Observable<int>((int n) async* {
+Observable<int> getStream(int n) => Observable<int>((int n) async* {
       var k = 0;
 
       while (k < n) {
-        await new Future<void>.delayed(const Duration(milliseconds: 100));
+        await Future<void>.delayed(const Duration(milliseconds: 100));
 
         yield k++;
       }
@@ -46,9 +46,9 @@ void main() {
 
   test('rx.Observable.bufferTime.shouldClose', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
+    Observable(controller.stream)
         .bufferTime(const Duration(seconds: 3))
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
@@ -65,9 +65,9 @@ void main() {
 
   test('rx.Observable.bufferTime.shouldClose.asBuffer', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
+    Observable(controller.stream)
         .buffer(onTime(const Duration(seconds: 3)))
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
@@ -83,8 +83,8 @@ void main() {
   });
 
   test('rx.Observable.bufferTime.reusable', () async {
-    final transformer = new BufferStreamTransformer<int>(
-        onTime(const Duration(milliseconds: 220)));
+    final transformer =
+        BufferStreamTransformer<int>(onTime(const Duration(milliseconds: 220)));
     const expectedOutput = [
       [0, 1],
       [2, 3]
@@ -131,9 +131,8 @@ void main() {
   });
 
   test('rx.Observable.bufferTime.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .bufferTime(const Duration(milliseconds: 220));
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .bufferTime(const Duration(milliseconds: 220));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -142,9 +141,8 @@ void main() {
   });
 
   test('rx.Observable.bufferTime.error.shouldThrowA.asBuffer', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .buffer(onTime(const Duration(milliseconds: 220)));
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .buffer(onTime(const Duration(milliseconds: 220)));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -153,15 +151,14 @@ void main() {
   });
 
   test('rx.Observable.bufferTime.error.shouldThrowB', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
-        .bufferTime(null)
-        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
+    Observable.fromIterable(const [1, 2, 3, 4]).bufferTime(null).listen(null,
+        onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
     }));
   });
 
   test('rx.Observable.bufferTime.error.shouldThrowB.asBuffer', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .buffer(onTime(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);

--- a/test/transformers/buffer_when_test.dart
+++ b/test/transformers/buffer_when_test.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Observable<int> getStream(int n) => new Observable<int>((int n) async* {
+Observable<int> getStream(int n) => Observable<int>((int n) async* {
       var k = 0;
 
       while (k < n) {
-        await new Future<Null>.delayed(const Duration(milliseconds: 100));
+        await Future<Null>.delayed(const Duration(milliseconds: 100));
 
         yield k++;
       }
@@ -22,8 +22,7 @@ void main() {
     var count = 0;
 
     getStream(4)
-        .bufferWhen(
-            new Stream<Null>.periodic(const Duration(milliseconds: 220)))
+        .bufferWhen(Stream<Null>.periodic(const Duration(milliseconds: 220)))
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
           expect(result, expectedOutput[count++]);
@@ -38,8 +37,8 @@ void main() {
     var count = 0;
 
     getStream(4)
-        .buffer(onStream(
-            new Stream<Null>.periodic(const Duration(milliseconds: 220))))
+        .buffer(
+            onStream(Stream<Null>.periodic(const Duration(milliseconds: 220))))
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
           expect(result, expectedOutput[count++]);
@@ -56,10 +55,10 @@ void main() {
     ];
     var count = 0;
 
-    new Observable.fromFuture(
-            new Future<Null>.delayed(const Duration(milliseconds: 200))
+    Observable.fromFuture(
+            Future<Null>.delayed(const Duration(milliseconds: 200))
                 .then((_) => 'done'))
-        .bufferWhen(new Stream<Null>.periodic(const Duration(milliseconds: 40)))
+        .bufferWhen(Stream<Null>.periodic(const Duration(milliseconds: 40)))
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
           expect(result, expectedOutput[count++]);
@@ -77,11 +76,11 @@ void main() {
     ];
     var count = 0;
 
-    new Observable.fromFuture(
-            new Future<Null>.delayed(const Duration(milliseconds: 200))
+    Observable.fromFuture(
+            Future<Null>.delayed(const Duration(milliseconds: 200))
                 .then((_) => 'done'))
-        .buffer(onStream(
-            new Stream<Null>.periodic(const Duration(milliseconds: 40))))
+        .buffer(
+            onStream(Stream<Null>.periodic(const Duration(milliseconds: 40))))
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
           expect(result, expectedOutput[count++]);
@@ -90,10 +89,10 @@ void main() {
 
   test('rx.Observable.bufferWhen.shouldClose', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
-        .bufferWhen(new Stream<Null>.periodic(const Duration(seconds: 3)))
+    Observable(controller.stream)
+        .bufferWhen(Stream<Null>.periodic(const Duration(seconds: 3)))
         .listen(
             expectAsync1((result) => expect(result, expectedOutput), count: 1),
             onDone: expectAsync0(() => expect(true, isTrue)));
@@ -108,10 +107,10 @@ void main() {
 
   test('rx.Observable.bufferWhen.shouldClose.asBuffer', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
-        .buffer(onStream(new Stream<Null>.periodic(const Duration(seconds: 3))))
+    Observable(controller.stream)
+        .buffer(onStream(Stream<Null>.periodic(const Duration(seconds: 3))))
         .listen(
             expectAsync1((result) => expect(result, expectedOutput), count: 1),
             onDone: expectAsync0(() => expect(true, isTrue)));
@@ -125,8 +124,8 @@ void main() {
   }, skip: 'todo: investigate why this test makes the process hang');
 
   test('rx.Observable.bufferWhen.reusable', () async {
-    final transformer = new BufferStreamTransformer<int>(onStream(
-        new Stream<Null>.periodic(const Duration(milliseconds: 220))
+    final transformer = BufferStreamTransformer<int>(onStream(
+        Stream<Null>.periodic(const Duration(milliseconds: 220))
             .asBroadcastStream()));
     const expectedOutput = [
       [0, 1],
@@ -151,7 +150,7 @@ void main() {
 
   test('rx.Observable.bufferWhen.asBroadcastStream', () async {
     final stream = getStream(4).asBroadcastStream().bufferWhen(
-        new Stream<Null>.periodic(const Duration(milliseconds: 220))
+        Stream<Null>.periodic(const Duration(milliseconds: 220))
             .asBroadcastStream());
 
     // listen twice on same stream
@@ -163,7 +162,7 @@ void main() {
 
   test('rx.Observable.bufferWhen.asBroadcastStream.asBuffer', () async {
     final stream = getStream(4).asBroadcastStream().buffer(onStream(
-        new Stream<Null>.periodic(const Duration(milliseconds: 220))
+        Stream<Null>.periodic(const Duration(milliseconds: 220))
             .asBroadcastStream()));
 
     // listen twice on same stream
@@ -174,9 +173,8 @@ void main() {
   }, skip: 'todo: investigate why this test makes the process hang');
 
   test('rx.Observable.bufferWhen.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<Null>(new Exception())).bufferWhen(
-            new Stream<Null>.periodic(const Duration(milliseconds: 220)));
+    final observableWithError = Observable(ErrorStream<Null>(Exception()))
+        .bufferWhen(Stream<Null>.periodic(const Duration(milliseconds: 220)));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -185,9 +183,9 @@ void main() {
   });
 
   test('rx.Observable.bufferWhen.error.shouldThrowA.asBuffer', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<Null>(new Exception())).buffer(onStream(
-            new Stream<Null>.periodic(const Duration(milliseconds: 220))));
+    final observableWithError = Observable(ErrorStream<Null>(Exception()))
+        .buffer(
+            onStream(Stream<Null>.periodic(const Duration(milliseconds: 220))));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -196,7 +194,7 @@ void main() {
   });
 
   test('rx.Observable.bufferWhen.error.shouldThrowB', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .bufferWhen<Null>(null)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -204,7 +202,7 @@ void main() {
   });
 
   test('rx.Observable.bufferWhen.error.shouldThrowB.asBuffer', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .buffer(onStream<int, List<int>, void>(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);

--- a/test/transformers/concat_map_test.dart
+++ b/test/transformers/concat_map_test.dart
@@ -8,7 +8,7 @@ void main() {
     const expectedOutput = [1, 1, 2, 2, 3, 3];
     var count = 0;
 
-    new Observable(_getStream()).concatMap(_getOtherStream).listen(
+    Observable(_getStream()).concatMap(_getOtherStream).listen(
         expectAsync1((result) {
           expect(result, expectedOutput[count++]);
         }, count: expectedOutput.length), onDone: expectAsync0(() {
@@ -18,8 +18,7 @@ void main() {
 
   test('rx.Observable.concatMap.error.shouldThrow', () async {
     final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .concatMap(_getOtherStream);
+        Observable(ErrorStream<int>(Exception())).concatMap(_getOtherStream);
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -29,15 +28,14 @@ void main() {
 
   test('rx.Observable.concatMap.pause.resume', () async {
     StreamSubscription<int> subscription;
-    final stream =
-        new Observable.just(0).concatMap((_) => new Observable.just(1));
+    final stream = Observable.just(0).concatMap((_) => Observable.just(1));
 
     subscription = stream.listen(expectAsync1((value) {
       expect(value, 1);
       subscription.cancel();
     }, count: 1));
 
-    new Timer(new Duration(milliseconds: 10), () {
+    Timer(Duration(milliseconds: 10), () {
       subscription.pause();
       subscription.resume();
     });
@@ -45,7 +43,7 @@ void main() {
 
   test('rx.Observable.concatMap.cancel', () async {
     StreamSubscription<int> subscription;
-    final stream = new Observable(_getStream()).concatMap(_getOtherStream);
+    final stream = Observable(_getStream()).concatMap(_getOtherStream);
 
     // Cancel the subscription before any events come through
     subscription = stream.listen(
@@ -59,27 +57,26 @@ void main() {
           expect(true, isFalse);
         }, count: 0));
 
-    new Timer(new Duration(milliseconds: 5), () {
+    Timer(Duration(milliseconds: 5), () {
       subscription.cancel();
     });
   });
 }
 
-Stream<int> _getStream() => new Stream.fromIterable(const [1, 2, 3]);
+Stream<int> _getStream() => Stream.fromIterable(const [1, 2, 3]);
 
 Stream<int> _getOtherStream(int value) {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(
+  Timer(
       // Reverses the order of 1, 2, 3 to 3, 2, 1 by delaying 1, and 2 longer
       // than it delays 3
-      new Duration(milliseconds: value == 1 ? 20 : value == 2 ? 10 : 5), () {
+      Duration(milliseconds: value == 1 ? 20 : value == 2 ? 10 : 5), () {
     controller.add(value);
   });
 
   // Delay by a longer amount, with the same reversing effect
-  new Timer(new Duration(milliseconds: value == 1 ? 30 : value == 2 ? 20 : 10),
-      () {
+  Timer(Duration(milliseconds: value == 1 ? 30 : value == 2 ? 20 : 10), () {
     controller.add(value);
     controller.close();
   });

--- a/test/transformers/concat_with_test.dart
+++ b/test/transformers/concat_with_test.dart
@@ -3,13 +3,12 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.concatWith', () async {
-    final delayedStream =
-        new Observable.timer(1, new Duration(milliseconds: 10));
-    final immediateStream = new Observable.just(2);
+    final delayedStream = Observable.timer(1, Duration(milliseconds: 10));
+    final immediateStream = Observable.just(2);
     const expected = [1, 2];
     var count = 0;
 
-    new Observable(delayedStream)
+    Observable(delayedStream)
         .concatWith([immediateStream]).listen(expectAsync1((result) {
       expect(result, expected[count++]);
     }, count: expected.length));

--- a/test/transformers/contains_test.dart
+++ b/test/transformers/contains_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.contains', () async {
-    final actual = await new Observable.just(1).contains(1);
+    final actual = await Observable.just(1).contains(1);
 
     await expectLater(actual, true);
   });

--- a/test/transformers/debounce_test.dart
+++ b/test/transformers/debounce_test.dart
@@ -4,12 +4,12 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 Stream<int> _getStream() {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(const Duration(milliseconds: 100), () => controller.add(1));
-  new Timer(const Duration(milliseconds: 200), () => controller.add(2));
-  new Timer(const Duration(milliseconds: 300), () => controller.add(3));
-  new Timer(const Duration(milliseconds: 400), () {
+  Timer(const Duration(milliseconds: 100), () => controller.add(1));
+  Timer(const Duration(milliseconds: 200), () => controller.add(2));
+  Timer(const Duration(milliseconds: 300), () => controller.add(3));
+  Timer(const Duration(milliseconds: 400), () {
     controller.add(4);
     controller.close();
   });
@@ -19,7 +19,7 @@ Stream<int> _getStream() {
 
 void main() {
   test('rx.Observable.debounce', () async {
-    new Observable(_getStream())
+    Observable(_getStream())
         .debounce(const Duration(milliseconds: 200))
         .listen(expectAsync1((result) {
           expect(result, 4);
@@ -28,15 +28,15 @@ void main() {
 
   test('rx.Observable.debounce.reusable', () async {
     final transformer =
-        new DebounceStreamTransformer<int>(const Duration(milliseconds: 200));
+        DebounceStreamTransformer<int>(const Duration(milliseconds: 200));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, 4);
         }, count: 1));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, 4);
@@ -44,7 +44,7 @@ void main() {
   });
 
   test('rx.Observable.debounce.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
+    final stream = Observable(_getStream().asBroadcastStream())
         .debounce(const Duration(milliseconds: 200));
 
     // listen twice on same stream
@@ -55,9 +55,8 @@ void main() {
   });
 
   test('rx.Observable.debounce.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .debounce(const Duration(milliseconds: 200));
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .debounce(const Duration(milliseconds: 200));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -69,21 +68,21 @@ void main() {
   test('rx.Observable.debounce.error.shouldThrowB', () async {
     runZoned(() {
       final observableWithError =
-          new Observable.just(1).debounce(const Duration(milliseconds: 200));
+          Observable.just(1).debounce(const Duration(milliseconds: 200));
 
       observableWithError.listen(null,
           onError: expectAsync2(
               (Exception e, StackTrace s) => expect(e, isException)));
     },
-        zoneSpecification: new ZoneSpecification(
+        zoneSpecification: ZoneSpecification(
             createTimer: (self, parent, zone, duration, void f()) =>
-                throw new Exception('Zone createTimer error')));
+                throw Exception('Zone createTimer error')));
   });
 
   test('rx.Observable.debounce.pause.resume', () async {
     StreamSubscription<int> subscription;
-    final stream = new Observable.fromIterable(const [1, 2, 3])
-        .debounce(new Duration(milliseconds: 1));
+    final stream = Observable.fromIterable(const [1, 2, 3])
+        .debounce(Duration(milliseconds: 1));
 
     subscription = stream.listen(expectAsync1((value) {
       expect(value, 3);
@@ -97,9 +96,9 @@ void main() {
 
   test('rx.Observable.debounce.emits.last.item.immediately', () async {
     final emissions = <int>[];
-    final stopwatch = new Stopwatch();
-    final stream = new Observable.fromIterable(const [1, 2, 3])
-        .debounce(new Duration(seconds: 100));
+    final stopwatch = Stopwatch();
+    final stream = Observable.fromIterable(const [1, 2, 3])
+        .debounce(Duration(seconds: 100));
 
     stopwatch.start();
 
@@ -116,20 +115,20 @@ void main() {
       // last value to be emitted to be much shorter than that.
       expect(stopwatch.elapsedMilliseconds < 500, isTrue);
     }));
-  }, timeout: new Timeout(new Duration(seconds: 3)));
+  }, timeout: Timeout(Duration(seconds: 3)));
 
   test(
     'rx.Observable.debounce.cancel.emits.nothing',
     () async {
       StreamSubscription<int> subscription;
-      final stream = new Observable.fromIterable(const [1, 2, 3]).doOnDone(() {
+      final stream = Observable.fromIterable(const [1, 2, 3]).doOnDone(() {
         subscription.cancel();
-      }).debounce(new Duration(seconds: 10));
+      }).debounce(Duration(seconds: 10));
 
       // We expect the onData callback to be called 0 times because the
       // subscription is cancelled when the base stream ends.
       subscription = stream.listen(expectAsync1((_) {}, count: 0));
     },
-    timeout: new Timeout(new Duration(seconds: 3)),
+    timeout: Timeout(Duration(seconds: 3)),
   );
 }

--- a/test/transformers/default_if_empty_test.dart
+++ b/test/transformers/default_if_empty_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.defaultIfEmpty.whenEmpty', () async {
-    new Observable(new Stream<bool>.empty())
+    Observable(Stream<bool>.empty())
         .defaultIfEmpty(true)
         .listen(expectAsync1((bool result) {
           expect(result, true);
@@ -13,15 +13,15 @@ void main() {
   });
 
   test('rx.Observable.defaultIfEmpty.reusable', () async {
-    final transformer = new DefaultIfEmptyStreamTransformer<bool>(true);
+    final transformer = DefaultIfEmptyStreamTransformer<bool>(true);
 
-    new Observable(new Stream<bool>.empty())
+    Observable(Stream<bool>.empty())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, true);
         }, count: 1));
 
-    new Observable(new Stream<bool>.empty())
+    Observable(Stream<bool>.empty())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, true);
@@ -29,7 +29,7 @@ void main() {
   });
 
   test('rx.Observable.defaultIfEmpty.whenNotEmpty', () async {
-    new Observable(new Stream.fromIterable(const [false, false, false]))
+    Observable(Stream.fromIterable(const [false, false, false]))
         .defaultIfEmpty(true)
         .listen(expectAsync1((result) {
           expect(result, false);
@@ -37,7 +37,7 @@ void main() {
   });
 
   test('rx.Observable.defaultIfEmpty.asBroadcastStream', () async {
-    final stream = new Observable.fromIterable(const <int>[])
+    final stream = Observable.fromIterable(const <int>[])
         .defaultIfEmpty(-1)
         .asBroadcastStream();
 
@@ -51,8 +51,7 @@ void main() {
 
   test('rx.Observable.defaultIfEmpty.error.shouldThrow', () async {
     final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .defaultIfEmpty(-1);
+        Observable(ErrorStream<int>(Exception())).defaultIfEmpty(-1);
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -62,7 +61,7 @@ void main() {
 
   test('rx.Observable.defaultIfEmpty.pause.resume', () async {
     StreamSubscription<int> subscription;
-    final stream = new Observable.fromIterable(const <int>[]).defaultIfEmpty(1);
+    final stream = Observable.fromIterable(const <int>[]).defaultIfEmpty(1);
 
     subscription = stream.listen(expectAsync1((value) {
       expect(value, 1);

--- a/test/transformers/delay_test.dart
+++ b/test/transformers/delay_test.dart
@@ -3,13 +3,12 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Stream<int> _getStream() =>
-    new Stream<int>.fromIterable(const <int>[1, 2, 3, 4]);
+Stream<int> _getStream() => Stream<int>.fromIterable(const <int>[1, 2, 3, 4]);
 
 void main() {
   test('rx.Observable.delay', () async {
     var value = 1;
-    new Observable(_getStream())
+    Observable(_getStream())
         .delay(const Duration(milliseconds: 200))
         .listen(expectAsync1((result) {
           expect(result, value++);
@@ -18,7 +17,7 @@ void main() {
 
   test('rx.Observable.delay.shouldBeDelayed', () async {
     var value = 1;
-    new Observable(_getStream())
+    Observable(_getStream())
         .delay(const Duration(milliseconds: 500))
         .timeInterval()
         .listen(expectAsync1((result) {
@@ -35,16 +34,16 @@ void main() {
 
   test('rx.Observable.delay.reusable', () async {
     final transformer =
-        new DelayStreamTransformer<int>(const Duration(milliseconds: 200));
+        DelayStreamTransformer<int>(const Duration(milliseconds: 200));
     var valueA = 1, valueB = 1;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, valueA++);
         }, count: 4));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, valueB++);
@@ -52,7 +51,7 @@ void main() {
   });
 
   test('rx.Observable.delay.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
+    final stream = Observable(_getStream().asBroadcastStream())
         .delay(const Duration(milliseconds: 200));
 
     // listen twice on same stream
@@ -63,9 +62,8 @@ void main() {
   });
 
   test('rx.Observable.delay.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .delay(const Duration(milliseconds: 200));
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .delay(const Duration(milliseconds: 200));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -77,21 +75,21 @@ void main() {
   test('rx.Observable.delay.error.shouldThrowB', () async {
     runZoned(() {
       final observableWithError =
-          new Observable.just(1).delay(const Duration(milliseconds: 200));
+          Observable.just(1).delay(const Duration(milliseconds: 200));
 
       observableWithError.listen(null,
           onError: expectAsync2(
               (Exception e, StackTrace s) => expect(e, isException)));
     },
-        zoneSpecification: new ZoneSpecification(
+        zoneSpecification: ZoneSpecification(
             createTimer: (self, parent, zone, duration, void f()) =>
-                throw new Exception('Zone createTimer error')));
+                throw Exception('Zone createTimer error')));
   });
 
   test('rx.Observable.delay.pause.resume', () async {
     StreamSubscription<int> subscription;
-    final stream = new Observable.fromIterable(const [1, 2, 3])
-        .delay(new Duration(milliseconds: 1));
+    final stream = Observable.fromIterable(const [1, 2, 3])
+        .delay(Duration(milliseconds: 1));
 
     subscription = stream.listen(expectAsync1((value) {
       expect(value, 1);
@@ -107,14 +105,14 @@ void main() {
     'rx.Observable.delay.cancel.emits.nothing',
     () async {
       StreamSubscription<int> subscription;
-      final stream = new Observable.fromIterable(const [1, 2, 3]).doOnDone(() {
+      final stream = Observable.fromIterable(const [1, 2, 3]).doOnDone(() {
         subscription.cancel();
-      }).delay(new Duration(seconds: 10));
+      }).delay(Duration(seconds: 10));
 
       // We expect the onData callback to be called 0 times because the
       // subscription is cancelled when the base stream ends.
       subscription = stream.listen(expectAsync1((_) {}, count: 0));
     },
-    timeout: new Timeout(new Duration(seconds: 3)),
+    timeout: Timeout(Duration(seconds: 3)),
   );
 }

--- a/test/transformers/dematerialize_test.dart
+++ b/test/transformers/dematerialize_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   test('rx.Observable.dematerialize.happyPath', () async {
     const expectedValue = 1;
-    final observable = new Observable.just(1).materialize();
+    final observable = Observable.just(1).materialize();
 
     observable.dematerialize<int>().listen(expectAsync1((value) {
       expect(value, expectedValue);
@@ -19,10 +19,10 @@ void main() {
   });
 
   test('rx.Observable.dematerialize.reusable', () async {
-    final transformer = new DematerializeStreamTransformer<int>();
+    final transformer = DematerializeStreamTransformer<int>();
     const expectedValue = 1;
-    final observableA = new Observable.just(1).materialize();
-    final observableB = new Observable.just(1).materialize();
+    final observableA = Observable.just(1).materialize();
+    final observableB = Observable.just(1).materialize();
 
     observableA.transform(transformer).listen(expectAsync1((value) {
       expect(value, expectedValue);
@@ -41,12 +41,10 @@ void main() {
 
   test('dematerializeTransformer.happyPath', () async {
     const expectedValue = 1;
-    final stream = new Stream.fromIterable([
-      new Notification.onData(expectedValue),
-      new Notification<int>.onDone()
-    ]);
+    final stream = Stream.fromIterable(
+        [Notification.onData(expectedValue), Notification<int>.onDone()]);
 
-    stream.transform(new DematerializeStreamTransformer()).listen(
+    stream.transform(DematerializeStreamTransformer()).listen(
         expectAsync1((value) {
       expect(value, expectedValue);
     }), onDone: expectAsync0(() {
@@ -56,10 +54,10 @@ void main() {
   });
 
   test('dematerializeTransformer.sadPath', () async {
-    final stream = new Stream.fromIterable(
-        [new Notification<int>.onError(new Exception(), new Chain.current())]);
+    final stream = Stream.fromIterable(
+        [Notification<int>.onError(Exception(), Chain.current())]);
 
-    stream.transform(new DematerializeStreamTransformer()).listen(null,
+    stream.transform(DematerializeStreamTransformer()).listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
       expect(e, isException);
     }));
@@ -67,12 +65,10 @@ void main() {
 
   test('dematerializeTransformer.onPause.onResume', () async {
     const expectedValue = 1;
-    final stream = new Stream.fromIterable([
-      new Notification.onData(expectedValue),
-      new Notification<int>.onDone()
-    ]);
+    final stream = Stream.fromIterable(
+        [Notification.onData(expectedValue), Notification<int>.onDone()]);
 
-    stream.transform(new DematerializeStreamTransformer()).listen(
+    stream.transform(DematerializeStreamTransformer()).listen(
         expectAsync1((value) {
       expect(value, expectedValue);
     }), onDone: expectAsync0(() {

--- a/test/transformers/distinct_test.dart
+++ b/test/transformers/distinct_test.dart
@@ -6,7 +6,7 @@ void main() {
     const expected = 1;
 
     final observable =
-        new Observable.fromIterable(const [expected, expected]).distinct();
+        Observable.fromIterable(const [expected, expected]).distinct();
 
     observable.listen(expectAsync1((actual) {
       expect(actual, expected);

--- a/test/transformers/distinct_unique_test.dart
+++ b/test/transformers/distinct_unique_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 void main() {
   group("DistinctUniqueStreamTransformer", () {
     test("works with the equals and hascode of the class", () async {
-      final observable = new Observable.fromIterable(const [
+      final observable = Observable.fromIterable(const [
         _TestObject("a"),
         _TestObject("a"),
         _TestObject("b"),
@@ -30,7 +30,7 @@ void main() {
     });
 
     test("works with a provided equals and hashcode", () async {
-      final observable = new Observable.fromIterable(const [
+      final observable = Observable.fromIterable(const [
         _TestObject("a"),
         _TestObject("a"),
         _TestObject("b"),
@@ -57,11 +57,11 @@ void main() {
     test(
         "sends an error to the subscription if an error occurs in the equals or hashmap methods",
         () async {
-      final observable = new Observable.fromIterable(
+      final observable = Observable.fromIterable(
               const [_TestObject("a"), _TestObject("b"), _TestObject("c")])
           .distinctUnique(
               equals: (a, b) => a.key == b.key,
-              hashCode: (o) => throw new Exception('Catch me if you can!'));
+              hashCode: (o) => throw Exception('Catch me if you can!'));
 
       observable.listen(
         null,
@@ -89,13 +89,13 @@ void main() {
       ];
 
       final distinctUniqueStreamTransformer =
-          new DistinctUniqueStreamTransformer<_TestObject>();
+          DistinctUniqueStreamTransformer<_TestObject>();
 
-      final firstStream = new Stream.fromIterable(data)
-          .transform(distinctUniqueStreamTransformer);
+      final firstStream =
+          Stream.fromIterable(data).transform(distinctUniqueStreamTransformer);
 
-      final secondStream = new Stream.fromIterable(data)
-          .transform(distinctUniqueStreamTransformer);
+      final secondStream =
+          Stream.fromIterable(data).transform(distinctUniqueStreamTransformer);
 
       await expectLater(
           firstStream,

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -10,7 +10,7 @@ void main() {
     test('calls onDone when the stream is finished', () async {
       var onDoneCalled = false;
       final observable =
-          new Observable<void>.empty().doOnDone(() => onDoneCalled = true);
+          Observable<void>.empty().doOnDone(() => onDoneCalled = true);
 
       await expectLater(observable, emitsDone);
       await expectLater(onDoneCalled, isTrue);
@@ -18,7 +18,7 @@ void main() {
 
     test('calls onError when an error is emitted', () async {
       var onErrorCalled = false;
-      final observable = new Observable<void>.error(new Exception())
+      final observable = Observable<void>.error(Exception())
           .doOnError((dynamic e, dynamic s) => onErrorCalled = true);
 
       await expectLater(observable, emitsError(isException));
@@ -29,7 +29,7 @@ void main() {
         'onError only called once when an error is emitted on a broadcast stream',
         () async {
       var count = 0;
-      final subject = new BehaviorSubject<int>(sync: true);
+      final subject = BehaviorSubject<int>(sync: true);
       final stream = subject.stream.doOnError(
         (dynamic e, dynamic s) => count++,
       );
@@ -37,8 +37,8 @@ void main() {
       stream.listen(null, onError: (dynamic e, dynamic s) {});
       stream.listen(null, onError: (dynamic e, dynamic s) {});
 
-      subject.addError(new Exception());
-      subject.addError(new Exception());
+      subject.addError(Exception());
+      subject.addError(Exception());
 
       await expectLater(count, 2);
       await subject.close();
@@ -46,7 +46,7 @@ void main() {
 
     test('calls onCancel when the subscription is cancelled', () async {
       var onCancelCalled = false;
-      final observable = new Observable.just(1);
+      final observable = Observable.just(1);
 
       await observable
           .doOnCancel(() => onCancelCalled = true)
@@ -58,11 +58,11 @@ void main() {
 
     test('awaits onCancel when the subscription is cancelled', () async {
       var onCancelCompleted = 10, onCancelHandled = 10, eventSequenceCount = 0;
-      final observable = new Observable.just(1);
+      final observable = Observable.just(1);
 
       await observable
           .doOnCancel(() =>
-              new Future<void>.delayed(const Duration(milliseconds: 100))
+              Future<void>.delayed(const Duration(milliseconds: 100))
                   .whenComplete(() => onCancelHandled = ++eventSequenceCount))
           .listen(null)
           .cancel()
@@ -75,7 +75,7 @@ void main() {
         'onCancel called only once when the subscription is multiple listeners',
         () async {
       var count = 0;
-      final subject = new BehaviorSubject<int>(sync: true);
+      final subject = BehaviorSubject<int>(sync: true);
       final observable = subject.doOnCancel(() => count++);
 
       observable.listen(null);
@@ -88,7 +88,7 @@ void main() {
     test('calls onData when the observable emits an item', () async {
       var onDataCalled = false;
       final observable =
-          new Observable.just(1).doOnData((_) => onDataCalled = true);
+          Observable.just(1).doOnData((_) => onDataCalled = true);
 
       await expectLater(observable, emits(1));
       await expectLater(onDataCalled, isTrue);
@@ -97,9 +97,9 @@ void main() {
     test('onData only emits once for broadcast streams with multiple listeners',
         () async {
       final actual = <int>[];
-      final controller = new StreamController<int>.broadcast(sync: true);
-      final observable = controller.stream
-          .transform(new DoStreamTransformer(onData: actual.add));
+      final controller = StreamController<int>.broadcast(sync: true);
+      final observable =
+          controller.stream.transform(DoStreamTransformer(onData: actual.add));
 
       observable.listen(null);
       observable.listen(null);
@@ -114,9 +114,9 @@ void main() {
     test('emits onEach Notifications for Data, Error, and Done', () async {
       StackTrace stacktrace;
       final actual = <Notification<int>>[];
-      final exception = new Exception();
-      final observable = new Observable.just(1).concatWith(
-          [new Observable<int>.error(exception)]).doOnEach((notification) {
+      final exception = Exception();
+      final observable = Observable.just(1).concatWith(
+          [Observable<int>.error(exception)]).doOnEach((notification) {
         actual.add(notification);
 
         if (notification.isOnError) {
@@ -128,18 +128,18 @@ void main() {
           emitsInOrder(<dynamic>[1, emitsError(isException), emitsDone]));
 
       await expectLater(actual, [
-        new Notification.onData(1),
-        new Notification<void>.onError(exception, stacktrace),
-        new Notification<void>.onDone()
+        Notification.onData(1),
+        Notification<void>.onError(exception, stacktrace),
+        Notification<void>.onDone()
       ]);
     });
 
     test('onEach only emits once for broadcast streams with multiple listeners',
         () async {
       var count = 0;
-      final controller = new StreamController<int>.broadcast(sync: true);
+      final controller = StreamController<int>.broadcast(sync: true);
       final observable =
-          controller.stream.transform(new DoStreamTransformer(onEach: (_) {
+          controller.stream.transform(DoStreamTransformer(onEach: (_) {
         count++;
       }));
 
@@ -155,7 +155,7 @@ void main() {
 
     test('calls onListen when a consumer listens', () async {
       var onListenCalled = false;
-      final observable = new Observable<void>.empty().doOnListen(() {
+      final observable = Observable<void>.empty().doOnListen(() {
         onListenCalled = true;
       });
 
@@ -166,10 +166,10 @@ void main() {
     test('calls onListen every time a consumer listens to a broadcast stream',
         () async {
       var onListenCallCount = 0;
-      final sc = new StreamController<int>.broadcast()..add(1)..add(2)..add(3);
+      final sc = StreamController<int>.broadcast()..add(1)..add(2)..add(3);
 
       final observable =
-          new Observable(sc.stream).doOnListen(() => onListenCallCount++);
+          Observable(sc.stream).doOnListen(() => onListenCallCount++);
 
       observable.listen(null);
       observable.listen(null);
@@ -180,7 +180,7 @@ void main() {
 
     test('calls onPause and onResume when the subscription is', () async {
       var onPauseCalled = false, onResumeCalled = false;
-      final observable = new Observable.just(1).doOnPause((_) {
+      final observable = Observable.just(1).doOnPause((_) {
         onPauseCalled = true;
       }).doOnResume(() {
         onResumeCalled = true;
@@ -196,12 +196,12 @@ void main() {
 
     test('should be reusable', () async {
       var callCount = 0;
-      final transformer = new DoStreamTransformer<int>(onData: (_) {
+      final transformer = DoStreamTransformer<int>(onData: (_) {
         callCount++;
       });
 
-      final observableA = new Observable.just(1).transform(transformer),
-          observableB = new Observable.just(1).transform(transformer);
+      final observableA = Observable.just(1).transform(transformer),
+          observableB = Observable.just(1).transform(transformer);
 
       observableA.listen(null, onDone: expectAsync0(() {
         expect(callCount, 2);
@@ -213,26 +213,25 @@ void main() {
     });
 
     test('throws an error when no arguments are provided', () {
-      expect(() => new DoStreamTransformer<void>(), throwsArgumentError);
+      expect(() => DoStreamTransformer<void>(), throwsArgumentError);
     });
 
     test('should propagate errors', () {
-      new Observable.just(1)
-          .doOnListen(
-              () => throw new Exception('catch me if you can! doOnListen'))
+      Observable.just(1)
+          .doOnListen(() => throw Exception('catch me if you can! doOnListen'))
           .listen(null,
               onError: expectAsync2(
                   (Exception e, [StackTrace s]) => expect(e, isException)));
 
-      new Observable.just(1)
-          .doOnData((_) => throw new Exception('catch me if you can! doOnData'))
+      Observable.just(1)
+          .doOnData((_) => throw Exception('catch me if you can! doOnData'))
           .listen(null,
               onError: expectAsync2(
                   (Exception e, [StackTrace s]) => expect(e, isException)));
 
-      new Observable<void>.error(new Exception('oh noes!'))
+      Observable<void>.error(Exception('oh noes!'))
           .doOnError((dynamic _, dynamic __) =>
-              throw new Exception('catch me if you can! doOnError'))
+              throw Exception('catch me if you can! doOnError'))
           .listen(null,
               onError: expectAsync2(
                   (Exception e, [StackTrace s]) => expect(e, isException),
@@ -242,14 +241,14 @@ void main() {
       // in that case, the error is forwarded to the current [Zone]
       runZoned(
         () {
-          new Observable.just(1)
+          Observable.just(1)
               .doOnCancel(() =>
-                  throw new Exception('catch me if you can! doOnCancel-zoned'))
+                  throw Exception('catch me if you can! doOnCancel-zoned'))
               .listen(null);
 
-          new Observable.just(1)
+          Observable.just(1)
               .doOnCancel(
-                  () => throw new Exception('catch me if you can! doOnCancel'))
+                  () => throw Exception('catch me if you can! doOnCancel'))
               .listen(null)
                 ..cancel();
         },
@@ -258,8 +257,8 @@ void main() {
         ),
       );
 
-      new Observable.just(1)
-          .doOnDone(() => throw new Exception('catch me if you can! doOnDone'))
+      Observable.just(1)
+          .doOnDone(() => throw Exception('catch me if you can! doOnDone'))
           .listen(
             null,
             onError: expectAsync2(
@@ -267,8 +266,8 @@ void main() {
             ),
           );
 
-      new Observable.just(1)
-          .doOnEach((_) => throw new Exception('catch me if you can! doOnEach'))
+      Observable.just(1)
+          .doOnEach((_) => throw Exception('catch me if you can! doOnEach'))
           .listen(
             null,
             onError: expectAsync2(
@@ -277,9 +276,8 @@ void main() {
             ),
           );
 
-      new Observable.just(1)
-          .doOnPause(
-              (_) => throw new Exception('catch me if you can! doOnPause'))
+      Observable.just(1)
+          .doOnPause((_) => throw Exception('catch me if you can! doOnPause'))
           .listen(null,
               onError: expectAsync2(
                 (Exception e, [StackTrace s]) => expect(e, isException),
@@ -287,9 +285,8 @@ void main() {
             ..pause()
             ..resume();
 
-      new Observable.just(1)
-          .doOnResume(
-              () => throw new Exception('catch me if you can! doOnResume'))
+      Observable.just(1)
+          .doOnResume(() => throw Exception('catch me if you can! doOnResume'))
           .listen(null,
               onError: expectAsync2(
                   (Exception e, [StackTrace s]) => expect(e, isException)))

--- a/test/transformers/drain_test.dart
+++ b/test/transformers/drain_test.dart
@@ -5,7 +5,7 @@ void main() {
   test('rx.Observable.drain', () async {
     const expected = 2;
 
-    final actual = await new Observable.just(1).drain(expected);
+    final actual = await Observable.just(1).drain(expected);
 
     await expectLater(actual, expected);
   });

--- a/test/transformers/element_at_test.dart
+++ b/test/transformers/element_at_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   test('rx.Observable.elementAt', () async {
     final actual =
-        await new Observable.fromIterable(const [1, 2, 3, 4, 5]).elementAt(0);
+        await Observable.fromIterable(const [1, 2, 3, 4, 5]).elementAt(0);
 
     await expectLater(actual, 1);
   });

--- a/test/transformers/every_test.dart
+++ b/test/transformers/every_test.dart
@@ -3,8 +3,8 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.every', () async {
-    final actual = await new Observable.fromIterable(const [1, 2, 3])
-        .every((val) => val == 1);
+    final actual =
+        await Observable.fromIterable(const [1, 2, 3]).every((val) => val == 1);
 
     await expectLater(actual, isFalse);
   });

--- a/test/transformers/exhaust_map_test.dart
+++ b/test/transformers/exhaust_map_test.dart
@@ -10,7 +10,7 @@ void main() {
       var calls = 0;
       final observable = Observable.range(0, 9).exhaustMap((i) {
         calls++;
-        return new Observable.timer(i, new Duration(milliseconds: 100));
+        return Observable.timer(i, Duration(milliseconds: 100));
       });
 
       await expectLater(observable, emitsInOrder(<dynamic>[0, emitsDone]));
@@ -20,10 +20,10 @@ void main() {
     test('starts emitting again after previous Stream is complete', () async {
       var calls = 0;
       final observable = Observable.range(0, 9)
-          .interval(new Duration(milliseconds: 20))
+          .interval(Duration(milliseconds: 20))
           .exhaustMap((i) {
         calls++;
-        return new Observable.timer(i, new Duration(milliseconds: 100));
+        return Observable.timer(i, Duration(milliseconds: 100));
       });
 
       await expectLater(observable, emitsInOrder(<dynamic>[0, 5, emitsDone]));
@@ -31,8 +31,8 @@ void main() {
     });
 
     test('is reusable', () async {
-      final transformer = new ExhaustMapStreamTransformer(
-          (int i) => new Observable.timer(i, new Duration(milliseconds: 100)));
+      final transformer = ExhaustMapStreamTransformer(
+          (int i) => Observable.timer(i, Duration(milliseconds: 100)));
 
       await expectLater(
         Observable.range(0, 9).transform(transformer),
@@ -46,8 +46,9 @@ void main() {
     });
 
     test('works as a broadcast stream', () async {
-      final stream = Observable.range(0, 9).asBroadcastStream().exhaustMap(
-          (i) => new Observable.timer(i, new Duration(milliseconds: 100)));
+      final stream = Observable.range(0, 9)
+          .asBroadcastStream()
+          .exhaustMap((i) => Observable.timer(i, Duration(milliseconds: 100)));
 
       await expectLater(() {
         stream.listen(null);
@@ -56,23 +57,22 @@ void main() {
     });
 
     test('should emit errors from source', () async {
-      final observableWithError =
-          new Observable(new ErrorStream<int>(new Exception())).exhaustMap(
-              (i) => new Observable.timer(i, new Duration(milliseconds: 100)));
+      final observableWithError = Observable(ErrorStream<int>(Exception()))
+          .exhaustMap((i) => Observable.timer(i, Duration(milliseconds: 100)));
 
       await expectLater(observableWithError, emitsError(isException));
     });
 
     test('should emit errors from mapped stream', () async {
-      final observableWithError = new Observable.just(1).exhaustMap(
-          (_) => new ErrorStream<void>(new Exception('Catch me if you can!')));
+      final observableWithError = Observable.just(1).exhaustMap(
+          (_) => ErrorStream<void>(Exception('Catch me if you can!')));
 
       await expectLater(observableWithError, emitsError(isException));
     });
 
     test('should emit errors thrown in the mapper', () async {
-      final observableWithError = new Observable.just(1).exhaustMap<void>((_) {
-        throw new Exception('oh noes!');
+      final observableWithError = Observable.just(1).exhaustMap<void>((_) {
+        throw Exception('oh noes!');
       });
 
       await expectLater(observableWithError, emitsError(isException));
@@ -80,8 +80,8 @@ void main() {
 
     test('can be paused and resumed', () async {
       StreamSubscription<int> subscription;
-      final stream = Observable.range(0, 9).exhaustMap(
-          (i) => new Observable.timer(i, new Duration(milliseconds: 20)));
+      final stream = Observable.range(0, 9)
+          .exhaustMap((i) => Observable.timer(i, Duration(milliseconds: 20)));
 
       subscription = stream.listen(expectAsync1((value) {
         expect(value, 0);

--- a/test/transformers/expand_test.dart
+++ b/test/transformers/expand_test.dart
@@ -7,7 +7,7 @@ void main() {
     var count = 0;
 
     final observable =
-        new Observable.fromIterable(expected).expand((value) => [value]);
+        Observable.fromIterable(expected).expand((value) => [value]);
 
     observable.listen(expectAsync1((actual) {
       expect(actual, expected[count++]);

--- a/test/transformers/first_test.dart
+++ b/test/transformers/first_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.first', () async {
-    final actual = await new Observable.fromIterable(const [1, 2, 3]).first;
+    final actual = await Observable.fromIterable(const [1, 2, 3]).first;
 
     await expectLater(actual, 1);
   });

--- a/test/transformers/first_where_test.dart
+++ b/test/transformers/first_where_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   test('rx.Observable.every', () async {
     final dynamic actual =
-        await new Observable<int>.just(1).firstWhere((int val) => val == 1);
+        await Observable<int>.just(1).firstWhere((int val) => val == 1);
 
     await expectLater(actual, 1);
   });

--- a/test/transformers/flat_map_iterable_test.dart
+++ b/test/transformers/flat_map_iterable_test.dart
@@ -5,8 +5,8 @@ void main() {
   group('Observable.flatMapIterable', () {
     test('transforms a Stream<Iterable<S>> into individual items', () {
       expect(
-          Observable.range(1, 4).flatMapIterable(
-              (int i) => new Observable<List<int>>.just(<int>[i])),
+          Observable.range(1, 4)
+              .flatMapIterable((int i) => Observable<List<int>>.just(<int>[i])),
           emitsInOrder(<dynamic>[1, 2, 3, 4, emitsDone]));
     });
   });

--- a/test/transformers/flat_map_test.dart
+++ b/test/transformers/flat_map_test.dart
@@ -3,15 +3,15 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Stream<int> _getStream() => new Stream.fromIterable(const [1, 2, 3]);
+Stream<int> _getStream() => Stream.fromIterable(const [1, 2, 3]);
 
 Stream<int> _getOtherStream(int value) {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(
+  Timer(
       // Reverses the order of 1, 2, 3 to 3, 2, 1 by delaying 1, and 2 longer
       // than they delay 3
-      new Duration(milliseconds: value == 1 ? 15 : value == 2 ? 10 : 5), () {
+      Duration(milliseconds: value == 1 ? 15 : value == 2 ? 10 : 5), () {
     controller.add(value);
     controller.close();
   });
@@ -24,7 +24,7 @@ void main() {
     const expectedOutput = [3, 2, 1];
     var count = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .flatMap(_getOtherStream)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[count++]);
@@ -32,17 +32,17 @@ void main() {
   });
 
   test('rx.Observable.flatMap.reusable', () async {
-    final transformer = new FlatMapStreamTransformer<int, int>(_getOtherStream);
+    final transformer = FlatMapStreamTransformer<int, int>(_getOtherStream);
     const expectedOutput = [3, 2, 1];
     var countA = 0, countB = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[countA++]);
         }, count: expectedOutput.length));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[countB++]);
@@ -50,8 +50,8 @@ void main() {
   });
 
   test('rx.Observable.flatMap.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
-        .flatMap(_getOtherStream);
+    final stream =
+        Observable(_getStream().asBroadcastStream()).flatMap(_getOtherStream);
 
     // listen twice on same stream
     stream.listen(null);
@@ -62,8 +62,7 @@ void main() {
 
   test('rx.Observable.flatMap.error.shouldThrowA', () async {
     final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .flatMap(_getOtherStream);
+        Observable(ErrorStream<int>(Exception())).flatMap(_getOtherStream);
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -72,8 +71,8 @@ void main() {
   });
 
   test('rx.Observable.flatMap.error.shouldThrowB', () async {
-    final observableWithError = new Observable.just(1).flatMap(
-        (_) => new ErrorStream<void>(new Exception('Catch me if you can!')));
+    final observableWithError = Observable.just(1)
+        .flatMap((_) => ErrorStream<void>(Exception('Catch me if you can!')));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -82,8 +81,8 @@ void main() {
   });
 
   test('rx.Observable.flatMap.error.shouldThrowC', () async {
-    final observableWithError = new Observable.just(1)
-        .flatMap<void>((_) => throw new Exception('oh noes!'));
+    final observableWithError =
+        Observable.just(1).flatMap<void>((_) => throw Exception('oh noes!'));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -93,8 +92,7 @@ void main() {
 
   test('rx.Observable.flatMap.pause.resume', () async {
     StreamSubscription<int> subscription;
-    final stream =
-        new Observable.just(0).flatMap((_) => new Observable.just(1));
+    final stream = Observable.just(0).flatMap((_) => Observable.just(1));
 
     subscription = stream.listen(expectAsync1((value) {
       expect(value, 1);

--- a/test/transformers/fold_test.dart
+++ b/test/transformers/fold_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.fold', () async {
-    final actual = await new Observable.fromIterable(const [1, 2, 3])
+    final actual = await Observable.fromIterable(const [1, 2, 3])
         .fold(4, (int prev, int val) => prev + val);
 
     await expectLater(actual, 10);

--- a/test/transformers/for_each_test.dart
+++ b/test/transformers/for_each_test.dart
@@ -5,7 +5,7 @@ void main() {
   test('rx.Observable.forEach', () async {
     var wasCalled = false;
 
-    await new Observable.just(1).forEach((_) {
+    await Observable.just(1).forEach((_) {
       wasCalled = true;
     });
 

--- a/test/transformers/group_by_test.dart
+++ b/test/transformers/group_by_test.dart
@@ -67,9 +67,9 @@ void main() {
   });
 
   test('rx.Observable.groupBy.asBroadcastStream', () async {
-    final stream = new Observable(
-            new Stream.fromIterable([1, 2, 3, 4]).asBroadcastStream())
-        .groupBy((value) => value);
+    final stream =
+        Observable(Stream.fromIterable([1, 2, 3, 4]).asBroadcastStream())
+            .groupBy((value) => value);
 
     // listen twice on same stream
     stream.listen(null);
@@ -82,7 +82,7 @@ void main() {
     var count = 0;
     StreamSubscription subscription;
 
-    subscription = new Observable(new Stream.fromIterable([1, 2, 3, 4]))
+    subscription = Observable(Stream.fromIterable([1, 2, 3, 4]))
         .groupBy((value) => value)
         .listen(expectAsync1((result) {
           count++;
@@ -97,8 +97,7 @@ void main() {
 
   test('rx.Observable.groupBy.error.shouldThrow.onError', () async {
     final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .groupBy((value) => value);
+        Observable(ErrorStream<void>(Exception())).groupBy((value) => value);
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -108,8 +107,8 @@ void main() {
 
   test('rx.Observable.groupBy.error.shouldThrow.onGrouper', () async {
     final observableWithError =
-        new Observable(new Stream.fromIterable([1, 2, 3, 4])).groupBy((value) {
-      throw new Exception();
+        Observable(Stream.fromIterable([1, 2, 3, 4])).groupBy((value) {
+      throw Exception();
     });
 
     observableWithError.listen(null,

--- a/test/transformers/handle_error_test.dart
+++ b/test/transformers/handle_error_test.dart
@@ -3,10 +3,10 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.handleError', () async {
-    final expected = new ArgumentError();
+    final expected = ArgumentError();
 
-    final obs = new Observable(new ErrorStream<void>(new Exception()))
-        .handleError((dynamic _) {
+    final obs =
+        Observable(ErrorStream<void>(Exception())).handleError((dynamic _) {
       throw expected;
     });
 

--- a/test/transformers/ignore_elements_test.dart
+++ b/test/transformers/ignore_elements_test.dart
@@ -4,12 +4,12 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 Stream<int> _getStream() {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(const Duration(milliseconds: 100), () => controller.add(1));
-  new Timer(const Duration(milliseconds: 200), () => controller.add(2));
-  new Timer(const Duration(milliseconds: 300), () => controller.add(3));
-  new Timer(const Duration(milliseconds: 400), () {
+  Timer(const Duration(milliseconds: 100), () => controller.add(1));
+  Timer(const Duration(milliseconds: 200), () => controller.add(2));
+  Timer(const Duration(milliseconds: 300), () => controller.add(3));
+  Timer(const Duration(milliseconds: 400), () {
     controller.add(4);
     controller.close();
   });
@@ -21,7 +21,7 @@ void main() {
   test('rx.Observable.ignoreElements', () async {
     var hasReceivedEvent = false;
 
-    new Observable(_getStream()).ignoreElements().listen((_) {
+    Observable(_getStream()).ignoreElements().listen((_) {
       hasReceivedEvent = true;
     },
         onDone: expectAsync0(() {
@@ -30,17 +30,17 @@ void main() {
   });
 
   test('rx.Observable.ignoreElements.reusable', () async {
-    final transformer = new IgnoreElementsStreamTransformer<int>();
+    final transformer = IgnoreElementsStreamTransformer<int>();
     var hasReceivedEvent = false;
 
-    new Observable(_getStream()).transform(transformer).listen((_) {
+    Observable(_getStream()).transform(transformer).listen((_) {
       hasReceivedEvent = true;
     },
         onDone: expectAsync0(() {
           expect(hasReceivedEvent, isFalse);
         }, count: 1));
 
-    new Observable(_getStream()).transform(transformer).listen((_) {
+    Observable(_getStream()).transform(transformer).listen((_) {
       hasReceivedEvent = true;
     },
         onDone: expectAsync0(() {
@@ -50,7 +50,7 @@ void main() {
 
   test('rx.Observable.ignoreElements.asBroadcastStream', () async {
     final stream =
-        new Observable(_getStream().asBroadcastStream()).ignoreElements();
+        Observable(_getStream().asBroadcastStream()).ignoreElements();
 
     // listen twice on same stream
     stream.listen(null);
@@ -62,7 +62,7 @@ void main() {
   test('rx.Observable.ignoreElements.pause.resume', () async {
     var hasReceivedEvent = false;
 
-    new Observable(_getStream()).ignoreElements().listen((_) {
+    Observable(_getStream()).ignoreElements().listen((_) {
       hasReceivedEvent = true;
     },
         onDone: expectAsync0(() {
@@ -74,7 +74,7 @@ void main() {
 
   test('rx.Observable.ignoreElements.error.shouldThrow', () async {
     final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception())).ignoreElements();
+        Observable(ErrorStream<void>(Exception())).ignoreElements();
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {

--- a/test/transformers/interval_test.dart
+++ b/test/transformers/interval_test.dart
@@ -3,42 +3,40 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Stream<int> _getStream() => new Stream.fromIterable(const [0, 1, 2, 3, 4]);
+Stream<int> _getStream() => Stream.fromIterable(const [0, 1, 2, 3, 4]);
 
 void main() {
   test('rx.Observable.interval', () async {
     const expectedOutput = [0, 1, 2, 3, 4];
     var count = 0, lastInterval = -1;
-    final stopwatch = new Stopwatch()..start();
+    final stopwatch = Stopwatch()..start();
 
-    new Observable(_getStream())
-        .interval(const Duration(milliseconds: 1))
-        .listen(
-            expectAsync1((result) {
-              expect(expectedOutput[count++], result);
+    Observable(_getStream()).interval(const Duration(milliseconds: 1)).listen(
+        expectAsync1((result) {
+          expect(expectedOutput[count++], result);
 
-              if (lastInterval != -1)
-                expect(stopwatch.elapsedMilliseconds - lastInterval >= 1, true);
+          if (lastInterval != -1)
+            expect(stopwatch.elapsedMilliseconds - lastInterval >= 1, true);
 
-              lastInterval = stopwatch.elapsedMilliseconds;
-            }, count: expectedOutput.length),
-            onDone: stopwatch.stop);
+          lastInterval = stopwatch.elapsedMilliseconds;
+        }, count: expectedOutput.length),
+        onDone: stopwatch.stop);
   });
 
   test('rx.Observable.interval.reusable', () async {
     final transformer =
-        new IntervalStreamTransformer<int>(const Duration(milliseconds: 1));
+        IntervalStreamTransformer<int>(const Duration(milliseconds: 1));
     const expectedOutput = [0, 1, 2, 3, 4];
     var countA = 0, countB = 0;
-    final stopwatch = new Stopwatch()..start();
+    final stopwatch = Stopwatch()..start();
 
-    new Observable(_getStream()).transform(transformer).listen(
+    Observable(_getStream()).transform(transformer).listen(
         expectAsync1((result) {
           expect(expectedOutput[countA++], result);
         }, count: expectedOutput.length),
         onDone: stopwatch.stop);
 
-    new Observable(_getStream()).transform(transformer).listen(
+    Observable(_getStream()).transform(transformer).listen(
         expectAsync1((result) {
           expect(expectedOutput[countB++], result);
         }, count: expectedOutput.length),
@@ -46,7 +44,7 @@ void main() {
   });
 
   test('rx.Observable.interval.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
+    final stream = Observable(_getStream().asBroadcastStream())
         .interval(const Duration(milliseconds: 20));
 
     // listen twice on same stream
@@ -57,9 +55,8 @@ void main() {
   });
 
   test('rx.Observable.interval.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .interval(const Duration(milliseconds: 20));
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .interval(const Duration(milliseconds: 20));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -70,14 +67,14 @@ void main() {
   test('rx.Observable.interval.error.shouldThrowB', () async {
     runZoned(() {
       final observableWithError =
-          new Observable.just(1).interval(const Duration(milliseconds: 20));
+          Observable.just(1).interval(const Duration(milliseconds: 20));
 
       observableWithError.listen(null,
           onError: expectAsync2(
               (Exception e, StackTrace s) => expect(e, isException)));
     },
-        zoneSpecification: new ZoneSpecification(
+        zoneSpecification: ZoneSpecification(
             createTimer: (self, parent, zone, duration, void f()) =>
-                throw new Exception('Zone createTimer error')));
+                throw Exception('Zone createTimer error')));
   });
 }

--- a/test/transformers/is_empty_test.dart
+++ b/test/transformers/is_empty_test.dart
@@ -3,14 +3,13 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.isEmpty.populated', () async {
-    final populated =
-        await new Observable.fromIterable(const [1, 2, 3]).isEmpty;
+    final populated = await Observable.fromIterable(const [1, 2, 3]).isEmpty;
 
     await expectLater(populated, isFalse);
   });
 
   test('rx.Observable.isEmpty.empty', () async {
-    final empty = await new Observable.fromIterable(const <int>[]).isEmpty;
+    final empty = await Observable.fromIterable(const <int>[]).isEmpty;
     await expectLater(empty, isTrue);
   });
 }

--- a/test/transformers/join_test.dart
+++ b/test/transformers/join_test.dart
@@ -3,8 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.join', () async {
-    final joined =
-        await new Observable.fromIterable(const ['h', 'i']).join('+');
+    final joined = await Observable.fromIterable(const ['h', 'i']).join('+');
 
     await expectLater(joined, 'h+i');
   });

--- a/test/transformers/last_test.dart
+++ b/test/transformers/last_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.last', () async {
-    final actual = await new Observable.fromIterable(const [1, 2, 3]).last;
+    final actual = await Observable.fromIterable(const [1, 2, 3]).last;
 
     await expectLater(actual, 3);
   });

--- a/test/transformers/last_where_test.dart
+++ b/test/transformers/last_where_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   test('rx.Observable.lastWhere', () async {
     final dynamic last =
-        await new Observable<String>.fromIterable(const <String>['h', 'i'])
+        await Observable<String>.fromIterable(const <String>['h', 'i'])
             .lastWhere((String element) => element.length == 1);
 
     await expectLater(last, 'i');

--- a/test/transformers/map_to_test.dart
+++ b/test/transformers/map_to_test.dart
@@ -12,19 +12,19 @@ void main() {
   test('rx.Observable.mapTo.shouldThrow', () async {
     await expectLater(
         Observable.range(1, 4)
-            .concatWith([new ErrorStream<int>(new Error())]).mapTo(true),
+            .concatWith([ErrorStream<int>(Error())]).mapTo(true),
         emitsInOrder(<dynamic>[
           true,
           true,
           true,
           true,
-          emitsError(new TypeMatcher<Error>()),
+          emitsError(TypeMatcher<Error>()),
           emitsDone
         ]));
   });
 
   test('rx.Observable.mapTo.reusable', () async {
-    final transformer = new MapToStreamTransformer<int, bool>(true);
+    final transformer = MapToStreamTransformer<int, bool>(true);
     final observable = Observable.range(1, 4).asBroadcastStream();
 
     observable.transform(transformer).listen(null);

--- a/test/transformers/materialize_test.dart
+++ b/test/transformers/materialize_test.dart
@@ -5,52 +5,52 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.materialize.happyPath', () async {
-    final observable = new Observable.just(1);
+    final observable = Observable.just(1);
     final notifications = <Notification<int>>[];
 
     observable.materialize().listen(notifications.add, onDone: expectAsync0(() {
-      expect(notifications,
-          [new Notification.onData(1), new Notification<int>.onDone()]);
+      expect(
+          notifications, [Notification.onData(1), Notification<int>.onDone()]);
     }));
   });
 
   test('rx.Observable.materialize.reusable', () async {
-    final transformer = new MaterializeStreamTransformer<int>();
-    final observable = new Observable.just(1).asBroadcastStream();
+    final transformer = MaterializeStreamTransformer<int>();
+    final observable = Observable.just(1).asBroadcastStream();
     final notificationsA = <Notification<int>>[],
         notificationsB = <Notification<int>>[];
 
     observable.transform(transformer).listen(notificationsA.add,
         onDone: expectAsync0(() {
-      expect(notificationsA,
-          [new Notification.onData(1), new Notification<int>.onDone()]);
+      expect(
+          notificationsA, [Notification.onData(1), Notification<int>.onDone()]);
     }));
 
     observable.transform(transformer).listen(notificationsB.add,
         onDone: expectAsync0(() {
-      expect(notificationsB,
-          [new Notification.onData(1), new Notification<int>.onDone()]);
+      expect(
+          notificationsB, [Notification.onData(1), Notification<int>.onDone()]);
     }));
   });
 
   test('materializeTransformer.happyPath', () async {
-    final stream = new Stream.fromIterable(const [1]);
+    final stream = Stream.fromIterable(const [1]);
     final notifications = <Notification<int>>[];
 
     stream
-        .transform(new MaterializeStreamTransformer<int>())
+        .transform(MaterializeStreamTransformer<int>())
         .listen(notifications.add, onDone: expectAsync0(() {
-      expect(notifications,
-          [new Notification.onData(1), new Notification<int>.onDone()]);
+      expect(
+          notifications, [Notification.onData(1), Notification<int>.onDone()]);
     }));
   });
 
   test('materializeTransformer.sadPath', () async {
-    final stream = new ErrorStream<int>(new Exception());
+    final stream = ErrorStream<int>(Exception());
     final notifications = <Notification<int>>[];
 
     stream
-        .transform(new MaterializeStreamTransformer<int>())
+        .transform(MaterializeStreamTransformer<int>())
         .listen(notifications.add,
             onError: expectAsync2((Exception e, StackTrace s) {
               // Check to ensure the stream does not come to this point
@@ -63,15 +63,15 @@ void main() {
   });
 
   test('materializeTransformer.onPause.onResume', () async {
-    final stream = new Stream.fromIterable(const [1]);
+    final stream = Stream.fromIterable(const [1]);
     final notifications = <Notification<int>>[];
 
     stream
-        .transform(new MaterializeStreamTransformer<int>())
+        .transform(MaterializeStreamTransformer<int>())
         .listen(notifications.add, onDone: expectAsync0(() {
       expect(notifications, <Notification<int>>[
-        new Notification.onData(1),
-        new Notification<int>.onDone()
+        Notification.onData(1),
+        Notification<int>.onDone()
       ]);
     }))
           ..pause()

--- a/test/transformers/merge_with_test.dart
+++ b/test/transformers/merge_with_test.dart
@@ -3,13 +3,12 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.mergeWith', () async {
-    final delayedStream =
-        new Observable.timer(1, new Duration(milliseconds: 10));
-    final immediateStream = new Observable.just(2);
+    final delayedStream = Observable.timer(1, Duration(milliseconds: 10));
+    final immediateStream = Observable.just(2);
     const expected = [2, 1];
     var count = 0;
 
-    new Observable(delayedStream)
+    Observable(delayedStream)
         .mergeWith([immediateStream]).listen(expectAsync1((result) {
       expect(result, expected[count++]);
     }, count: expected.length));

--- a/test/transformers/of_type_test.dart
+++ b/test/transformers/of_type_test.dart
@@ -5,16 +5,16 @@ import 'package:rxdart/src/utils/type_token.dart';
 import 'package:test/test.dart';
 
 Stream<Object> _getStream() {
-  final controller = new StreamController<dynamic>();
+  final controller = StreamController<dynamic>();
 
-  new Timer(const Duration(milliseconds: 100), () => controller.add(1));
-  new Timer(const Duration(milliseconds: 200), () => controller.add('2'));
-  new Timer(
+  Timer(const Duration(milliseconds: 100), () => controller.add(1));
+  Timer(const Duration(milliseconds: 200), () => controller.add('2'));
+  Timer(
       const Duration(milliseconds: 300), () => controller.add(const {'3': 3}));
-  new Timer(const Duration(milliseconds: 400), () {
+  Timer(const Duration(milliseconds: 400), () {
     controller.add(const {'4': '4'});
   });
-  new Timer(const Duration(milliseconds: 500), () {
+  Timer(const Duration(milliseconds: 500), () {
     controller.add(5.0);
     controller.close();
   });
@@ -24,22 +24,21 @@ Stream<Object> _getStream() {
 
 void main() {
   test('rx.Observable.ofType', () async {
-    new Observable(_getStream())
-        .ofType(new TypeToken<Map<String, int>>())
+    Observable(_getStream())
+        .ofType(TypeToken<Map<String, int>>())
         .listen(expectAsync1((result) {
           expect(result, isMap);
         }, count: 1));
   });
 
   test('rx.Observable.ofType.polymorphism', () async {
-    new Observable(_getStream()).ofType(kNum).listen(expectAsync1((result) {
+    Observable(_getStream()).ofType(kNum).listen(expectAsync1((result) {
           expect(result is num, true);
         }, count: 2));
   });
 
   test('rx.Observable.ofType.asBroadcastStream', () async {
-    final stream =
-        new Observable(_getStream().asBroadcastStream()).ofType(kInt);
+    final stream = Observable(_getStream().asBroadcastStream()).ofType(kInt);
 
     // listen twice on same stream
     stream.listen(null);
@@ -50,7 +49,7 @@ void main() {
 
   test('rx.Observable.ofType.error.shouldThrow', () async {
     final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception())).ofType(kNum);
+        Observable(ErrorStream<void>(Exception())).ofType(kNum);
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -60,7 +59,7 @@ void main() {
 
   test('rx.Observable.ofType.pause.resume', () async {
     StreamSubscription<int> subscription;
-    final stream = new Observable.just(1).ofType(kInt);
+    final stream = Observable.just(1).ofType(kInt);
 
     subscription = stream.listen(expectAsync1((value) {
       expect(value, 1);

--- a/test/transformers/on_error_resume_next_test.dart
+++ b/test/transformers/on_error_resume_next_test.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Stream<int> _getStream() => new Stream.fromIterable(const [0, 1, 2, 3]);
+Stream<int> _getStream() => Stream.fromIterable(const [0, 1, 2, 3]);
 
 const List<int> expected = [0, 1, 2, 3];
 
@@ -11,7 +11,7 @@ void main() {
   test('rx.Observable.onErrorResumeNext', () async {
     var count = 0;
 
-    new Observable(new ErrorStream<num>(new Exception()))
+    Observable(ErrorStream<num>(Exception()))
         .onErrorResumeNext(_getStream())
         .listen(expectAsync1((result) {
           expect(result, expected[count++]);
@@ -22,17 +22,16 @@ void main() {
     // ignore: deprecated_member_use
     final transformer =
         // ignore: deprecated_member_use
-        new OnErrorResumeNextStreamTransformer(
-            _getStream().asBroadcastStream());
+        OnErrorResumeNextStreamTransformer(_getStream().asBroadcastStream());
     var countA = 0, countB = 0;
 
-    new Observable(new ErrorStream<int>(new Exception()))
+    Observable(ErrorStream<int>(Exception()))
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, expected[countA++]);
         }, count: expected.length));
 
-    new Observable(new ErrorStream<int>(new Exception()))
+    Observable(ErrorStream<int>(Exception()))
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, expected[countB++]);
@@ -40,7 +39,7 @@ void main() {
   });
 
   test('rx.Observable.onErrorResumeNext.asBroadcastStream', () async {
-    final stream = new Observable(new ErrorStream<int>(new Exception()))
+    final stream = Observable(ErrorStream<int>(Exception()))
         .onErrorResumeNext(_getStream())
         .asBroadcastStream();
     var countA = 0, countB = 0;
@@ -56,9 +55,8 @@ void main() {
   });
 
   test('rx.Observable.onErrorResumeNext.error.shouldThrow', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .onErrorResumeNext(new ErrorStream<void>(new Exception()));
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .onErrorResumeNext(ErrorStream<void>(Exception()));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -70,7 +68,7 @@ void main() {
     StreamSubscription<num> subscription;
     var count = 0;
 
-    subscription = new Observable(new ErrorStream<int>(new Exception()))
+    subscription = Observable(ErrorStream<int>(Exception()))
         .onErrorResumeNext(_getStream())
         .listen(expectAsync1((result) {
           expect(result, expected[count++]);
@@ -87,7 +85,7 @@ void main() {
   test('rx.Observable.onErrorResumeNext.close', () async {
     var count = 0;
 
-    new Observable(new ErrorStream<int>(new Exception()))
+    Observable(ErrorStream<int>(Exception()))
         .onErrorResumeNext(_getStream())
         .listen(
             expectAsync1((result) {

--- a/test/transformers/on_error_resume_test.dart
+++ b/test/transformers/on_error_resume_test.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Stream<int> _getStream() => new Stream.fromIterable(const [0, 1, 2, 3]);
+Stream<int> _getStream() => Stream.fromIterable(const [0, 1, 2, 3]);
 
 const List<int> expected = [0, 1, 2, 3];
 
@@ -11,7 +11,7 @@ void main() {
   test('rx.Observable.onErrorResumeNext', () async {
     var count = 0;
 
-    new Observable(new ErrorStream<int>(new Exception()))
+    Observable(ErrorStream<int>(Exception()))
         .onErrorResumeNext(_getStream())
         .listen(expectAsync1((result) {
           expect(result, expected[count++]);
@@ -21,7 +21,7 @@ void main() {
   test('rx.Observable.onErrorResume', () async {
     var count = 0;
 
-    new Observable(new ErrorStream<int>(new Exception()))
+    Observable(ErrorStream<int>(Exception()))
         .onErrorResume((dynamic e) => _getStream())
         .listen(expectAsync1((result) {
           expect(result, expected[count++]);
@@ -29,17 +29,17 @@ void main() {
   });
 
   test('rx.Observable.onErrorResume.correctError', () async {
-    final exception = new Exception();
+    final exception = Exception();
 
     expect(
-      new Observable(new ErrorStream<Object>(exception))
-          .onErrorResume((Object e) => new Observable.just(e)),
+      Observable(ErrorStream<Object>(exception))
+          .onErrorResume((Object e) => Observable.just(e)),
       emits(exception),
     );
   });
 
   test('rx.Observable.onErrorResumeNext.asBroadcastStream', () async {
-    final stream = new Observable(new ErrorStream<int>(new Exception()))
+    final stream = Observable(ErrorStream<int>(Exception()))
         .onErrorResumeNext(_getStream())
         .asBroadcastStream();
     var countA = 0, countB = 0;
@@ -55,9 +55,8 @@ void main() {
   });
 
   test('rx.Observable.onErrorResumeNext.error.shouldThrow', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .onErrorResumeNext(new ErrorStream<void>(new Exception()));
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .onErrorResumeNext(ErrorStream<void>(Exception()));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -67,14 +66,14 @@ void main() {
 
   test('rx.Observable.onErrorResumeNext.pause.resume', () async {
     final transformer =
-        new OnErrorResumeStreamTransformer<int>((Object _) => _getStream());
+        OnErrorResumeStreamTransformer<int>((Object _) => _getStream());
     final exp = const [50] + expected;
     StreamSubscription<num> subscription;
     var count = 0;
 
-    subscription = new Observable.merge([
-      new Observable.just(50),
-      new ErrorStream<int>(new Exception()),
+    subscription = Observable.merge([
+      Observable.just(50),
+      ErrorStream<int>(Exception()),
     ]).transform(transformer).listen(expectAsync1((result) {
           expect(result, exp[count++]);
 
@@ -90,7 +89,7 @@ void main() {
   test('rx.Observable.onErrorResumeNext.close', () async {
     var count = 0;
 
-    new Observable(new ErrorStream<int>(new Exception()))
+    Observable(ErrorStream<int>(Exception()))
         .onErrorResumeNext(_getStream())
         .listen(
             expectAsync1((result) {
@@ -104,23 +103,23 @@ void main() {
 
   test('rx.Observable.onErrorResumeNext.noErrors.close', () async {
     expect(
-      new Observable<int>.empty().onErrorResumeNext(_getStream()),
+      Observable<int>.empty().onErrorResumeNext(_getStream()),
       emitsDone,
     );
   });
 
   test('OnErrorResumeStreamTransformer.reusable', () async {
-    final transformer = new OnErrorResumeStreamTransformer<int>(
+    final transformer = OnErrorResumeStreamTransformer<int>(
         (Object _) => _getStream().asBroadcastStream());
     var countA = 0, countB = 0;
 
-    new Observable(new ErrorStream<int>(new Exception()))
+    Observable(ErrorStream<int>(Exception()))
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, expected[countA++]);
         }, count: expected.length));
 
-    new Observable(new ErrorStream<int>(new Exception()))
+    Observable(ErrorStream<int>(Exception()))
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, expected[countB++]);

--- a/test/transformers/on_error_return_test.dart
+++ b/test/transformers/on_error_return_test.dart
@@ -7,7 +7,7 @@ void main() {
   const num expected = 0;
 
   test('rx.Observable.onErrorReturn', () async {
-    new Observable<num>(new ErrorStream<num>(new Exception()))
+    Observable<num>(ErrorStream<num>(Exception()))
         .onErrorReturn(0)
         .listen(expectAsync1((num result) {
       expect(result, expected);
@@ -15,10 +15,9 @@ void main() {
   });
 
   test('rx.Observable.onErrorReturn.asBroadcastStream', () async {
-    Stream<num> stream =
-        new Observable<num>(new ErrorStream<num>(new Exception()))
-            .onErrorReturn(0)
-            .asBroadcastStream();
+    Stream<num> stream = Observable<num>(ErrorStream<num>(Exception()))
+        .onErrorReturn(0)
+        .asBroadcastStream();
 
     await expectLater(stream.isBroadcast, isTrue);
 
@@ -34,7 +33,7 @@ void main() {
   test('rx.Observable.onErrorReturn.pause.resume', () async {
     StreamSubscription<num> subscription;
 
-    subscription = new Observable<num>(new ErrorStream<num>(new Exception()))
+    subscription = Observable<num>(ErrorStream<num>(Exception()))
         .onErrorReturn(0)
         .listen(expectAsync1((num result) {
       expect(result, expected);

--- a/test/transformers/on_error_return_with_test.dart
+++ b/test/transformers/on_error_return_with_test.dart
@@ -7,7 +7,7 @@ void main() {
   const num expected = 0;
 
   test('rx.Observable.onErrorReturnWith', () async {
-    new Observable<num>(new ErrorStream<num>(new Exception()))
+    Observable<num>(ErrorStream<num>(Exception()))
         .onErrorReturnWith((dynamic e) => e is StateError ? 1 : 0)
         .listen(expectAsync1((num result) {
       expect(result, expected);
@@ -15,10 +15,9 @@ void main() {
   });
 
   test('rx.Observable.onErrorReturnWith.asBroadcastStream', () async {
-    Stream<num> stream =
-        new Observable<num>(new ErrorStream<num>(new Exception()))
-            .onErrorReturnWith((dynamic e) => 0)
-            .asBroadcastStream();
+    Stream<num> stream = Observable<num>(ErrorStream<num>(Exception()))
+        .onErrorReturnWith((dynamic e) => 0)
+        .asBroadcastStream();
 
     await expectLater(stream.isBroadcast, isTrue);
 
@@ -34,7 +33,7 @@ void main() {
   test('rx.Observable.onErrorReturnWith.pause.resume', () async {
     StreamSubscription<num> subscription;
 
-    subscription = new Observable<num>(new ErrorStream<num>(new Exception()))
+    subscription = Observable<num>(ErrorStream<num>(Exception()))
         .onErrorReturnWith((dynamic e) => 0)
         .listen(expectAsync1((num result) {
       expect(result, expected);

--- a/test/transformers/pairwise_test.dart
+++ b/test/transformers/pairwise_test.dart
@@ -25,9 +25,9 @@ void main() {
   });
 
   test('rx.Observable.pairwise.asBroadcastStream', () async {
-    final stream = new Observable(
-            new Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
-        .pairwise();
+    final stream =
+        Observable(Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
+            .pairwise();
 
     // listen twice on same stream
     stream.listen(null);
@@ -38,7 +38,7 @@ void main() {
 
   test('rx.Observable.pairwise.error.shouldThrow.onError', () async {
     final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception())).pairwise();
+        Observable(ErrorStream<void>(Exception())).pairwise();
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {

--- a/test/transformers/reduce_test.dart
+++ b/test/transformers/reduce_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.reduce', () async {
-    final actual = await new Observable.fromIterable(const [1, 2, 3])
+    final actual = await Observable.fromIterable(const [1, 2, 3])
         .reduce((int prev, int val) => prev + val);
 
     await expectLater(actual, 6);

--- a/test/transformers/sample_test.dart
+++ b/test/transformers/sample_test.dart
@@ -4,25 +4,25 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 Stream<int> _getStream() =>
-    new Stream<int>.periodic(const Duration(milliseconds: 20), (count) => count)
+    Stream<int>.periodic(const Duration(milliseconds: 20), (count) => count)
         .take(5);
 
 Stream<int> _getSampleStream() =>
-    new Stream<int>.periodic(const Duration(milliseconds: 35), (count) => count)
+    Stream<int>.periodic(const Duration(milliseconds: 35), (count) => count)
         .take(10);
 
 void main() {
   test('rx.Observable.sample', () async {
-    final observable = new Observable(_getStream()).sample(_getSampleStream());
+    final observable = Observable(_getStream()).sample(_getSampleStream());
 
     await expectLater(observable, emitsInOrder(const <int>[0, 2, 4]));
   });
 
   test('rx.Observable.sample.reusable', () async {
-    final transformer = new SampleStreamTransformer<int>(
-        _getSampleStream().asBroadcastStream());
-    final observableA = new Observable(_getStream()).transform(transformer);
-    final observableB = new Observable(_getStream()).transform(transformer);
+    final transformer =
+        SampleStreamTransformer<int>(_getSampleStream().asBroadcastStream());
+    final observableA = Observable(_getStream()).transform(transformer);
+    final observableB = Observable(_getStream()).transform(transformer);
 
     await Future.wait<dynamic>([
       expectLater(observableA, emitsInOrder(const <int>[0, 2, 4])),
@@ -31,17 +31,17 @@ void main() {
   });
 
   test('rx.Observable.sample.onDone', () async {
-    final observable = new Observable(new Observable.just(1))
-        .sample(new Observable<void>.empty());
+    final observable =
+        Observable(Observable.just(1)).sample(Observable<void>.empty());
 
     await expectLater(observable, emits(1));
   });
 
   test('rx.Observable.sample.shouldClose', () async {
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
-        .sample(new Stream<void>.empty()) // should trigger onDone
+    Observable(controller.stream)
+        .sample(Stream<void>.empty()) // should trigger onDone
         .listen(null, onDone: expectAsync0(() => expect(true, isTrue)));
 
     controller.add(0);
@@ -53,7 +53,7 @@ void main() {
   });
 
   test('rx.Observable.sample.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
+    final stream = Observable(_getStream().asBroadcastStream())
         .sample(_getSampleStream().asBroadcastStream());
 
     // listen twice on same stream
@@ -65,8 +65,7 @@ void main() {
 
   test('rx.Observable.sample.error.shouldThrowA', () async {
     final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .sample(_getSampleStream());
+        Observable(ErrorStream<void>(Exception())).sample(_getSampleStream());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -75,8 +74,8 @@ void main() {
   });
 
   test('rx.Observable.sample.error.shouldThrowB', () async {
-    final observableWithError = new Observable.just(1)
-        .sample(new ErrorStream<void>(new Exception('Catch me if you can!')));
+    final observableWithError = Observable.just(1)
+        .sample(ErrorStream<void>(Exception('Catch me if you can!')));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -89,7 +88,7 @@ void main() {
     var count = 0;
     StreamSubscription<int> subscription;
 
-    subscription = new Observable(_getStream())
+    subscription = Observable(_getStream())
         .sample(_getSampleStream())
         .listen(expectAsync1((result) {
           expect(expectedOutput[count++], result);

--- a/test/transformers/scan_test.dart
+++ b/test/transformers/scan_test.dart
@@ -8,7 +8,7 @@ void main() {
     const expectedOutput = [1, 3, 6, 10];
     var count = 0;
 
-    new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .scan((int acc, int value, int index) => (acc ?? 0) + value)
         .listen(expectAsync1((result) {
           expect(expectedOutput[count++], result);
@@ -16,18 +16,18 @@ void main() {
   });
 
   test('rx.Observable.scan.reusable', () async {
-    final transformer = new ScanStreamTransformer<int, int>(
+    final transformer = ScanStreamTransformer<int, int>(
         (int acc, int value, int index) => (acc ?? 0) + value);
     const expectedOutput = [1, 3, 6, 10];
     var countA = 0, countB = 0;
 
-    new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(expectedOutput[countA++], result);
         }, count: expectedOutput.length));
 
-    new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(expectedOutput[countB++], result);
@@ -35,9 +35,9 @@ void main() {
   });
 
   test('rx.Observable.scan.asBroadcastStream', () async {
-    final stream = new Observable(
-            new Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
-        .scan((int acc, int value, int index) => (acc ?? 0) + value, 0);
+    final stream =
+        Observable(Stream.fromIterable(const [1, 2, 3, 4]).asBroadcastStream())
+            .scan((int acc, int value, int index) => (acc ?? 0) + value, 0);
 
     // listen twice on same stream
     stream.listen(null);
@@ -48,9 +48,9 @@ void main() {
 
   test('rx.Observable.scan.error.shouldThrow', () async {
     final observableWithError =
-        new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+        Observable(Stream.fromIterable(const [1, 2, 3, 4]))
             .scan((num acc, num value, int index) {
-      throw new StateError("oh noes!");
+      throw StateError("oh noes!");
     });
 
     observableWithError.listen(null,

--- a/test/transformers/single_test.dart
+++ b/test/transformers/single_test.dart
@@ -3,14 +3,14 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.single', () async {
-    final actual = await new Observable.just(1).single;
+    final actual = await Observable.just(1).single;
 
     await expectLater(actual, 1);
   });
 
   test('rx.Observable.single.throws', () async {
     try {
-      await new Observable.fromIterable(const [1, 2, 3]).single;
+      await Observable.fromIterable(const [1, 2, 3]).single;
     } catch (e) {
       await expectLater(e, isStateError);
     }

--- a/test/transformers/single_where_test.dart
+++ b/test/transformers/single_where_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.singleWhere', () async {
-    final actual = await new Observable.fromIterable(const [1, 2, 3])
+    final actual = await Observable.fromIterable(const [1, 2, 3])
         .singleWhere((val) => val == 2);
 
     await expectLater(actual, 2);
@@ -11,7 +11,7 @@ void main() {
 
   test('rx.Observable.singleWhere.throws', () async {
     try {
-      await new Observable.fromIterable(const [1, 2, 2])
+      await Observable.fromIterable(const [1, 2, 2])
           .singleWhere((val) => val == 2);
     } catch (e) {
       await expectLater(e, isStateError);

--- a/test/transformers/skip_test.dart
+++ b/test/transformers/skip_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 void main() {
   test('rx.Observable.skip', () async {
     Stream<int> observable =
-        new Observable<int>.fromIterable(<int>[1, 2, 3]).skip(2);
+        Observable<int>.fromIterable(<int>[1, 2, 3]).skip(2);
 
     observable.listen(expectAsync1((int actual) {
       expect(actual, 3);

--- a/test/transformers/skip_until_test.dart
+++ b/test/transformers/skip_until_test.dart
@@ -4,12 +4,12 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 Stream<int> _getStream() {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(const Duration(milliseconds: 100), () => controller.add(1));
-  new Timer(const Duration(milliseconds: 200), () => controller.add(2));
-  new Timer(const Duration(milliseconds: 300), () => controller.add(3));
-  new Timer(const Duration(milliseconds: 400), () {
+  Timer(const Duration(milliseconds: 100), () => controller.add(1));
+  Timer(const Duration(milliseconds: 200), () => controller.add(2));
+  Timer(const Duration(milliseconds: 300), () => controller.add(3));
+  Timer(const Duration(milliseconds: 400), () {
     controller.add(4);
     controller.close();
   });
@@ -18,9 +18,9 @@ Stream<int> _getStream() {
 }
 
 Stream<int> _getOtherStream() {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(const Duration(milliseconds: 250), () {
+  Timer(const Duration(milliseconds: 250), () {
     controller.add(1);
     controller.close();
   });
@@ -33,7 +33,7 @@ void main() {
     const expectedOutput = [3, 4];
     var count = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .skipUntil(_getOtherStream())
         .listen(expectAsync1((result) {
           expect(expectedOutput[count++], result);
@@ -41,24 +41,24 @@ void main() {
   });
 
   test('rx.Observable.skipUntil.shouldClose', () async {
-    new Observable(_getStream())
-        .skipUntil(new Stream<void>.empty())
+    Observable(_getStream())
+        .skipUntil(Stream<void>.empty())
         .listen(null, onDone: expectAsync0(() => expect(true, isTrue)));
   });
 
   test('rx.Observable.skipUntil.reusable', () async {
-    final transformer = new SkipUntilStreamTransformer<int, int>(
+    final transformer = SkipUntilStreamTransformer<int, int>(
         _getOtherStream().asBroadcastStream());
     const expectedOutput = [3, 4];
     var countA = 0, countB = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(expectedOutput[countA++], result);
         }, count: expectedOutput.length));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(expectedOutput[countB++], result);
@@ -66,7 +66,7 @@ void main() {
   });
 
   test('rx.Observable.skipUntil.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
+    final stream = Observable(_getStream().asBroadcastStream())
         .skipUntil(_getOtherStream().asBroadcastStream());
 
     // listen twice on same stream
@@ -78,8 +78,7 @@ void main() {
 
   test('rx.Observable.skipUntil.error.shouldThrowA', () async {
     final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .skipUntil(_getOtherStream());
+        Observable(ErrorStream<int>(Exception())).skipUntil(_getOtherStream());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -88,8 +87,8 @@ void main() {
   });
 
   test('rx.Observable.skipUntil.error.shouldThrowB', () async {
-    final observableWithError = new Observable.just(1)
-        .skipUntil(new ErrorStream<void>(new Exception('Oh noes!')));
+    final observableWithError =
+        Observable.just(1).skipUntil(ErrorStream<void>(Exception('Oh noes!')));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -98,8 +97,7 @@ void main() {
   });
 
   test('rx.Observable.skipUntil.error.shouldThrowC', () {
-    expect(() => new Observable.just(1).skipUntil<void>(null),
-        throwsArgumentError);
+    expect(() => Observable.just(1).skipUntil<void>(null), throwsArgumentError);
   });
 
   test('rx.Observable.skipUntil.pause.resume', () async {
@@ -107,7 +105,7 @@ void main() {
     const expectedOutput = [3, 4];
     var count = 0;
 
-    subscription = new Observable(_getStream())
+    subscription = Observable(_getStream())
         .skipUntil(_getOtherStream())
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[count++]);

--- a/test/transformers/skip_while_test.dart
+++ b/test/transformers/skip_while_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.skipWhile', () async {
-    Stream<int> observable = new Observable<int>.fromIterable(<int>[1, 2, 3])
+    Stream<int> observable = Observable<int>.fromIterable(<int>[1, 2, 3])
         .skipWhile((int value) => value < 3);
 
     observable.listen(expectAsync1((int actual) {

--- a/test/transformers/start_with_many_test.dart
+++ b/test/transformers/start_with_many_test.dart
@@ -3,31 +3,31 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Stream<int> _getStream() => new Stream.fromIterable(const [1, 2, 3, 4]);
+Stream<int> _getStream() => Stream.fromIterable(const [1, 2, 3, 4]);
 
 void main() {
   test('rx.Observable.startWithMany', () async {
     const expectedOutput = [5, 6, 1, 2, 3, 4];
     var count = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .startWithMany(const [5, 6]).listen(expectAsync1((result) {
       expect(expectedOutput[count++], result);
     }, count: expectedOutput.length));
   });
 
   test('rx.Observable.startWithMany.reusable', () async {
-    final transformer = new StartWithManyStreamTransformer<int>(const [5, 6]);
+    final transformer = StartWithManyStreamTransformer<int>(const [5, 6]);
     const expectedOutput = [5, 6, 1, 2, 3, 4];
     var countA = 0, countB = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(expectedOutput[countA++], result);
         }, count: expectedOutput.length));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(expectedOutput[countB++], result);
@@ -35,7 +35,7 @@ void main() {
   });
 
   test('rx.Observable.startWithMany.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
+    final stream = Observable(_getStream().asBroadcastStream())
         .startWithMany(const [5, 6]);
 
     // listen twice on same stream
@@ -47,8 +47,7 @@ void main() {
 
   test('rx.Observable.startWithMany.error.shouldThrowA', () async {
     final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .startWithMany(const [5, 6]);
+        Observable(ErrorStream<int>(Exception())).startWithMany(const [5, 6]);
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -57,8 +56,7 @@ void main() {
   });
 
   test('rx.Observable.startWithMany.error.shouldThrowA', () {
-    expect(
-        () => new Observable.just(1).startWithMany(null), throwsArgumentError);
+    expect(() => Observable.just(1).startWithMany(null), throwsArgumentError);
   });
 
   test('rx.Observable.startWithMany.pause.resume', () async {
@@ -66,7 +64,7 @@ void main() {
     var count = 0;
 
     StreamSubscription<int> subscription;
-    subscription = new Observable(_getStream())
+    subscription = Observable(_getStream())
         .startWithMany(const [5, 6]).listen(expectAsync1((result) {
       expect(expectedOutput[count++], result);
 

--- a/test/transformers/start_with_test.dart
+++ b/test/transformers/start_with_test.dart
@@ -3,30 +3,30 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Stream<int> _getStream() => new Stream.fromIterable(const [1, 2, 3, 4]);
+Stream<int> _getStream() => Stream.fromIterable(const [1, 2, 3, 4]);
 
 void main() {
   test('rx.Observable.startWith', () async {
     const expectedOutput = [5, 1, 2, 3, 4];
     var count = 0;
 
-    new Observable(_getStream()).startWith(5).listen(expectAsync1((result) {
+    Observable(_getStream()).startWith(5).listen(expectAsync1((result) {
           expect(expectedOutput[count++], result);
         }, count: expectedOutput.length));
   });
 
   test('rx.Observable.startWith.reusable', () async {
-    final transformer = new StartWithStreamTransformer<int>(5);
+    final transformer = StartWithStreamTransformer<int>(5);
     const expectedOutput = [5, 1, 2, 3, 4];
     var countA = 0, countB = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(expectedOutput[countA++], result);
         }, count: expectedOutput.length));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(expectedOutput[countB++], result);
@@ -34,8 +34,7 @@ void main() {
   });
 
   test('rx.Observable.startWith.asBroadcastStream', () async {
-    final stream =
-        new Observable(_getStream().asBroadcastStream()).startWith(5);
+    final stream = Observable(_getStream().asBroadcastStream()).startWith(5);
 
     // listen twice on same stream
     stream.listen(null);
@@ -46,7 +45,7 @@ void main() {
 
   test('rx.Observable.startWith.error.shouldThrow', () async {
     final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception())).startWith(5);
+        Observable(ErrorStream<int>(Exception())).startWith(5);
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -60,7 +59,7 @@ void main() {
 
     StreamSubscription<int> subscription;
     subscription =
-        new Observable(_getStream()).startWith(5).listen(expectAsync1((result) {
+        Observable(_getStream()).startWith(5).listen(expectAsync1((result) {
               expect(expectedOutput[count++], result);
 
               if (count == expectedOutput.length) {

--- a/test/transformers/switch_if_empty_test.dart
+++ b/test/transformers/switch_if_empty_test.dart
@@ -19,16 +19,16 @@ void main() {
   });
 
   test('rx.Observable.switchIfEmpty.reusable', () async {
-    final transformer = new SwitchIfEmptyStreamTransformer<bool>(
-        new Observable.just(true).asBroadcastStream());
+    final transformer = SwitchIfEmptyStreamTransformer<bool>(
+        Observable.just(true).asBroadcastStream());
 
-    new Observable(new Stream<bool>.empty())
+    Observable(Stream<bool>.empty())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, true);
         }, count: 1));
 
-    new Observable(new Stream<bool>.empty())
+    Observable(Stream<bool>.empty())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, true);
@@ -36,16 +36,16 @@ void main() {
   });
 
   test('rx.Observable.switchIfEmpty.whenNotEmpty', () async {
-    new Observable.just(false)
-        .switchIfEmpty(new Observable.just(true))
+    Observable.just(false)
+        .switchIfEmpty(Observable.just(true))
         .listen(expectAsync1((result) {
           expect(result, false);
         }, count: 1));
   });
 
   test('rx.Observable.switchIfEmpty.asBroadcastStream', () async {
-    final stream = new Observable(new Stream<int>.empty())
-        .switchIfEmpty(new Observable.just(1))
+    final stream = Observable(Stream<int>.empty())
+        .switchIfEmpty(Observable.just(1))
         .asBroadcastStream();
 
     // listen twice on same stream
@@ -57,9 +57,8 @@ void main() {
   });
 
   test('rx.Observable.switchIfEmpty.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .switchIfEmpty(new Observable.just(1));
+    final observableWithError = Observable(ErrorStream<int>(Exception()))
+        .switchIfEmpty(Observable.just(1));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -68,14 +67,14 @@ void main() {
   });
 
   test('rx.Observable.switchIfEmpty.error.shouldThrowB', () {
-    expect(() => new Observable<void>.empty().switchIfEmpty(null),
+    expect(() => Observable<void>.empty().switchIfEmpty(null),
         throwsArgumentError);
   });
 
   test('rx.Observable.switchIfEmpty.pause.resume', () async {
     StreamSubscription<int> subscription;
-    final stream = new Observable(new Stream<int>.empty())
-        .switchIfEmpty(new Observable.just(1));
+    final stream =
+        Observable(Stream<int>.empty()).switchIfEmpty(Observable.just(1));
 
     subscription = stream.listen(expectAsync1((value) {
       expect(value, 1);

--- a/test/transformers/switch_map_test.dart
+++ b/test/transformers/switch_map_test.dart
@@ -4,12 +4,12 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 Stream<int> _getStream() {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(const Duration(milliseconds: 10), () => controller.add(1));
-  new Timer(const Duration(milliseconds: 20), () => controller.add(2));
-  new Timer(const Duration(milliseconds: 30), () => controller.add(3));
-  new Timer(const Duration(milliseconds: 40), () {
+  Timer(const Duration(milliseconds: 10), () => controller.add(1));
+  Timer(const Duration(milliseconds: 20), () => controller.add(2));
+  Timer(const Duration(milliseconds: 30), () => controller.add(3));
+  Timer(const Duration(milliseconds: 40), () {
     controller.add(4);
     controller.close();
   });
@@ -18,12 +18,12 @@ Stream<int> _getStream() {
 }
 
 Stream<int> _getOtherStream(int value) {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(const Duration(milliseconds: 15), () => controller.add(value + 1));
-  new Timer(const Duration(milliseconds: 25), () => controller.add(value + 2));
-  new Timer(const Duration(milliseconds: 35), () => controller.add(value + 3));
-  new Timer(const Duration(milliseconds: 45), () {
+  Timer(const Duration(milliseconds: 15), () => controller.add(value + 1));
+  Timer(const Duration(milliseconds: 25), () => controller.add(value + 2));
+  Timer(const Duration(milliseconds: 35), () => controller.add(value + 3));
+  Timer(const Duration(milliseconds: 45), () {
     controller.add(value + 4);
     controller.close();
   });
@@ -32,14 +32,14 @@ Stream<int> _getOtherStream(int value) {
 }
 
 Stream<int> range() =>
-    new Stream.fromIterable(const [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    Stream.fromIterable(const [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
 void main() {
   test('rx.Observable.switchMap', () async {
     const expectedOutput = [5, 6, 7, 8];
     var count = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .switchMap(_getOtherStream)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[count++]);
@@ -47,18 +47,17 @@ void main() {
   });
 
   test('rx.Observable.switchMap.reusable', () async {
-    final transformer =
-        new SwitchMapStreamTransformer<int, int>(_getOtherStream);
+    final transformer = SwitchMapStreamTransformer<int, int>(_getOtherStream);
     const expectedOutput = [5, 6, 7, 8];
     var countA = 0, countB = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[countA++]);
         }, count: expectedOutput.length));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[countB++]);
@@ -66,8 +65,8 @@ void main() {
   });
 
   test('rx.Observable.switchMap.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
-        .switchMap(_getOtherStream);
+    final stream =
+        Observable(_getStream().asBroadcastStream()).switchMap(_getOtherStream);
 
     // listen twice on same stream
     stream.listen(null);
@@ -78,8 +77,7 @@ void main() {
 
   test('rx.Observable.switchMap.error.shouldThrowA', () async {
     final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .switchMap(_getOtherStream);
+        Observable(ErrorStream<int>(Exception())).switchMap(_getOtherStream);
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -88,8 +86,8 @@ void main() {
   });
 
   test('rx.Observable.switchMap.error.shouldThrowB', () async {
-    final observableWithError = new Observable.just(1).switchMap(
-        (_) => new ErrorStream<void>(new Exception('Catch me if you can!')));
+    final observableWithError = Observable.just(1)
+        .switchMap((_) => ErrorStream<void>(Exception('Catch me if you can!')));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -98,8 +96,8 @@ void main() {
   });
 
   test('rx.Observable.switchMap.error.shouldThrowC', () async {
-    final observableWithError = new Observable.just(1).switchMap<void>((_) {
-      throw new Exception('oh noes!');
+    final observableWithError = Observable.just(1).switchMap<void>((_) {
+      throw Exception('oh noes!');
     });
 
     observableWithError.listen(null,
@@ -110,8 +108,7 @@ void main() {
 
   test('rx.Observable.switchMap.pause.resume', () async {
     StreamSubscription<int> subscription;
-    final stream =
-        new Observable.just(0).switchMap((_) => new Observable.just(1));
+    final stream = Observable.just(0).switchMap((_) => Observable.just(1));
 
     subscription = stream.listen(expectAsync1((value) {
       expect(value, 1);

--- a/test/transformers/take_until_test.dart
+++ b/test/transformers/take_until_test.dart
@@ -4,12 +4,12 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 Stream<int> _getStream() {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(const Duration(milliseconds: 100), () => controller.add(1));
-  new Timer(const Duration(milliseconds: 200), () => controller.add(2));
-  new Timer(const Duration(milliseconds: 300), () => controller.add(3));
-  new Timer(const Duration(milliseconds: 400), () {
+  Timer(const Duration(milliseconds: 100), () => controller.add(1));
+  Timer(const Duration(milliseconds: 200), () => controller.add(2));
+  Timer(const Duration(milliseconds: 300), () => controller.add(3));
+  Timer(const Duration(milliseconds: 400), () {
     controller.add(4);
     controller.close();
   });
@@ -18,9 +18,9 @@ Stream<int> _getStream() {
 }
 
 Stream<int> _getOtherStream() {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(const Duration(milliseconds: 250), () {
+  Timer(const Duration(milliseconds: 250), () {
     controller.add(1);
     controller.close();
   });
@@ -33,7 +33,7 @@ void main() {
     const expectedOutput = [1, 2];
     var count = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .takeUntil(_getOtherStream())
         .listen(expectAsync1((result) {
           expect(expectedOutput[count++], result);
@@ -41,24 +41,24 @@ void main() {
   });
 
   test('rx.Observable.takeUntil.shouldClose', () async {
-    new Observable(_getStream())
-        .takeUntil(new Stream<void>.empty())
+    Observable(_getStream())
+        .takeUntil(Stream<void>.empty())
         .listen(null, onDone: expectAsync0(() => expect(true, isTrue)));
   });
 
   test('rx.Observable.takeUntil.reusable', () async {
-    final transformer = new TakeUntilStreamTransformer<int, int>(
+    final transformer = TakeUntilStreamTransformer<int, int>(
         _getOtherStream().asBroadcastStream());
     const expectedOutput = [1, 2];
     var countA = 0, countB = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(expectedOutput[countA++], result);
         }, count: expectedOutput.length));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(expectedOutput[countB++], result);
@@ -66,7 +66,7 @@ void main() {
   });
 
   test('rx.Observable.takeUntil.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
+    final stream = Observable(_getStream().asBroadcastStream())
         .takeUntil(_getOtherStream().asBroadcastStream());
 
     // listen twice on same stream
@@ -78,8 +78,7 @@ void main() {
 
   test('rx.Observable.takeUntil.error.shouldThrowA', () async {
     final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .takeUntil(_getOtherStream());
+        Observable(ErrorStream<void>(Exception())).takeUntil(_getOtherStream());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -88,8 +87,7 @@ void main() {
   });
 
   test('rx.Observable.takeUntil.error.shouldThrowB', () {
-    expect(() => new Observable.just(1).takeUntil<void>(null),
-        throwsArgumentError);
+    expect(() => Observable.just(1).takeUntil<void>(null), throwsArgumentError);
   });
 
   test('rx.Observable.takeUntil.pause.resume', () async {
@@ -97,7 +95,7 @@ void main() {
     const expectedOutput = [1, 2];
     var count = 0;
 
-    subscription = new Observable(_getStream())
+    subscription = Observable(_getStream())
         .takeUntil(_getOtherStream())
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[count++]);

--- a/test/transformers/take_while_test.dart
+++ b/test/transformers/take_while_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.takeWhile', () async {
-    Stream<int> observable = new Observable<int>.fromIterable(<int>[1, 2, 3])
+    Stream<int> observable = Observable<int>.fromIterable(<int>[1, 2, 3])
         .takeWhile((int value) => value < 2);
 
     observable.listen(expectAsync1((int actual) {

--- a/test/transformers/throttle_test.dart
+++ b/test/transformers/throttle_test.dart
@@ -4,12 +4,12 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 Stream<int> _getStream() {
-  final controller = new StreamController<int>();
+  final controller = StreamController<int>();
 
-  new Timer(const Duration(milliseconds: 100), () => controller.add(1));
-  new Timer(const Duration(milliseconds: 200), () => controller.add(2));
-  new Timer(const Duration(milliseconds: 300), () => controller.add(3));
-  new Timer(const Duration(milliseconds: 400), () {
+  Timer(const Duration(milliseconds: 100), () => controller.add(1));
+  Timer(const Duration(milliseconds: 200), () => controller.add(2));
+  Timer(const Duration(milliseconds: 300), () => controller.add(3));
+  Timer(const Duration(milliseconds: 400), () {
     controller.add(4);
     controller.close();
   });
@@ -22,7 +22,7 @@ void main() {
     const expectedOutput = [1, 4];
     var count = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .throttle(const Duration(milliseconds: 250))
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[count++]);
@@ -31,17 +31,17 @@ void main() {
 
   test('rx.Observable.throttle.reusable', () async {
     final transformer =
-        new ThrottleStreamTransformer<int>(const Duration(milliseconds: 250));
-    const expectedOutput = const [1, 4];
+        ThrottleStreamTransformer<int>(const Duration(milliseconds: 250));
+    const expectedOutput = [1, 4];
     var countA = 0, countB = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[countA++]);
         }, count: 2));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[countB++]);
@@ -49,7 +49,7 @@ void main() {
   });
 
   test('rx.Observable.throttle.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
+    final stream = Observable(_getStream().asBroadcastStream())
         .throttle(const Duration(milliseconds: 200));
 
     // listen twice on same stream
@@ -60,9 +60,8 @@ void main() {
   });
 
   test('rx.Observable.throttle.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .throttle(const Duration(milliseconds: 200));
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .throttle(const Duration(milliseconds: 200));
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -71,21 +70,21 @@ void main() {
   });
 
   test('rx.Observable.throttle.error.shouldThrowB', () {
-    expect(() => new Observable.just(1).throttle(null), throwsArgumentError);
+    expect(() => Observable.just(1).throttle(null), throwsArgumentError);
   });
 
   test('rx.Observable.throttle.error.shouldThrowC', () async {
     runZoned(() {
       final observable =
-          new Observable.just(1).throttle(const Duration(milliseconds: 200));
+          Observable.just(1).throttle(const Duration(milliseconds: 200));
 
       observable.listen(null,
           onError: expectAsync2(
               (Exception e, StackTrace s) => expect(e, isException)));
     },
-        zoneSpecification: new ZoneSpecification(
+        zoneSpecification: ZoneSpecification(
             createTimer: (self, parent, zone, duration, void f()) =>
-                throw new Exception('Zone createTimer error')));
+                throw Exception('Zone createTimer error')));
   });
 
   test('rx.Observable.throttle.pause.resume', () async {
@@ -93,7 +92,7 @@ void main() {
     const expectedOutput = [1, 4];
     var count = 0;
 
-    subscription = new Observable(_getStream())
+    subscription = Observable(_getStream())
         .throttle(const Duration(milliseconds: 250))
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[count++]);

--- a/test/transformers/time_interval_test.dart
+++ b/test/transformers/time_interval_test.dart
@@ -3,14 +3,14 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Stream<int> _getStream() => new Stream<int>.fromIterable(<int>[0, 1, 2]);
+Stream<int> _getStream() => Stream<int>.fromIterable(<int>[0, 1, 2]);
 
 void main() {
   test('rx.Observable.timeInterval', () async {
     const expectedOutput = [0, 1, 2];
     var count = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .interval(const Duration(milliseconds: 1))
         .timeInterval()
         .listen(expectAsync1((result) {
@@ -22,11 +22,11 @@ void main() {
   });
 
   test('rx.Observable.timeInterval.reusable', () async {
-    final transformer = new TimeIntervalStreamTransformer<int>();
+    final transformer = TimeIntervalStreamTransformer<int>();
     const expectedOutput = [0, 1, 2];
     var countA = 0, countB = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .interval(const Duration(milliseconds: 1))
         .transform(transformer)
         .listen(expectAsync1((result) {
@@ -36,7 +36,7 @@ void main() {
               result.interval.inMicroseconds >= 1000 /* microseconds! */, true);
         }, count: expectedOutput.length));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .interval(const Duration(milliseconds: 1))
         .transform(transformer)
         .listen(expectAsync1((result) {
@@ -48,7 +48,7 @@ void main() {
   });
 
   test('rx.Observable.timeInterval.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
+    final stream = Observable(_getStream().asBroadcastStream())
         .interval(const Duration(milliseconds: 1))
         .timeInterval();
 
@@ -60,10 +60,9 @@ void main() {
   });
 
   test('rx.Observable.timeInterval.error.shouldThrow', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .interval(const Duration(milliseconds: 1))
-            .timeInterval();
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .interval(const Duration(milliseconds: 1))
+        .timeInterval();
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -76,7 +75,7 @@ void main() {
     const expectedOutput = [0, 1, 2];
     var count = 0;
 
-    subscription = new Observable(_getStream())
+    subscription = Observable(_getStream())
         .interval(const Duration(milliseconds: 1))
         .timeInterval()
         .listen(expectAsync1((result) {

--- a/test/transformers/timeout_test.dart
+++ b/test/transformers/timeout_test.dart
@@ -7,9 +7,9 @@ void main() {
   test('rx.Observable.timeout', () async {
     StreamSubscription<int> subscription;
 
-    Stream<int> observable = new Observable<int>.fromFuture(
-            new Future<int>.delayed(new Duration(milliseconds: 30), () => 1))
-        .timeout(new Duration(milliseconds: 1));
+    Stream<int> observable = Observable<int>.fromFuture(
+            Future<int>.delayed(Duration(milliseconds: 30), () => 1))
+        .timeout(Duration(milliseconds: 1));
 
     subscription = observable.listen((_) {},
         onError: expectAsync2((TimeoutException e, StackTrace s) {

--- a/test/transformers/timestamp_test.dart
+++ b/test/transformers/timestamp_test.dart
@@ -8,7 +8,7 @@ void main() {
     const expected = [1, 2, 3];
     var count = 0;
 
-    new Observable(new Stream.fromIterable(const [1, 2, 3]))
+    Observable(Stream.fromIterable(const [1, 2, 3]))
         .timestamp()
         .listen(expectAsync1((result) {
           expect(result.value, expected[count++]);
@@ -16,17 +16,17 @@ void main() {
   });
 
   test('Rx.Observable.timestamp.reusable', () async {
-    final transformer = new TimestampStreamTransformer<int>();
+    final transformer = TimestampStreamTransformer<int>();
     const expected = [1, 2, 3];
     var countA = 0, countB = 0;
 
-    new Observable(new Stream.fromIterable(const [1, 2, 3]))
+    Observable(Stream.fromIterable(const [1, 2, 3]))
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result.value, expected[countA++]);
         }, count: expected.length));
 
-    new Observable(new Stream.fromIterable(const [1, 2, 3]))
+    Observable(Stream.fromIterable(const [1, 2, 3]))
         .transform(transformer)
         .listen(expectAsync1((result) {
           expect(result.value, expected[countB++]);
@@ -37,16 +37,16 @@ void main() {
     const expected = [1, 2, 3];
     var count = 0;
 
-    new Stream.fromIterable(const [1, 2, 3])
-        .transform(new TimestampStreamTransformer<int>())
+    Stream.fromIterable(const [1, 2, 3])
+        .transform(TimestampStreamTransformer<int>())
         .listen(expectAsync1((result) {
           expect(result.value, expected[count++]);
         }, count: expected.length));
   });
 
   test('timestampTransformer.asBroadcastStream', () async {
-    final stream = new Stream.fromIterable(const [1, 2, 3])
-        .transform(new TimestampStreamTransformer<int>())
+    final stream = Stream.fromIterable(const [1, 2, 3])
+        .transform(TimestampStreamTransformer<int>())
         .asBroadcastStream();
 
     // listen twice on same stream
@@ -57,8 +57,8 @@ void main() {
   });
 
   test('timestampTransformer.error.shouldThrow', () async {
-    final streamWithError = new ErrorStream<int>(new Exception())
-        .transform(new TimestampStreamTransformer());
+    final streamWithError =
+        ErrorStream<int>(Exception()).transform(TimestampStreamTransformer());
 
     streamWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -67,8 +67,8 @@ void main() {
   });
 
   test('timestampTransformer.pause.resume', () async {
-    final stream = new Stream.fromIterable(const [1, 2, 3])
-        .transform(new TimestampStreamTransformer());
+    final stream = Stream.fromIterable(const [1, 2, 3])
+        .transform(TimestampStreamTransformer());
     const expected = [1, 2, 3];
     StreamSubscription<Timestamped<int>> subscription;
     var count = 0;

--- a/test/transformers/to_list_test.dart
+++ b/test/transformers/to_list_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.toList', () async {
-    final actual = await new Observable.fromIterable(const [1, 2, 3]).toList();
+    final actual = await Observable.fromIterable(const [1, 2, 3]).toList();
     const expected = [1, 2, 3];
 
     await expectLater(actual, expected);

--- a/test/transformers/to_set_test.dart
+++ b/test/transformers/to_set_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.toSet', () async {
-    final actual = await new Observable.fromIterable(const [1, 2, 2]).toSet();
+    final actual = await Observable.fromIterable(const [1, 2, 2]).toSet();
     final expected = const [1, 2].toSet();
 
     await expectLater(actual, expected);

--- a/test/transformers/transform_test.dart
+++ b/test/transformers/transform_test.dart
@@ -5,8 +5,8 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.transform', () async {
-    final observable = new Observable.fromIterable(const [1, 2])
-        .transform(new TestStreamTransformer());
+    final observable = Observable.fromIterable(const [1, 2])
+        .transform(TestStreamTransformer());
 
     observable.listen(expectAsync1((val) {
       expect(val, "Hi");
@@ -17,7 +17,7 @@ void main() {
 class TestStreamTransformer extends StreamTransformerBase<int, String> {
   @override
   Stream<String> bind(Stream<int> stream) {
-    final controller = new StreamController<String>();
+    final controller = StreamController<String>();
 
     stream.listen((_) => controller.add("Hi"), onDone: controller.close);
 

--- a/test/transformers/where_test.dart
+++ b/test/transformers/where_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.where', () async {
-    Stream<int> observable = new Observable<int>.fromIterable(<int>[1, 2, 3])
+    Stream<int> observable = Observable<int>.fromIterable(<int>[1, 2, 3])
         .where((int value) => value < 2);
 
     observable.listen(expectAsync1((int actual) {

--- a/test/transformers/window_count_test.dart
+++ b/test/transformers/window_count_test.dart
@@ -143,14 +143,14 @@ void main() {
   });
 
   test('rx.Observable.windowCount.reusable', () async {
-    final transformer = new WindowStreamTransformer<int>(onCount(2));
+    final transformer = WindowStreamTransformer<int>(onCount(2));
     const expectedOutput = [
       [1, 2],
       [3, 4]
     ];
     var countA = 0, countB = 0;
 
-    final streamA = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final streamA = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer)
         .asyncMap((s) => s.toList());
 
@@ -161,7 +161,7 @@ void main() {
       countA++;
     }, count: expectedOutput.length));
 
-    final streamB = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final streamB = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer)
         .asyncMap((s) => s.toList());
 
@@ -174,7 +174,7 @@ void main() {
   });
 
   test('rx.Observable.windowCount.asBroadcastStream', () async {
-    final stream = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final stream = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .windowCount(2)
         .asyncMap((s) => s.toList())
         .asBroadcastStream();
@@ -187,7 +187,7 @@ void main() {
   });
 
   test('rx.Observable.windowCount.asBroadcastStream.asWindow', () async {
-    final stream = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final stream = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .window(onCount(2))
         .asyncMap((s) => s.toList())
         .asBroadcastStream();
@@ -200,10 +200,9 @@ void main() {
   });
 
   test('rx.Observable.windowCount.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .windowCount(2)
-            .asyncMap((s) => s.toList());
+    final observableWithError = Observable(ErrorStream<int>(Exception()))
+        .windowCount(2)
+        .asyncMap((s) => s.toList());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -212,10 +211,9 @@ void main() {
   });
 
   test('rx.Observable.windowCount.error.shouldThrowA.asWindow', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .window(onCount(2))
-            .asyncMap((s) => s.toList());
+    final observableWithError = Observable(ErrorStream<int>(Exception()))
+        .window(onCount(2))
+        .asyncMap((s) => s.toList());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -224,7 +222,7 @@ void main() {
   });
 
   test('rx.Observable.windowCount.shouldThrow.invalidCount.negative', () {
-    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+    Observable<int>.fromIterable(const [1, 2, 3, 4])
         .windowCount(-1)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -232,7 +230,7 @@ void main() {
   });
 
   test('rx.Observable.windowCount.shouldThrow.invalidCount.isNull', () {
-    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+    Observable<int>.fromIterable(const [1, 2, 3, 4])
         .windowCount(null)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -241,7 +239,7 @@ void main() {
 
   test('rx.Observable.windowCount.shouldThrow.invalidCount.negative.asBuffer',
       () {
-    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+    Observable<int>.fromIterable(const [1, 2, 3, 4])
         .window(onCount(-1))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -250,7 +248,7 @@ void main() {
 
   test('rx.Observable.windowCount.shouldThrow.invalidCount.isNull.asBuffer',
       () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .window(onCount(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -260,7 +258,7 @@ void main() {
   test(
       'rx.Observable.windowCount.startBufferEvery.shouldThrow.invalidStartBufferEvery',
       () {
-    new Observable<int>.fromIterable(const [1, 2, 3, 4])
+    Observable<int>.fromIterable(const [1, 2, 3, 4])
         .windowCount(2, -1)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);

--- a/test/transformers/window_future_test.dart
+++ b/test/transformers/window_future_test.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Observable<int> getStream(int n) => new Observable<int>((int n) async* {
+Observable<int> getStream(int n) => Observable<int>((int n) async* {
       var k = 0;
 
       while (k < n) {
-        await new Future<Null>.delayed(const Duration(milliseconds: 100));
+        await Future<Null>.delayed(const Duration(milliseconds: 100));
 
         yield k++;
       }
@@ -23,7 +23,7 @@ void main() {
 
     getStream(4)
         .windowFuture(
-            () => new Future<Null>.delayed(const Duration(milliseconds: 220)))
+            () => Future<Null>.delayed(const Duration(milliseconds: 220)))
         .asyncMap((s) => s.toList())
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
@@ -40,7 +40,7 @@ void main() {
 
     getStream(4)
         .window(onFuture(
-            () => new Future<Null>.delayed(const Duration(milliseconds: 220))))
+            () => Future<Null>.delayed(const Duration(milliseconds: 220))))
         .asyncMap((s) => s.toList())
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
@@ -50,11 +50,10 @@ void main() {
 
   test('rx.Observable.windowFuture.shouldClose', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
-        .windowFuture(
-            () => new Future<Null>.delayed(const Duration(seconds: 3)))
+    Observable(controller.stream)
+        .windowFuture(() => Future<Null>.delayed(const Duration(seconds: 3)))
         .asyncMap((s) => s.toList())
         .listen(
             expectAsync1((result) => expect(result, expectedOutput), count: 1),
@@ -70,11 +69,11 @@ void main() {
 
   test('rx.Observable.windowFuture.shouldClose.asWindow', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
-        .window(onFuture(
-            () => new Future<Null>.delayed(const Duration(seconds: 3))))
+    Observable(controller.stream)
+        .window(
+            onFuture(() => Future<Null>.delayed(const Duration(seconds: 3))))
         .asyncMap((s) => s.toList())
         .listen(
             expectAsync1((result) => expect(result, expectedOutput), count: 1),
@@ -89,8 +88,8 @@ void main() {
   });
 
   test('rx.Observable.windowFuture.reusable', () async {
-    final transformer = new WindowStreamTransformer<int>(onFuture(
-        () => new Future<Null>.delayed(const Duration(milliseconds: 220))));
+    final transformer = WindowStreamTransformer<int>(onFuture(
+        () => Future<Null>.delayed(const Duration(milliseconds: 220))));
     const expectedOutput = [
       [0, 1],
       [2, 3]
@@ -117,7 +116,7 @@ void main() {
   test('rx.Observable.windowFuture.asBroadcastStream', () async {
     final stream = getStream(4)
         .windowFuture(
-            () => new Future<Null>.delayed(const Duration(milliseconds: 220)))
+            () => Future<Null>.delayed(const Duration(milliseconds: 220)))
         .asyncMap((s) => s.toList())
         .asBroadcastStream();
 
@@ -131,7 +130,7 @@ void main() {
   test('rx.Observable.windowFuture.asBroadcastStream.asWindow', () async {
     final stream = getStream(4)
         .window(onFuture(
-            () => new Future<Null>.delayed(const Duration(milliseconds: 220))))
+            () => Future<Null>.delayed(const Duration(milliseconds: 220))))
         .asyncMap((s) => s.toList())
         .asBroadcastStream();
 
@@ -143,11 +142,10 @@ void main() {
   });
 
   test('rx.Observable.windowFuture.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<Null>(new Exception()))
-            .windowFuture(() =>
-                new Future<Null>.delayed(const Duration(milliseconds: 220)))
-            .asyncMap((s) => s.toList());
+    final observableWithError = Observable(ErrorStream<Null>(Exception()))
+        .windowFuture(
+            () => Future<Null>.delayed(const Duration(milliseconds: 220)))
+        .asyncMap((s) => s.toList());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -156,11 +154,10 @@ void main() {
   });
 
   test('rx.Observable.windowFuture.error.shouldThrowA.asWindow', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<Null>(new Exception()))
-            .window(onFuture(() =>
-                new Future<Null>.delayed(const Duration(milliseconds: 220))))
-            .asyncMap((s) => s.toList());
+    final observableWithError = Observable(ErrorStream<Null>(Exception()))
+        .window(onFuture(
+            () => Future<Null>.delayed(const Duration(milliseconds: 220))))
+        .asyncMap((s) => s.toList());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -169,7 +166,7 @@ void main() {
   });
 
   test('rx.Observable.windowFuture.error.shouldThrowB', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .windowFuture<Null>(null)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -177,7 +174,7 @@ void main() {
   });
 
   test('rx.Observable.windowFuture.error.shouldThrowB.asFuture', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .window(onFuture<int, Stream<int>, void>(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);

--- a/test/transformers/window_test.dart
+++ b/test/transformers/window_test.dart
@@ -5,8 +5,8 @@ import 'package:test/test.dart';
 /// using [onCount], [onFuture], [onTest], [onTime], [onStream]
 void main() {
   test('rx.Observable.window.onNull.shouldThrow', () {
-    new Observable<int>.fromIterable(<int>[1, 2, 3, 4]).window(null).listen(
-        null, onError: expectAsync2((NoSuchMethodError e, StackTrace s) {
+    Observable<int>.fromIterable(<int>[1, 2, 3, 4]).window(null).listen(null,
+        onError: expectAsync2((NoSuchMethodError e, StackTrace s) {
       expect(e, isNoSuchMethodError);
     }));
   });

--- a/test/transformers/window_test_test.dart
+++ b/test/transformers/window_test_test.dart
@@ -43,15 +43,14 @@ void main() {
   });
 
   test('rx.Observable.windowTest.reusable', () async {
-    final transformer =
-        new WindowStreamTransformer<int>(onTest((i) => i % 2 == 0));
-    const expectedOutput = const [
+    final transformer = WindowStreamTransformer<int>(onTest((i) => i % 2 == 0));
+    const expectedOutput = [
       [1, 2],
       [3, 4]
     ];
     var countA = 0, countB = 0;
 
-    final streamA = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final streamA = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer)
         .asyncMap((s) => s.toList());
 
@@ -62,7 +61,7 @@ void main() {
       countA++;
     }, count: 2));
 
-    final streamB = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final streamB = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .transform(transformer)
         .asyncMap((s) => s.toList());
 
@@ -75,7 +74,7 @@ void main() {
   });
 
   test('rx.Observable.windowTest.asBroadcastStream', () async {
-    final stream = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final stream = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .windowTest((i) => i % 2 == 0)
         .asyncMap((s) => s.toList())
         .asBroadcastStream();
@@ -88,7 +87,7 @@ void main() {
   });
 
   test('rx.Observable.windowTest.asBroadcastStream.asWindow', () async {
-    final stream = new Observable(new Stream.fromIterable(const [1, 2, 3, 4]))
+    final stream = Observable(Stream.fromIterable(const [1, 2, 3, 4]))
         .window(onTest((i) => i % 2 == 0))
         .asyncMap((s) => s.toList())
         .asBroadcastStream();
@@ -101,10 +100,9 @@ void main() {
   });
 
   test('rx.Observable.windowTest.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .windowTest((i) => i % 2 == 0)
-            .asyncMap((s) => s.toList());
+    final observableWithError = Observable(ErrorStream<int>(Exception()))
+        .windowTest((i) => i % 2 == 0)
+        .asyncMap((s) => s.toList());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -113,10 +111,9 @@ void main() {
   });
 
   test('rx.Observable.windowTest.error.shouldThrowA.asWindow', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .window(onTest((i) => i % 2 == 0))
-            .asyncMap((s) => s.toList());
+    final observableWithError = Observable(ErrorStream<int>(Exception()))
+        .window(onTest((i) => i % 2 == 0))
+        .asyncMap((s) => s.toList());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -125,15 +122,14 @@ void main() {
   });
 
   test('rx.Observable.windowTest.skip.shouldThrowB', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
-        .windowTest(null)
-        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
+    Observable.fromIterable(const [1, 2, 3, 4]).windowTest(null).listen(null,
+        onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
     }));
   });
 
   test('rx.Observable.windowTest.skip.shouldThrowB.asWindow', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .window(onTest(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);

--- a/test/transformers/window_time_test.dart
+++ b/test/transformers/window_time_test.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Observable<int> getStream(int n) => new Observable<int>((int n) async* {
+Observable<int> getStream(int n) => Observable<int>((int n) async* {
       var k = 0;
 
       while (k < n) {
-        await new Future<Null>.delayed(const Duration(milliseconds: 100));
+        await Future<Null>.delayed(const Duration(milliseconds: 100));
 
         yield k++;
       }
@@ -48,9 +48,9 @@ void main() {
 
   test('rx.Observable.windowTime.shouldClose', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
+    Observable(controller.stream)
         .windowTime(const Duration(seconds: 3))
         .asyncMap((s) => s.toList())
         .listen(expectAsync1((result) {
@@ -68,9 +68,9 @@ void main() {
 
   test('rx.Observable.windowTime.shouldClose.asWindow', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
+    Observable(controller.stream)
         .window(onTime(const Duration(seconds: 3)))
         .asyncMap((s) => s.toList())
         .listen(expectAsync1((result) {
@@ -87,8 +87,8 @@ void main() {
   });
 
   test('rx.Observable.windowTime.reusable', () async {
-    final transformer = new WindowStreamTransformer<int>(
-        onTime(const Duration(milliseconds: 220)));
+    final transformer =
+        WindowStreamTransformer<int>(onTime(const Duration(milliseconds: 220)));
     const expectedOutput = [
       [0, 1],
       [2, 3]
@@ -139,10 +139,9 @@ void main() {
   });
 
   test('rx.Observable.windowTime.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .windowTime(const Duration(milliseconds: 220))
-            .asyncMap((s) => s.toList());
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .windowTime(const Duration(milliseconds: 220))
+        .asyncMap((s) => s.toList());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -151,10 +150,9 @@ void main() {
   });
 
   test('rx.Observable.windowTime.error.shouldThrowA.asWindow', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<void>(new Exception()))
-            .window(onTime(const Duration(milliseconds: 220)))
-            .asyncMap((s) => s.toList());
+    final observableWithError = Observable(ErrorStream<void>(Exception()))
+        .window(onTime(const Duration(milliseconds: 220)))
+        .asyncMap((s) => s.toList());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -163,15 +161,14 @@ void main() {
   });
 
   test('rx.Observable.windowTime.error.shouldThrowB', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
-        .windowTime(null)
-        .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
+    Observable.fromIterable(const [1, 2, 3, 4]).windowTime(null).listen(null,
+        onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
     }));
   });
 
   test('rx.Observable.windowTime.error.shouldThrowB.asWindow', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .window(onTime(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);

--- a/test/transformers/window_when_test.dart
+++ b/test/transformers/window_when_test.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-Observable<int> getStream(int n) => new Observable<int>((int n) async* {
+Observable<int> getStream(int n) => Observable<int>((int n) async* {
       var k = 0;
 
       while (k < n) {
-        await new Future<Null>.delayed(const Duration(milliseconds: 100));
+        await Future<Null>.delayed(const Duration(milliseconds: 100));
 
         yield k++;
       }
@@ -22,8 +22,7 @@ void main() {
     var count = 0;
 
     getStream(4)
-        .windowWhen(
-            new Stream<Null>.periodic(const Duration(milliseconds: 220)))
+        .windowWhen(Stream<Null>.periodic(const Duration(milliseconds: 220)))
         .asyncMap((s) => s.toList())
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
@@ -39,8 +38,8 @@ void main() {
     var count = 0;
 
     getStream(4)
-        .window(onStream(
-            new Stream<Null>.periodic(const Duration(milliseconds: 220))))
+        .window(
+            onStream(Stream<Null>.periodic(const Duration(milliseconds: 220))))
         .asyncMap((s) => s.toList())
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
@@ -59,11 +58,11 @@ void main() {
     ];
     var count = 0;
 
-    new Observable<String>.fromFuture(
-            new Future<Null>.delayed(const Duration(milliseconds: 200))
+    Observable<String>.fromFuture(
+            Future<Null>.delayed(const Duration(milliseconds: 200))
                 .then((_) => 'done'))
-        .window(onStream(
-            new Stream<Null>.periodic(const Duration(milliseconds: 40))))
+        .window(
+            onStream(Stream<Null>.periodic(const Duration(milliseconds: 40))))
         .asyncMap((s) => s.toList())
         .listen(expectAsync1((result) {
           // test to see if the combined output matches
@@ -73,10 +72,10 @@ void main() {
 
   test('rx.Observable.windowWhen.shouldClose', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
-        .windowWhen(new Stream<Null>.periodic(const Duration(seconds: 3)))
+    Observable(controller.stream)
+        .windowWhen(Stream<Null>.periodic(const Duration(seconds: 3)))
         .asyncMap((s) => s.toList())
         .listen(
             expectAsync1((result) => expect(result, expectedOutput), count: 1),
@@ -92,10 +91,10 @@ void main() {
 
   test('rx.Observable.windowWhen.shouldClose.asWindow', () async {
     const expectedOutput = [0, 1, 2, 3];
-    final controller = new StreamController<int>();
+    final controller = StreamController<int>();
 
-    new Observable(controller.stream)
-        .window(onStream(new Stream<Null>.periodic(const Duration(seconds: 3))))
+    Observable(controller.stream)
+        .window(onStream(Stream<Null>.periodic(const Duration(seconds: 3))))
         .asyncMap((s) => s.toList())
         .listen(
             expectAsync1((result) => expect(result, expectedOutput), count: 1),
@@ -110,8 +109,8 @@ void main() {
   }, skip: 'todo: investigate why this test makes the process hang');
 
   test('rx.Observable.windowWhen.reusable', () async {
-    final transformer = new WindowStreamTransformer<int>(onStream(
-        new Stream<Null>.periodic(const Duration(milliseconds: 220))
+    final transformer = WindowStreamTransformer<int>(onStream(
+        Stream<Null>.periodic(const Duration(milliseconds: 220))
             .asBroadcastStream()));
     const expectedOutput = [
       [0, 1],
@@ -138,8 +137,7 @@ void main() {
 
   test('rx.Observable.windowWhen.asBroadcastStream', () async {
     final stream = getStream(4)
-        .windowWhen(
-            new Stream<Null>.periodic(const Duration(milliseconds: 220)))
+        .windowWhen(Stream<Null>.periodic(const Duration(milliseconds: 220)))
         .asyncMap((s) => s.toList())
         .asBroadcastStream();
 
@@ -152,8 +150,8 @@ void main() {
 
   test('rx.Observable.windowWhen.asBroadcastStream.asWindow', () async {
     final stream = getStream(4)
-        .window(onStream(
-            new Stream<Null>.periodic(const Duration(milliseconds: 220))))
+        .window(
+            onStream(Stream<Null>.periodic(const Duration(milliseconds: 220))))
         .asyncMap((s) => s.toList())
         .asBroadcastStream();
 
@@ -165,11 +163,9 @@ void main() {
   }, skip: 'todo: investigate why this test makes the process hang');
 
   test('rx.Observable.windowWhen.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .windowWhen(
-                new Stream<Null>.periodic(const Duration(milliseconds: 220)))
-            .asyncMap((s) => s.toList());
+    final observableWithError = Observable(ErrorStream<int>(Exception()))
+        .windowWhen(Stream<Null>.periodic(const Duration(milliseconds: 220)))
+        .asyncMap((s) => s.toList());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -178,11 +174,10 @@ void main() {
   });
 
   test('rx.Observable.windowWhen.error.shouldThrowA.asWindow', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception()))
-            .window(onStream(
-                new Stream<Null>.periodic(const Duration(milliseconds: 220))))
-            .asyncMap((s) => s.toList());
+    final observableWithError = Observable(ErrorStream<int>(Exception()))
+        .window(
+            onStream(Stream<Null>.periodic(const Duration(milliseconds: 220))))
+        .asyncMap((s) => s.toList());
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -191,7 +186,7 @@ void main() {
   });
 
   test('rx.Observable.windowWhen.error.shouldThrowB', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .windowWhen<Null>(null)
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);
@@ -199,7 +194,7 @@ void main() {
   });
 
   test('rx.Observable.windowWhen.error.shouldThrowB.asWindow', () {
-    new Observable.fromIterable(const [1, 2, 3, 4])
+    Observable.fromIterable(const [1, 2, 3, 4])
         .window(onStream<int, Stream<int>, void>(null))
         .listen(null, onError: expectAsync2((ArgumentError e, StackTrace s) {
       expect(e, isArgumentError);

--- a/test/transformers/with_latest_from_test.dart
+++ b/test/transformers/with_latest_from_test.dart
@@ -5,12 +5,10 @@ import 'package:rxdart/src/observables/observable.dart';
 import 'package:test/test.dart';
 
 Stream<int> _getStream() =>
-    new Stream.periodic(const Duration(milliseconds: 22), (count) => count)
-        .take(7);
+    Stream.periodic(const Duration(milliseconds: 22), (count) => count).take(7);
 
 Stream<int> _getLatestFromStream() =>
-    new Stream.periodic(const Duration(milliseconds: 50), (count) => count)
-        .take(4);
+    Stream.periodic(const Duration(milliseconds: 50), (count) => count).take(4);
 
 void main() {
   test('rx.Observable.withLatestFrom', () async {
@@ -23,9 +21,9 @@ void main() {
     ];
     var count = 0;
 
-    new Observable(_getStream())
-        .withLatestFrom(_getLatestFromStream(),
-            (first, int second) => new Pair(first, second))
+    Observable(_getStream())
+        .withLatestFrom(
+            _getLatestFromStream(), (first, int second) => Pair(first, second))
         .take(5)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[count++]);
@@ -33,9 +31,9 @@ void main() {
   });
 
   test('rx.Observable.withLatestFrom.reusable', () async {
-    final transformer = new WithLatestFromStreamTransformer<int, int, Pair>(
+    final transformer = WithLatestFromStreamTransformer<int, int, Pair>(
         _getLatestFromStream().asBroadcastStream(),
-        (first, second) => new Pair(first, second));
+        (first, second) => Pair(first, second));
     const expectedOutput = [
       Pair(2, 0),
       Pair(3, 0),
@@ -45,14 +43,14 @@ void main() {
     ];
     var countA = 0, countB = 0;
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .take(5)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[countA++]);
         }, count: expectedOutput.length));
 
-    new Observable(_getStream())
+    Observable(_getStream())
         .transform(transformer)
         .take(5)
         .listen(expectAsync1((result) {
@@ -61,9 +59,8 @@ void main() {
   });
 
   test('rx.Observable.withLatestFrom.asBroadcastStream', () async {
-    final stream = new Observable(_getStream().asBroadcastStream())
-        .withLatestFrom(_getLatestFromStream().asBroadcastStream(),
-            (first, int second) => 0);
+    final stream = Observable(_getStream().asBroadcastStream()).withLatestFrom(
+        _getLatestFromStream().asBroadcastStream(), (first, int second) => 0);
 
     // listen twice on same stream
     stream.listen(null);
@@ -73,9 +70,8 @@ void main() {
   });
 
   test('rx.Observable.withLatestFrom.error.shouldThrowA', () async {
-    final observableWithError =
-        new Observable(new ErrorStream<int>(new Exception())).withLatestFrom(
-            _getLatestFromStream(), (first, int second) => "Hello");
+    final observableWithError = Observable(ErrorStream<int>(Exception()))
+        .withLatestFrom(_getLatestFromStream(), (first, int second) => "Hello");
 
     observableWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -85,14 +81,14 @@ void main() {
 
   test('rx.Observable.withLatestFrom.error.shouldThrowB', () {
     expect(
-        () => new Observable.just(1)
+        () => Observable.just(1)
             .withLatestFrom(null, (first, int second) => "Hello"),
         throwsArgumentError);
   });
 
   test('rx.Observable.withLatestFrom.error.shouldThrowC', () {
     expect(
-        () => new Observable(_getStream())
+        () => Observable(_getStream())
             .withLatestFrom<int, void>(_getLatestFromStream(), null),
         throwsArgumentError);
   });
@@ -102,9 +98,9 @@ void main() {
     const expectedOutput = [Pair(2, 0)];
     var count = 0;
 
-    subscription = new Observable(_getStream())
-        .withLatestFrom(_getLatestFromStream(),
-            (first, int second) => new Pair(first, second))
+    subscription = Observable(_getStream())
+        .withLatestFrom(
+            _getLatestFromStream(), (first, int second) => Pair(first, second))
         .take(1)
         .listen(expectAsync1((result) {
           expect(result, expectedOutput[count++]);

--- a/test/transformers/zip_with_test.dart
+++ b/test/transformers/zip_with_test.dart
@@ -3,8 +3,8 @@ import 'package:test/test.dart';
 
 void main() {
   test('rx.Observable.zipWith', () async {
-    new Observable<int>(new Observable<int>.just(1))
-        .zipWith(new Observable<int>.just(2), (int one, int two) => one + two)
+    Observable<int>(Observable<int>.just(1))
+        .zipWith(Observable<int>.just(2), (int one, int two) => one + two)
         .listen(expectAsync1((int result) {
           expect(result, 3);
         }, count: 1));


### PR DESCRIPTION
As preparation for the next release on pub, I thought I'd run dartfmt.

I've used the -fix option, which cleans up all usage of `new`/`const`.