### PR TITLE
adds SequenceEqualStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ var myObservable = new Observable(myStream);
 - [repeat](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.repeat.html) / [RepeatStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/RepeatStream-class.html)
 - [retry](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.retry.html) / [RetryStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/RetryStream-class.html)
 - [retryWhen](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.retryWhen.html) / [RetryWhenStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/RetryWhenStream-class.html)
+- [sequenceEqual](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.sequenceEqual.html) / [SequenceEqualStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/SequenceEqualStream-class.html)
 - [switchLatest](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.switchLatest.html) / [SwitchLatestStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/SwitchLatestStream-class.html)
 - [timer](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.timer.html) / [TimerStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/TimerStream-class.html)
 

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -87,7 +87,7 @@ class Observable<T> extends Stream<T> {
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an item.
   /// This is helpful when you need to combine a dynamic number of Streams.
-  /// 
+  ///
   /// The Observable will not emit any lists of values until all of the source
   /// streams have emitted at least one value.
   ///
@@ -679,9 +679,24 @@ class Observable<T> extends Stream<T> {
   /// ); // Prints 0, 1, 2, 0, 1, 2, 3, RetryError
   /// ```
   factory Observable.retryWhen(Stream<T> streamFactory(),
-      Stream<void> retryWhenFactory(dynamic error, StackTrace stack)) {
-    return Observable<T>(RetryWhenStream<T>(streamFactory, retryWhenFactory));
-  }
+          Stream<void> retryWhenFactory(dynamic error, StackTrace stack)) =>
+      Observable<T>(RetryWhenStream<T>(streamFactory, retryWhenFactory));
+
+  /// Determine whether two Observables emit the same sequence of items.
+  /// You can provide an optional [equals] handler to determine equality.
+  ///
+  /// [Interactive marble diagram](https://rxmarbles.com/#sequenceEqual)
+  ///
+  /// ### Example
+  ///
+  ///     Observable.sequenceEqual([
+  ///       Stream.fromIterable([1, 2, 3, 4, 5]),
+  ///       Stream.fromIterable([1, 2, 3, 4, 5])
+  ///     ])
+  ///     .listen(print); // prints true
+  static Observable<bool> sequenceEqual<A, B>(Stream<A> stream, Stream<B> other,
+          {bool equals(A a, B b)}) =>
+      Observable(SequenceEqualStream<A, B>(stream, other, equals: equals));
 
   /// Convert a Stream that emits Streams (aka a "Higher Order Stream") into a
   /// single Observable that emits the items emitted by the

--- a/lib/src/streams/sequence_equal.dart
+++ b/lib/src/streams/sequence_equal.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+import 'package:rxdart/src/streams/zip.dart';
+
+import 'package:rxdart/src/transformers/materialize.dart';
+
+import 'package:rxdart/src/utils/notification.dart';
+
+/// Determine whether two Observables emit the same sequence of items.
+/// You can provide an optional equals handler to determine equality.
+///
+/// [Interactive marble diagram](https://rxmarbles.com/#sequenceEqual)
+///
+/// ### Example
+///
+///     new SequenceEqualsStream([
+///       Stream.fromIterable([1, 2, 3, 4, 5]),
+///       Stream.fromIterable([1, 2, 3, 4, 5])
+///     ])
+///     .listen(print); // prints true
+class SequenceEqualStream<S, T> extends Stream<bool> {
+  final StreamController<bool> controller;
+
+  SequenceEqualStream(Stream<S> stream, Stream<T> other,
+      {bool equals(S s, T t)})
+      : controller = _buildController(stream, other, equals);
+
+  @override
+  StreamSubscription<bool> listen(void onData(bool event),
+          {Function onError, void onDone(), bool cancelOnError}) =>
+      controller.stream.listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+
+  static StreamController<bool> _buildController<S, T>(
+      Stream<S> stream, Stream<T> other, bool equals(S s, T t)) {
+    if (stream == null) {
+      throw ArgumentError.notNull('stream');
+    }
+
+    if (other == null) {
+      throw ArgumentError.notNull('other');
+    }
+
+    final doCompare = equals ?? (S s, T t) => s == t;
+    StreamController<bool> controller;
+    StreamSubscription<bool> subscription;
+
+    controller = StreamController<bool>(
+        sync: true,
+        onListen: () {
+          final emitAndClose = ([bool value = true]) => controller
+            ..add(value)
+            ..close();
+
+          subscription = ZipStream.zip2(
+                  stream.transform(MaterializeStreamTransformer()),
+                  other.transform(MaterializeStreamTransformer()),
+                  (Notification<S> s, Notification<T> t) =>
+                      s.kind == t.kind &&
+                      s.error?.toString() == t.error?.toString() &&
+                      doCompare(s.value, t.value))
+              .where((isEqual) => !isEqual)
+              .listen(emitAndClose,
+                  onError: controller.addError, onDone: emitAndClose);
+        },
+        onPause: ([Future<dynamic> resumeSignal]) =>
+            subscription.pause(resumeSignal),
+        onResume: () => subscription.resume(),
+        onCancel: () => subscription.cancel());
+
+    return controller;
+  }
+}

--- a/lib/streams.dart
+++ b/lib/streams.dart
@@ -12,6 +12,7 @@ export 'package:rxdart/src/streams/range.dart';
 export 'package:rxdart/src/streams/repeat.dart';
 export 'package:rxdart/src/streams/retry.dart';
 export 'package:rxdart/src/streams/retry_when.dart';
+export 'package:rxdart/src/streams/sequence_equal.dart';
 export 'package:rxdart/src/streams/switch_latest.dart';
 export 'package:rxdart/src/streams/timer.dart';
 export 'package:rxdart/src/streams/utils.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -31,6 +31,7 @@ import 'streams/repeat_test.dart' as repeat_test;
 import 'streams/retry_test.dart' as retry_test;
 import 'streams/retry_when_test.dart' as retry_when_test;
 import 'streams/stream_test.dart' as stream_test;
+import 'streams/sequence_equals_test.dart' as sequence_equals_test;
 import 'streams/switch_latest_test.dart' as switch_latest_test;
 import 'streams/timer_test.dart' as timer_test;
 import 'streams/zip_test.dart' as zip_test;
@@ -137,6 +138,7 @@ void main() {
   retry_test.main();
   retry_when_test.main();
   stream_test.main();
+  sequence_equals_test.main();
   switch_latest_test.main();
   zip_test.main();
 

--- a/test/streams/sequence_equals_test.dart
+++ b/test/streams/sequence_equals_test.dart
@@ -12,6 +12,15 @@ void main() {
     await expectLater(observable, emitsInOrder(<dynamic>[true, emitsDone]));
   });
 
+  test('rx.Observable.sequenceEqual.diffTime.equals', () async {
+    final observable = Observable.sequenceEqual(
+        Stream.periodic(const Duration(milliseconds: 100), (i) => i + 1)
+            .take(5),
+        Stream.fromIterable(const [1, 2, 3, 4, 5]));
+
+    await expectLater(observable, emitsInOrder(<dynamic>[true, emitsDone]));
+  });
+
   test('rx.Observable.sequenceEqual.equals.customCompare.equals', () async {
     final observable = Observable.sequenceEqual(
         Stream.fromIterable(const [1, 1, 1, 1, 1]),
@@ -19,6 +28,15 @@ void main() {
         equals: (int a, int b) => true);
 
     await expectLater(observable, emitsInOrder(<dynamic>[true, emitsDone]));
+  });
+
+  test('rx.Observable.sequenceEqual.diffTime.notEquals', () async {
+    final observable = Observable.sequenceEqual(
+        Stream.periodic(const Duration(milliseconds: 100), (i) => i + 1)
+            .take(5),
+        Stream.fromIterable(const [1, 1, 1, 1, 1]));
+
+    await expectLater(observable, emitsInOrder(<dynamic>[false, emitsDone]));
   });
 
   test('rx.Observable.sequenceEqual.notEquals', () async {

--- a/test/streams/sequence_equals_test.dart
+++ b/test/streams/sequence_equals_test.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('rx.Observable.sequenceEqual.equals', () async {
+    final observable = Observable.sequenceEqual(
+        Stream.fromIterable(const [1, 2, 3, 4, 5]),
+        Stream.fromIterable(const [1, 2, 3, 4, 5]));
+
+    await expectLater(observable, emitsInOrder(<dynamic>[true, emitsDone]));
+  });
+
+  test('rx.Observable.sequenceEqual.equals.customCompare.equals', () async {
+    final observable = Observable.sequenceEqual(
+        Stream.fromIterable(const [1, 1, 1, 1, 1]),
+        Stream.fromIterable(const [2, 2, 2, 2, 2]),
+        equals: (int a, int b) => true);
+
+    await expectLater(observable, emitsInOrder(<dynamic>[true, emitsDone]));
+  });
+
+  test('rx.Observable.sequenceEqual.notEquals', () async {
+    final observable = Observable.sequenceEqual(
+        Stream.fromIterable(const [1, 2, 3, 4, 5]),
+        Stream.fromIterable(const [1, 2, 3, 5, 4]));
+
+    await expectLater(observable, emitsInOrder(<dynamic>[false, emitsDone]));
+  });
+
+  test('rx.Observable.sequenceEqual.equals.customCompare.notEquals', () async {
+    final observable = Observable.sequenceEqual(
+        Stream.fromIterable(const [1, 1, 1, 1, 1]),
+        Stream.fromIterable(const [1, 1, 1, 1, 1]),
+        equals: (int a, int b) => false);
+
+    await expectLater(observable, emitsInOrder(<dynamic>[false, emitsDone]));
+  });
+
+  test('rx.Observable.sequenceEqual.notEquals.differentLength', () async {
+    final observable = Observable.sequenceEqual(
+        Stream.fromIterable(const [1, 2, 3, 4, 5]),
+        Stream.fromIterable(const [1, 2, 3, 4, 5, 6]));
+
+    await expectLater(observable, emitsInOrder(<dynamic>[false, emitsDone]));
+  });
+
+  test(
+      'rx.Observable.sequenceEqual.notEquals.differentLength.customCompare.notEquals',
+      () async {
+    final observable = Observable.sequenceEqual(
+        Stream.fromIterable(const [1, 2, 3, 4, 5]),
+        Stream.fromIterable(const [1, 2, 3, 4, 5, 6]),
+        equals: (int a, int b) => true);
+
+    // expect false,
+    // even if the equals handler always returns true,
+    // the emitted events length is different
+    await expectLater(observable, emitsInOrder(<dynamic>[false, emitsDone]));
+  });
+
+  test('rx.Observable.sequenceEqual.equals.errors', () async {
+    final observable = Observable.sequenceEqual(
+        Observable<void>.error(ArgumentError('error A')),
+        Observable<void>.error(ArgumentError('error A')));
+
+    await expectLater(observable, emitsInOrder(<dynamic>[true, emitsDone]));
+  });
+
+  test('rx.Observable.sequenceEqual.notEquals.errors', () async {
+    final observable = Observable.sequenceEqual(
+        Observable<void>.error(ArgumentError('error A')),
+        Observable<void>.error(ArgumentError('error B')));
+
+    await expectLater(observable, emitsInOrder(<dynamic>[false, emitsDone]));
+  });
+
+  test('rx.Observable.sequenceEqual.single.subscription', () async {
+    final observable = Observable.sequenceEqual(
+        Stream.fromIterable(const [1, 2, 3, 4, 5]),
+        Stream.fromIterable(const [1, 2, 3, 4, 5]));
+
+    await expectLater(observable, emitsInOrder(<dynamic>[true, emitsDone]));
+    await expectLater(() => observable.listen(null), throwsA(isStateError));
+  });
+
+  test('rx.Observable.sequenceEqual.asBroadcastStream', () async {
+    final observable = Observable.sequenceEqual(
+            Stream.fromIterable(const [1, 2, 3, 4, 5]),
+            Stream.fromIterable(const [1, 2, 3, 4, 5]))
+        .asBroadcastStream()
+        .ignoreElements();
+
+    // listen twice on same stream
+    await expectLater(observable, emitsDone);
+    await expectLater(observable, emitsDone);
+  });
+
+  test('rx.Observable.sequenceEqual.error.shouldThrowA', () {
+    expect(
+        () => Observable.sequenceEqual<int, void>(
+            Stream.fromIterable(const [1, 2, 3, 4, 5]), null),
+        throwsArgumentError);
+  });
+
+  test('rx.Observable.sequenceEqual.error.shouldThrowB', () {
+    expect(
+        () => Observable.sequenceEqual<void, int>(
+            null, Stream.fromIterable(const [1, 2, 3, 4, 5])),
+        throwsArgumentError);
+  });
+}


### PR DESCRIPTION
Adds a new ctr, `sequenceEqual`.

see: https://rxmarbles.com/#sequenceEqual

Compares two sequences by first `materializing` the input `Stream`'s events, then uses `zip` and an optional `equals` handler to determine equality as events are being emitted.

Using `materialize` allow to compare errors and done events as well.