### PR TITLE
Purposely add a failing test to ensure we don't need to run tests twice

### DIFF
--- a/test/transformers/start_with_many_test.dart
+++ b/test/transformers/start_with_many_test.dart
@@ -8,7 +8,6 @@ Stream<int> _getStream() => Stream.fromIterable(const [1, 2, 3, 4]);
 void main() {
   test('rx.Observable.startWithMany', () async {
     const expectedOutput = [5, 6, 1, 2, 3, 4];
-    var count = 0;
 
     Observable(_getStream())
         .startWithMany(const [5, 6]).listen(expectAsync1((result) {

--- a/test/transformers/start_with_many_test.dart
+++ b/test/transformers/start_with_many_test.dart
@@ -12,7 +12,7 @@ void main() {
 
     Observable(_getStream())
         .startWithMany(const [5, 6]).listen(expectAsync1((result) {
-      expect(expectedOutput[count++], result);
+      expect(1, result);
     }, count: expectedOutput.length));
   });
 


### PR DESCRIPTION
In the new travis script, I stopped running the tests twice since that's exactly what the coverage team does in their travis setup. I want to ensure that's safe -- if we get a test failure, travis should fail.

Ensure the new travis script is working as expected when a test fails.