### PR TITLE
adds forkJoin Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ var myObservable = new Observable.merge([myFirstStream, mySecondStream]);
 
 ##### Available Static Methods
 - [combineLatest](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/combineLatest2.html) / [CombineLatestStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/CombineLatestStream-class.html) (combineLatest2, combineLatest... combineLatest9) 
+- [forkJoin](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/forkJoin2.html) / [ForkJoinStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/ForkJoinStream-class.html) (forkJoin2, forkJoin... forkJoin9) 
 - [range](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/range.html) / [RangeStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/RangeStream-class.html)
 - [tween](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/tween.html) / [TweenStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/TweenStream-class.html)
 - [zip](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/zip2.html) / [ZipStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/ZipStream-class.html) (zip2, zip3, zip4, ..., zip9)

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -87,7 +87,7 @@ class Observable<T> extends Stream<T> {
   /// Merges the given Streams into one Observable sequence by using the
   /// [combiner] function whenever any of the observable sequences emits an item.
   /// This is helpful when you need to combine a dynamic number of Streams.
-  /// 
+  ///
   /// The Observable will not emit any lists of values until all of the source
   /// streams have emitted at least one value.
   ///
@@ -464,6 +464,271 @@ class Observable<T> extends Stream<T> {
   factory Observable.eventTransformed(
           Stream<T> source, EventSink<T> mapSink(EventSink<T> sink)) =>
       Observable<T>((Stream<T>.eventTransformed(source, mapSink)));
+
+  ///  Creates an [Observable] where all last events of existing stream(s) are piped
+  ///  through a sink-transformation.
+  ///
+  /// This operator is best used when you have a group of observables
+  /// and only care about the final emitted value of each.
+  /// One common use case for this is if you wish to issue multiple
+  /// requests on page load (or some other event)
+  /// and only want to take action when a response has been received for all.
+  ///
+  /// In this way it is similar to how you might use [Future].wait.
+  ///
+  /// Be aware that if any of the inner observables supplied to forkJoin error
+  /// you will lose the value of any other observables that would or have already
+  /// completed if you do not catch the error correctly on the inner observable.
+  ///
+  /// If you are only concerned with all inner observables completing
+  /// successfully you can catch the error on the outside.
+  /// It's also worth noting that if you have an observable
+  /// that emits more than one item, and you are concerned with the previous
+  /// emissions forkJoin is not the correct choice.
+  ///
+  /// In these cases you may better off with an operator like combineLatest or zip.
+  ///
+  /// ### Example
+  ///
+  ///    Observable.forkJoin([
+  ///      new Observable.just("a"),
+  ///      new Observable.fromIterable(["b", "c", "d"])
+  ///    ], (list) => list.join(', '))
+  ///    .listen(print); // prints "a, d"
+  static Observable<R> forkJoin<T, R>(
+          Iterable<Stream<T>> streams, R combiner(List<T> values)) =>
+      Observable<R>(ForkJoinStream<T, R>(streams, combiner));
+
+  /// Merges the given Streams into one Observable that emits a List of the
+  /// last values emitted by the source stream(s). This is helpful when you need to
+  /// forkJoin a dynamic number of Streams.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.forkJoinList([
+  ///       Observable.just(1),
+  ///       Observable.fromIterable([0, 1, 2]),
+  ///     ])
+  ///     .listen(print); // prints [1, 2]
+  static Observable<List<T>> forkJoinList<T>(Iterable<Stream<T>> streams) =>
+      Observable<List<T>>(ForkJoinStream.list<T>(streams));
+
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function when all of the observable sequences emits their
+  /// last item.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.forkJoin2(
+  ///       new Observable.just(1),
+  ///       new Observable.fromIterable([0, 1, 2]),
+  ///       (a, b) => a + b)
+  ///     .listen(print); //prints 3
+  static Observable<T> forkJoin2<A, B, T>(
+          Stream<A> streamA, Stream<B> streamB, T combiner(A a, B b)) =>
+      Observable<T>(ForkJoinStream.combine2(streamA, streamB, combiner));
+
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function when all of the observable sequences emits their
+  /// last item.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.forkJoin3(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.fromIterable(["c", "d"]),
+  ///       (a, b, c) => a + b + c)
+  ///     .listen(print); //prints "abd"
+  static Observable<T> forkJoin3<A, B, C, T>(Stream<A> streamA,
+          Stream<B> streamB, Stream<C> streamC, T combiner(A a, B b, C c)) =>
+      Observable<T>(
+          ForkJoinStream.combine3(streamA, streamB, streamC, combiner));
+
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function when all of the observable sequences emits their
+  /// last item.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.forkJoin4(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.fromIterable(["d", "e"]),
+  ///       (a, b, c, d) => a + b + c + d)
+  ///     .listen(print); //prints "abce"
+  static Observable<T> forkJoin4<A, B, C, D, T>(
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          T combiner(A a, B b, C c, D d)) =>
+      Observable<T>(ForkJoinStream.combine4(
+          streamA, streamB, streamC, streamD, combiner));
+
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function when all of the observable sequences emits their
+  /// last item.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.forkJoin5(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.fromIterable(["e", "f"]),
+  ///       (a, b, c, d, e) => a + b + c + d + e)
+  ///     .listen(print); //prints "abcdf"
+  static Observable<T> forkJoin5<A, B, C, D, E, T>(
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          T combiner(A a, B b, C c, D d, E e)) =>
+      Observable<T>(ForkJoinStream.combine5(
+          streamA, streamB, streamC, streamD, streamE, combiner));
+
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function when all of the observable sequences emits their
+  /// last item.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.forkJoin6(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.fromIterable(["f", "g"]),
+  ///       (a, b, c, d, e, f) => a + b + c + d + e + f)
+  ///     .listen(print); //prints "abcdeg"
+  static Observable<T> forkJoin6<A, B, C, D, E, F, T>(
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
+          T combiner(A a, B b, C c, D d, E e, F f)) =>
+      Observable<T>(ForkJoinStream.combine6(
+          streamA, streamB, streamC, streamD, streamE, streamF, combiner));
+
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function when all of the observable sequences emits their
+  /// last item.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.forkJoin7(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.just("f"),
+  ///       new Observable.fromIterable(["g", "h"]),
+  ///       (a, b, c, d, e, f, g) => a + b + c + d + e + f + g)
+  ///     .listen(print); //prints "abcdefh"
+  static Observable<T> forkJoin7<A, B, C, D, E, F, G, T>(
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
+          Stream<G> streamG,
+          T combiner(A a, B b, C c, D d, E e, F f, G g)) =>
+      Observable<T>(ForkJoinStream.combine7(streamA, streamB, streamC, streamD,
+          streamE, streamF, streamG, combiner));
+
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function when all of the observable sequences emits their
+  /// last item.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.forkJoin8(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.just("f"),
+  ///       new Observable.just("g"),
+  ///       new Observable.fromIterable(["h", "i"]),
+  ///       (a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h)
+  ///     .listen(print); //prints "abcdefgi"
+  static Observable<T> forkJoin8<A, B, C, D, E, F, G, H, T>(
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
+          Stream<G> streamG,
+          Stream<H> streamH,
+          T combiner(A a, B b, C c, D d, E e, F f, G g, H h)) =>
+      Observable<T>(
+        ForkJoinStream.combine8(
+          streamA,
+          streamB,
+          streamC,
+          streamD,
+          streamE,
+          streamF,
+          streamG,
+          streamH,
+          combiner,
+        ),
+      );
+
+  /// Merges the given Streams into one Observable sequence by using the
+  /// [combiner] function when all of the observable sequences emits their
+  /// last item.
+  ///
+  /// ### Example
+  ///
+  ///     Observable.forkJoin9(
+  ///       new Observable.just("a"),
+  ///       new Observable.just("b"),
+  ///       new Observable.just("c"),
+  ///       new Observable.just("d"),
+  ///       new Observable.just("e"),
+  ///       new Observable.just("f"),
+  ///       new Observable.just("g"),
+  ///       new Observable.just("h"),
+  ///       new Observable.fromIterable(["i", "j"]),
+  ///       (a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h + i)
+  ///     .listen(print); //prints "abcdefghj"
+  static Observable<T> forkJoin9<A, B, C, D, E, F, G, H, I, T>(
+          Stream<A> streamA,
+          Stream<B> streamB,
+          Stream<C> streamC,
+          Stream<D> streamD,
+          Stream<E> streamE,
+          Stream<F> streamF,
+          Stream<G> streamG,
+          Stream<H> streamH,
+          Stream<I> streamI,
+          T combiner(A a, B b, C c, D d, E e, F f, G g, H h, I i)) =>
+      Observable<T>(
+        ForkJoinStream.combine9(
+          streamA,
+          streamB,
+          streamC,
+          streamD,
+          streamE,
+          streamF,
+          streamG,
+          streamH,
+          streamI,
+          combiner,
+        ),
+      );
 
   /// Creates an Observable from the future.
   ///

--- a/lib/src/streams/fork_join.dart
+++ b/lib/src/streams/fork_join.dart
@@ -1,0 +1,294 @@
+import 'dart:async';
+
+/// This operator is best used when you have a group of observables
+/// and only care about the final emitted value of each.
+/// One common use case for this is if you wish to issue multiple
+/// requests on page load (or some other event)
+/// and only want to take action when a response has been received for all.
+///
+/// In this way it is similar to how you might use [Future].wait.
+///
+/// Be aware that if any of the inner observables supplied to forkJoin error
+/// you will lose the value of any other observables that would or have already
+/// completed if you do not catch the error correctly on the inner observable.
+///
+/// If you are only concerned with all inner observables completing
+/// successfully you can catch the error on the outside.
+/// It's also worth noting that if you have an observable
+/// that emits more than one item, and you are concerned with the previous
+/// emissions forkJoin is not the correct choice.
+///
+/// In these cases you may better off with an operator like combineLatest or zip.
+///
+/// ### Basic Example
+///
+/// This constructor takes in an `Iterable<Stream<T>>` and outputs a
+/// `Stream<Iterable<T>>` whenever any of the values change from the source
+/// stream. This is useful with a dynamic number of source streams!
+///
+///     ForkJoinStream.list<String>([
+///       Stream.fromIterable(["a"]),
+///       Stream.fromIterable(["b"]),
+///       Stream.fromIterable(["C", "D"])])
+///     .listen(print); //prints ['a', 'b', 'D']
+///
+/// ### Example with combiner
+///
+/// If you wish to combine the list of values into a new object before you
+///
+///     CombineLatestStream(
+///       [
+///         Stream.fromIterable(["a"]),
+///         Stream.fromIterable(["b"]),
+///         Stream.fromIterable(["C", "D"])
+///       ],
+///       (values) => values.last
+///     )
+///     .listen(print); //prints 'D'
+///
+/// ### Example with a specific number of Streams
+///
+/// If you wish to combine a specific number of Streams together with proper
+/// types information for the value of each Stream, use the
+/// [combine2] - [combine9] operators.
+///
+///     ForkJoinStream.combine2(
+///       Stream.fromIterable(1),
+///       Stream.fromIterable([2, 3]),
+///       (a, b) => a + b,
+///     )
+///     .listen(print); // prints 4
+class ForkJoinStream<T, R> extends StreamView<R> {
+  ForkJoinStream(
+    Iterable<Stream<T>> streams,
+    R combiner(List<T> values),
+  )   : assert(streams != null && streams.every((s) => s != null),
+            'streams cannot be null'),
+        assert(streams.isNotEmpty, 'provide at least 1 stream'),
+        assert(combiner != null, 'must provide a combiner function'),
+        super(_buildController(streams, combiner).stream);
+
+  static ForkJoinStream<T, List<T>> list<T>(
+    Iterable<Stream<T>> streams,
+  ) =>
+      ForkJoinStream<T, List<T>>(
+        streams,
+        (List<T> values) => values,
+      );
+
+  static ForkJoinStream<dynamic, R> combine2<A, B, R>(
+    Stream<A> streamOne,
+    Stream<B> streamTwo,
+    R combiner(A a, B b),
+  ) =>
+      ForkJoinStream<dynamic, R>(
+        [streamOne, streamTwo],
+        (List<dynamic> values) => combiner(values[0] as A, values[1] as B),
+      );
+
+  static ForkJoinStream<dynamic, R> combine3<A, B, C, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    R combiner(A a, B b, C c),
+  ) =>
+      ForkJoinStream<dynamic, R>(
+        [streamA, streamB, streamC],
+        (List<dynamic> values) {
+          return combiner(
+            values[0] as A,
+            values[1] as B,
+            values[2] as C,
+          );
+        },
+      );
+
+  static ForkJoinStream<dynamic, R> combine4<A, B, C, D, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    R combiner(A a, B b, C c, D d),
+  ) =>
+      ForkJoinStream<dynamic, R>(
+        [streamA, streamB, streamC, streamD],
+        (List<dynamic> values) {
+          return combiner(
+            values[0] as A,
+            values[1] as B,
+            values[2] as C,
+            values[3] as D,
+          );
+        },
+      );
+
+  static ForkJoinStream<dynamic, R> combine5<A, B, C, D, E, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    R combiner(A a, B b, C c, D d, E e),
+  ) =>
+      ForkJoinStream<dynamic, R>(
+        [streamA, streamB, streamC, streamD, streamE],
+        (List<dynamic> values) {
+          return combiner(
+            values[0] as A,
+            values[1] as B,
+            values[2] as C,
+            values[3] as D,
+            values[4] as E,
+          );
+        },
+      );
+
+  static ForkJoinStream<dynamic, R> combine6<A, B, C, D, E, F, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    R combiner(A a, B b, C c, D d, E e, F f),
+  ) =>
+      ForkJoinStream<dynamic, R>(
+        [streamA, streamB, streamC, streamD, streamE, streamF],
+        (List<dynamic> values) {
+          return combiner(
+            values[0] as A,
+            values[1] as B,
+            values[2] as C,
+            values[3] as D,
+            values[4] as E,
+            values[5] as F,
+          );
+        },
+      );
+
+  static ForkJoinStream<dynamic, R> combine7<A, B, C, D, E, F, G, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    Stream<G> streamG,
+    R combiner(A a, B b, C c, D d, E e, F f, G g),
+  ) =>
+      ForkJoinStream<dynamic, R>(
+        [streamA, streamB, streamC, streamD, streamE, streamF, streamG],
+        (List<dynamic> values) {
+          return combiner(
+            values[0] as A,
+            values[1] as B,
+            values[2] as C,
+            values[3] as D,
+            values[4] as E,
+            values[5] as F,
+            values[6] as G,
+          );
+        },
+      );
+
+  static ForkJoinStream<dynamic, R> combine8<A, B, C, D, E, F, G, H, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    Stream<G> streamG,
+    Stream<H> streamH,
+    R combiner(A a, B b, C c, D d, E e, F f, G g, H h),
+  ) =>
+      ForkJoinStream<dynamic, R>(
+        [
+          streamA,
+          streamB,
+          streamC,
+          streamD,
+          streamE,
+          streamF,
+          streamG,
+          streamH
+        ],
+        (List<dynamic> values) {
+          return combiner(
+            values[0] as A,
+            values[1] as B,
+            values[2] as C,
+            values[3] as D,
+            values[4] as E,
+            values[5] as F,
+            values[6] as G,
+            values[7] as H,
+          );
+        },
+      );
+
+  static ForkJoinStream<dynamic, R> combine9<A, B, C, D, E, F, G, H, I, R>(
+    Stream<A> streamA,
+    Stream<B> streamB,
+    Stream<C> streamC,
+    Stream<D> streamD,
+    Stream<E> streamE,
+    Stream<F> streamF,
+    Stream<G> streamG,
+    Stream<H> streamH,
+    Stream<I> streamI,
+    R combiner(A a, B b, C c, D d, E e, F f, G g, H h, I i),
+  ) =>
+      ForkJoinStream<dynamic, R>(
+        [
+          streamA,
+          streamB,
+          streamC,
+          streamD,
+          streamE,
+          streamF,
+          streamG,
+          streamH,
+          streamI
+        ],
+        (List<dynamic> values) {
+          return combiner(
+            values[0] as A,
+            values[1] as B,
+            values[2] as C,
+            values[3] as D,
+            values[4] as E,
+            values[5] as F,
+            values[6] as G,
+            values[7] as H,
+            values[8] as I,
+          );
+        },
+      );
+
+  static StreamController<R> _buildController<T, R>(
+    Iterable<Stream<T>> streams,
+    R combiner(List<T> values),
+  ) {
+    StreamController<R> controller;
+
+    controller = StreamController<R>(
+        sync: true,
+        onListen: () {
+          final onDone = (List<T> values) {
+            try {
+              controller.add(combiner(values));
+            } catch (e, s) {
+              controller.addError(e, s);
+            }
+
+            controller.close();
+          };
+          Future.wait(streams.map((stream) => stream.last),
+                  eagerError: true, cleanUp: (dynamic _) => controller.close())
+              .then(onDone, onError: controller.addError);
+        });
+
+    return controller;
+  }
+}

--- a/lib/streams.dart
+++ b/lib/streams.dart
@@ -5,6 +5,7 @@ export 'package:rxdart/src/streams/concat.dart';
 export 'package:rxdart/src/streams/concat_eager.dart';
 export 'package:rxdart/src/streams/defer.dart';
 export 'package:rxdart/src/streams/error.dart';
+export 'package:rxdart/src/streams/fork_join.dart';
 export 'package:rxdart/src/streams/merge.dart';
 export 'package:rxdart/src/streams/never.dart';
 export 'package:rxdart/src/streams/race.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -19,6 +19,7 @@ import 'streams/defer_test.dart' as defer_test;
 import 'streams/empty_test.dart' as empty_test;
 import 'streams/error_test.dart' as error_test;
 import 'streams/event_transformed_test.dart' as event_transformed_test;
+import 'streams/fork_join_test.dart' as fork_join_test;
 import 'streams/from_future_test.dart' as from_future_test;
 import 'streams/from_iterable_test.dart' as from_iterable_test;
 import 'streams/just_test.dart' as just_test;
@@ -125,6 +126,7 @@ void main() {
   empty_test.main();
   error_test.main();
   event_transformed_test.main();
+  fork_join_test.main();
   from_future_test.main();
   from_iterable_test.main();
   just_test.main();

--- a/test/streams/fork_join_test.dart
+++ b/test/streams/fork_join_test.dart
@@ -1,0 +1,376 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+Stream<int> get streamA =>
+    Stream<int>.periodic(const Duration(milliseconds: 1), (int count) => count)
+        .take(3);
+
+Stream<int> get streamB => Stream<int>.fromIterable(const <int>[1, 2, 3, 4]);
+
+Stream<bool> get streamC {
+  final controller = StreamController<bool>()
+    ..add(true)
+    ..close();
+
+  return controller.stream;
+}
+
+void main() {
+  test('rx.Observable.forkJoinList', () async {
+    final combined = Observable.forkJoinList<int>([
+      Observable.fromIterable([1, 2, 3]),
+      Observable.just(2),
+      Observable.just(3),
+    ]);
+
+    await expectLater(
+      combined,
+      emitsInOrder(<dynamic>[
+        [3, 2, 3],
+        emitsDone
+      ]),
+    );
+  });
+
+  test('rx.Observable.forkJoinList.singleStream', () async {
+    final combined = Observable.forkJoinList<int>([
+      Observable.fromIterable([1, 2, 3])
+    ]);
+
+    await expectLater(
+      combined,
+      emitsInOrder(<dynamic>[
+        [3],
+        emitsDone
+      ]),
+    );
+  });
+
+  test('rx.Observable.forkJoin', () async {
+    final combined = Observable.forkJoin<int, int>(
+      [
+        Observable.fromIterable([1, 2, 3]),
+        Observable.just(2),
+        Observable.just(3),
+      ],
+      (values) => values.fold(0, (acc, val) => acc + val),
+    );
+
+    await expectLater(
+      combined,
+      emitsInOrder(<dynamic>[8, emitsDone]),
+    );
+  });
+
+  test('rx.Observable.forkJoin3', () async {
+    final observable = Observable.forkJoin3(
+        streamA,
+        streamB,
+        streamC,
+        (int a_value, int b_value, bool c_value) =>
+            '$a_value $b_value $c_value');
+
+    await expectLater(
+        observable, emitsInOrder(<dynamic>['2 4 true', emitsDone]));
+  });
+
+  test('rx.Observable.forkJoin3.single.subscription', () async {
+    final observable = Observable.forkJoin3(
+        streamA,
+        streamB,
+        streamC,
+        (int a_value, int b_value, bool c_value) =>
+            '$a_value $b_value $c_value');
+
+    await expectLater(
+      observable,
+      emitsInOrder(<dynamic>['2 4 true', emitsDone]),
+    );
+    await expectLater(() => observable.listen(null), throwsA(isStateError));
+  });
+
+  test('rx.Observable.forkJoin2', () async {
+    var a = Observable.fromIterable(const [1, 2]), b = Observable.just(2);
+
+    final observable =
+        Observable.forkJoin2(a, b, (int first, int second) => [first, second]);
+
+    await expectLater(
+        observable,
+        emitsInOrder(<dynamic>[
+          [2, 2],
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.forkJoin2.throws', () async {
+    var a = Observable.just(1), b = Observable.just(2);
+
+    final observable = Observable.forkJoin2(a, b, (int first, int second) {
+      throw Exception();
+    });
+
+    observable.listen(null, onError: expectAsync2((Exception e, StackTrace s) {
+      expect(e, isException);
+    }));
+  });
+
+  test('rx.Observable.forkJoin3', () async {
+    var a = Observable<int>.just(1),
+        b = Observable<String>.just("2"),
+        c = Observable<double>.just(3.0);
+
+    final observable = Observable.forkJoin3(a, b, c,
+        (int first, String second, double third) => [first, second, third]);
+
+    await expectLater(
+        observable,
+        emitsInOrder(<dynamic>[
+          const [1, "2", 3.0],
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.forkJoin4', () async {
+    var a = Observable.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4);
+
+    final observable = Observable.forkJoin4(
+        a,
+        b,
+        c,
+        d,
+        (int first, int second, int third, int fourth) =>
+            [first, second, third, fourth]);
+
+    await expectLater(
+        observable,
+        emitsInOrder(<dynamic>[
+          const [1, 2, 3, 4],
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.forkJoin5', () async {
+    var a = Observable<int>.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4),
+        e = Observable<int>.just(5);
+
+    final observable = Observable.forkJoin5(
+        a,
+        b,
+        c,
+        d,
+        e,
+        (int first, int second, int third, int fourth, int fifth) =>
+            <int>[first, second, third, fourth, fifth]);
+
+    await expectLater(
+        observable,
+        emitsInOrder(<dynamic>[
+          const [1, 2, 3, 4, 5],
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.forkJoin6', () async {
+    var a = Observable<int>.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4),
+        e = Observable<int>.just(5),
+        f = Observable<int>.just(6);
+
+    Stream<List<int>> observable = Observable.combineLatest6(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        (int first, int second, int third, int fourth, int fifth, int sixth) =>
+            [first, second, third, fourth, fifth, sixth]);
+
+    await expectLater(
+        observable,
+        emitsInOrder(<dynamic>[
+          const [1, 2, 3, 4, 5, 6],
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.forkJoin7', () async {
+    var a = Observable<int>.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4),
+        e = Observable<int>.just(5),
+        f = Observable<int>.just(6),
+        g = Observable<int>.just(7);
+
+    final observable = Observable.forkJoin7(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        (int first, int second, int third, int fourth, int fifth, int sixth,
+                int seventh) =>
+            [first, second, third, fourth, fifth, sixth, seventh]);
+
+    await expectLater(
+        observable,
+        emitsInOrder(<dynamic>[
+          const [1, 2, 3, 4, 5, 6, 7],
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.forkJoin8', () async {
+    var a = Observable<int>.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4),
+        e = Observable<int>.just(5),
+        f = Observable<int>.just(6),
+        g = Observable<int>.just(7),
+        h = Observable<int>.just(8);
+
+    final observable = Observable.forkJoin8(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        (int first, int second, int third, int fourth, int fifth, int sixth,
+                int seventh, int eighth) =>
+            [first, second, third, fourth, fifth, sixth, seventh, eighth]);
+
+    await expectLater(
+        observable,
+        emitsInOrder(<dynamic>[
+          const [1, 2, 3, 4, 5, 6, 7, 8],
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.forkJoin9', () async {
+    var a = Observable<int>.just(1),
+        b = Observable<int>.just(2),
+        c = Observable<int>.just(3),
+        d = Observable<int>.just(4),
+        e = Observable<int>.just(5),
+        f = Observable<int>.just(6),
+        g = Observable<int>.just(7),
+        h = Observable<int>.just(8),
+        i = Observable<int>.just(9);
+
+    final observable = Observable.forkJoin9(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        i,
+        (int first, int second, int third, int fourth, int fifth, int sixth,
+                int seventh, int eighth, int ninth) =>
+            [
+              first,
+              second,
+              third,
+              fourth,
+              fifth,
+              sixth,
+              seventh,
+              eighth,
+              ninth
+            ]);
+
+    await expectLater(
+        observable,
+        emitsInOrder(<dynamic>[
+          const [1, 2, 3, 4, 5, 6, 7, 8, 9],
+          emitsDone
+        ]));
+  });
+
+  test('rx.Observable.forkJoin.asBroadcastStream', () async {
+    final observable = Observable.forkJoin3(
+        streamA,
+        streamB,
+        streamC,
+        (int a_value, int b_value, bool c_value) =>
+            '$a_value $b_value $c_value').asBroadcastStream();
+
+// listen twice on same stream
+    observable.listen(null);
+    observable.listen(null);
+// code should reach here
+    await expectLater(observable.isBroadcast, isTrue);
+  });
+
+  test('rx.Observable.forkJoin.error.shouldThrowA', () async {
+    final observableWithError = Observable.forkJoin4(
+        Observable.just(1),
+        Observable.just(1),
+        Observable.just(1),
+        ErrorStream<int>(Exception()),
+        (int a_value, int b_value, int c_value, dynamic _) =>
+            '$a_value $b_value $c_value $_');
+
+    observableWithError.listen(null,
+        onError: expectAsync2((Exception e, StackTrace s) {
+      expect(e, isException);
+    }));
+  });
+
+  test('rx.Observable.forkJoin.error.shouldThrowB', () async {
+    final observableWithError = Observable.forkJoin3(
+        Observable.just(1), Observable.just(1), Observable.just(1),
+        (int a_value, int b_value, int c_value) {
+      throw Exception('oh noes!');
+    });
+
+    observableWithError.listen(null,
+        onError: expectAsync2((Exception e, StackTrace s) {
+      expect(e, isException);
+    }));
+  });
+
+  test('rx.Observable.forkJoin.pause.resume', () async {
+    final first = Stream.periodic(const Duration(milliseconds: 10),
+            (index) => const [1, 2, 3, 4][index]).take(4),
+        second = Stream.periodic(const Duration(milliseconds: 10),
+            (index) => const [5, 6, 7, 8][index]).take(4),
+        last = Stream.periodic(const Duration(milliseconds: 10),
+            (index) => const [9, 10, 11, 12][index]).take(4);
+
+    StreamSubscription<Iterable<num>> subscription;
+// ignore: deprecated_member_use
+    subscription = Observable.forkJoin3(
+            first, second, last, (int a, int b, int c) => [a, b, c])
+        .listen(expectAsync1((value) {
+      expect(value.elementAt(0), 4);
+      expect(value.elementAt(1), 8);
+      expect(value.elementAt(2), 12);
+
+      subscription.cancel();
+    }, count: 1));
+
+    subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
+  });
+}


### PR DESCRIPTION
For "completion"'s sake :P

Based on `combineLatest`, so that gives:
- `forkJoin`
- `forkJoinList`
- `forkJoin2` ... `forkJoin9`

Like `combineLatest`, you can provide a combiner `Function`. (which are Typed, if using any of the forkJoin-n ctrs)