### PR TITLE
review Streams

### DIFF
--- a/lib/src/streams/concat.dart
+++ b/lib/src/streams/concat.dart
@@ -24,10 +24,9 @@ class ConcatStream<T> extends Stream<T> {
 
   @override
   StreamSubscription<T> listen(void onData(T event),
-      {Function onError, void onDone(), bool cancelOnError}) {
-    return controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
-  }
+          {Function onError, void onDone(), bool cancelOnError}) =>
+      controller.stream.listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {

--- a/lib/src/streams/error.dart
+++ b/lib/src/streams/error.dart
@@ -18,9 +18,9 @@ class ErrorStream<T> extends Stream<T> {
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    controller.addError(error);
-
-    controller.close();
+    controller
+      ..addError(error)
+      ..close();
 
     return controller.stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);

--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -20,10 +20,9 @@ class MergeStream<T> extends Stream<T> {
 
   @override
   StreamSubscription<T> listen(void onData(T event),
-      {Function onError, void onDone(), bool cancelOnError}) {
-    return controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
-  }
+          {Function onError, void onDone(), bool cancelOnError}) =>
+      controller.stream.listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {
@@ -34,33 +33,35 @@ class MergeStream<T> extends Stream<T> {
       throw ArgumentError('One of the provided streams is null');
     }
 
-    final subscriptions = List<StreamSubscription<T>>(streams.length);
+    final len = streams.length;
+    final subscriptions = List<StreamSubscription<T>>(len);
     StreamController<T> controller;
 
     controller = StreamController<T>(
         sync: true,
         onListen: () {
-          final completedStatus = List.generate(streams.length, (_) => false);
+          var completed = 0;
 
-          for (var i = 0, len = streams.length; i < len; i++) {
+          final onDone = () {
+            completed++;
+
+            if (completed == len) controller.close();
+          };
+
+          for (var i = 0; i < len; i++) {
             var stream = streams.elementAt(i);
 
             subscriptions[i] = stream.listen(controller.add,
-                onError: controller.addError, onDone: () {
-              completedStatus[i] = true;
-
-              if (completedStatus.reduce((a, b) => a && b)) controller.close();
-            });
+                onError: controller.addError, onDone: onDone);
           }
         },
-        onPause: ([Future<dynamic> resumeSignal]) => subscriptions.forEach(
-            (StreamSubscription<T> subscription) =>
-                subscription.pause(resumeSignal)),
-        onResume: () => subscriptions.forEach(
-            (StreamSubscription<T> subscription) => subscription.resume()),
+        onPause: ([Future<dynamic> resumeSignal]) => subscriptions
+            .forEach((subscription) => subscription.pause(resumeSignal)),
+        onResume: () =>
+            subscriptions.forEach((subscription) => subscription.resume()),
         onCancel: () => Future.wait<dynamic>(subscriptions
-            .map((StreamSubscription<T> subscription) => subscription.cancel())
-            .where((Future<dynamic> cancelFuture) => cancelFuture != null)));
+            .map((subscription) => subscription.cancel())
+            .where((cancelFuture) => cancelFuture != null)));
 
     return controller;
   }

--- a/lib/src/streams/never.dart
+++ b/lib/src/streams/never.dart
@@ -19,8 +19,7 @@ class NeverStream<T> extends Stream<T> {
 
   @override
   StreamSubscription<T> listen(void onData(T event),
-      {Function onError, void onDone(), bool cancelOnError}) {
-    return controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
-  }
+          {Function onError, void onDone(), bool cancelOnError}) =>
+      controller.stream.listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 }

--- a/lib/src/streams/range.dart
+++ b/lib/src/streams/range.dart
@@ -16,18 +16,16 @@ class RangeStream extends Stream<int> {
 
   @override
   StreamSubscription<int> listen(void onData(int event),
-      {Function onError, void onDone(), bool cancelOnError}) {
-    return stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
-  }
+          {Function onError, void onDone(), bool cancelOnError}) =>
+      stream.listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   static Stream<int> buildStream(int startInclusive, int endInclusive) {
     final length = (endInclusive - startInclusive).abs() + 1;
+    final nextValue = (int index) => startInclusive > endInclusive
+        ? startInclusive - index
+        : startInclusive + index;
 
-    return Stream.fromIterable(List.generate(
-        length,
-        (int i) => startInclusive > endInclusive
-            ? startInclusive - i
-            : startInclusive + i));
+    return Stream.fromIterable(List.generate(length, nextValue));
   }
 }

--- a/lib/src/streams/repeat.dart
+++ b/lib/src/streams/repeat.dart
@@ -17,7 +17,6 @@ class RepeatStream<T> extends Stream<T> {
   int repeatStep = 0;
   StreamController<T> controller;
   StreamSubscription<T> subscription;
-  bool _isUsed = false;
 
   RepeatStream(this.streamFactory, [this.count]);
 
@@ -28,10 +27,7 @@ class RepeatStream<T> extends Stream<T> {
     void onDone(),
     bool cancelOnError,
   }) {
-    if (_isUsed) throw StateError("Stream has already been listened to.");
-    _isUsed = true;
-
-    controller = StreamController<T>(
+    controller ??= StreamController<T>(
         sync: true,
         onListen: maybeRepeatNext,
         onPause: ([Future<dynamic> resumeSignal]) =>

--- a/lib/src/streams/timer.dart
+++ b/lib/src/streams/timer.dart
@@ -7,14 +7,12 @@ import 'dart:async';
 ///     new TimerStream("hi", new Duration(minutes: 1))
 ///         .listen((i) => print(i)); // print "hi" after 1 minute
 class TimerStream<T> extends Stream<T> {
-  final T _value;
-  final Duration _duration;
   final Stream<T> Function() _streamFactory;
 
-  TimerStream(this._value, this._duration)
+  TimerStream(T value, Duration duration)
       : _streamFactory = (() {
           final stream =
-              Stream.fromFuture(Future.delayed(_duration, () => _value));
+              Stream.fromFuture(Future.delayed(duration, () => value));
 
           return () => stream;
         })();

--- a/lib/src/streams/timer.dart
+++ b/lib/src/streams/timer.dart
@@ -9,12 +9,19 @@ import 'dart:async';
 class TimerStream<T> extends Stream<T> {
   final T _value;
   final Duration _duration;
+  final Stream<T> Function() _streamFactory;
 
-  TimerStream(this._value, this._duration);
+  TimerStream(this._value, this._duration)
+      : _streamFactory = (() {
+          final stream =
+              Stream.fromFuture(Future.delayed(_duration, () => _value));
+
+          return () => stream;
+        })();
 
   @override
   StreamSubscription<T> listen(void onData(T event),
           {Function onError, void onDone(), bool cancelOnError}) =>
-      Stream.fromFuture(Future.delayed(_duration, () => _value)).listen(onData,
+      _streamFactory().listen(onData,
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 }

--- a/lib/src/streams/timer.dart
+++ b/lib/src/streams/timer.dart
@@ -7,23 +7,14 @@ import 'dart:async';
 ///     new TimerStream("hi", new Duration(minutes: 1))
 ///         .listen((i) => print(i)); // print "hi" after 1 minute
 class TimerStream<T> extends Stream<T> {
-  final T value;
-  final Duration duration;
-  final StreamController<T> controller = StreamController<T>();
+  final T _value;
+  final Duration _duration;
 
-  TimerStream(this.value, this.duration);
+  TimerStream(this._value, this._duration);
 
   @override
   StreamSubscription<T> listen(void onData(T event),
-      {Function onError, void onDone(), bool cancelOnError}) {
-    final subscription = controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
-
-    Timer(duration, () {
-      controller.add(value);
-      controller.close();
-    });
-
-    return subscription;
-  }
+          {Function onError, void onDone(), bool cancelOnError}) =>
+      Stream.fromFuture(Future.delayed(_duration, () => _value)).listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 }

--- a/lib/src/streams/utils.dart
+++ b/lib/src/streams/utils.dart
@@ -1,13 +1,19 @@
 import 'dart:async';
 
-typedef Stream<T> StreamFactory<T>();
-typedef Stream<void> RetryWhenStreamFactory(dynamic error, StackTrace stack);
+typedef RetryWhenStreamFactory = Stream<void> Function(
+    dynamic error, StackTrace stack);
 
 class RetryError extends Error {
   final String message;
   final List<ErrorAndStacktrace> errors;
 
-  RetryError(this.message, this.errors);
+  RetryError._(this.message, this.errors);
+
+  factory RetryError.withCount(int count, List<ErrorAndStacktrace> errors) =>
+      RetryError._('Received an error after attempting $count retries', errors);
+
+  factory RetryError.onReviveFailed(List<ErrorAndStacktrace> errors) =>
+      RetryError._('Received an error after attempting to retry.', errors);
 
   @override
   String toString() => message;

--- a/lib/src/transformers/interval.dart
+++ b/lib/src/transformers/interval.dart
@@ -23,14 +23,10 @@ class IntervalStreamTransformer<T> extends StreamTransformerBase<T, T> {
         StreamSubscription<T> subscription;
         Future<T> onInterval;
 
-        final combinedWait = (Future<dynamic> resumeSignal) {
-          if (resumeSignal != null && onInterval != null)
-            return Future.wait<dynamic>([onInterval, resumeSignal]);
-
-          if (onInterval != null) return onInterval;
-
-          return resumeSignal;
-        };
+        final combinedWait = (Future<dynamic> resumeSignal) =>
+            (resumeSignal != null && onInterval != null)
+                ? Future.wait<dynamic>([onInterval, resumeSignal])
+                : resumeSignal;
 
         controller = StreamController<T>(
             sync: true,

--- a/test/streams/retry_test.dart
+++ b/test/streams/retry_test.dart
@@ -107,7 +107,7 @@ void main() {
   });
 }
 
-StreamFactory<int> _getRetryStream(int failCount) {
+Stream<int> Function() _getRetryStream(int failCount) {
   var count = 0;
 
   return () {
@@ -120,7 +120,7 @@ StreamFactory<int> _getRetryStream(int failCount) {
   };
 }
 
-StreamFactory<int> _getStreamWithExtras(int failCount) {
+Stream<int> Function() _getStreamWithExtras(int failCount) {
   var count = 0;
 
   return () {

--- a/test/streams/retry_when_test.dart
+++ b/test/streams/retry_when_test.dart
@@ -106,7 +106,7 @@ void main() {
   });
 }
 
-StreamFactory<int> _sourceStream(int i, [int throwAt]) {
+Stream<int> Function() _sourceStream(int i, [int throwAt]) {
   return throwAt == null
       ? () => Observable.fromIterable(range(i))
       : () => Observable.fromIterable(range(i))
@@ -118,7 +118,7 @@ Stream<void> _alwaysThrow(dynamic e, StackTrace s) =>
 
 Stream<void> _neverThrow(dynamic e, StackTrace s) => Observable.just('');
 
-StreamFactory<int> _getStreamWithExtras(int failCount) {
+Stream<int> Function() _getStreamWithExtras(int failCount) {
   var count = 0;
 
   return () {

--- a/test/streams/timer_test.dart
+++ b/test/streams/timer_test.dart
@@ -35,6 +35,17 @@ void main() {
     subscription.resume();
   });
 
+  test('TimerStream.single.subscription', () async {
+    final observable = TimerStream(null, Duration(milliseconds: 1));
+
+    try {
+      observable.listen(null);
+      observable.listen(null);
+    } catch (e) {
+      await expectLater(e, isStateError);
+    }
+  });
+
   test('TimerStream.cancel', () async {
     const value = 1;
     StreamSubscription<int> subscription;

--- a/test/transformers/exhaust_map_test.dart
+++ b/test/transformers/exhaust_map_test.dart
@@ -18,16 +18,15 @@ void main() {
     });
 
     test('starts emitting again after previous Stream is complete', () async {
-      var calls = 0;
-      final observable = Observable.range(0, 9)
-          .interval(Duration(milliseconds: 20))
-          .exhaustMap((i) {
-        calls++;
-        return Observable.timer(i, Duration(milliseconds: 100));
+      final observable =
+          Observable.fromIterable(const [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+              .interval(Duration(milliseconds: 30))
+              .exhaustMap((i) async* {
+        yield await Future.delayed(Duration(milliseconds: 70), () => i);
       });
 
-      await expectLater(observable, emitsInOrder(<dynamic>[0, 5, emitsDone]));
-      await expectLater(calls, 2);
+      await expectLater(
+          observable, emitsInOrder(<dynamic>[0, 2, 4, 6, 8, emitsDone]));
     });
 
     test('is reusable', () async {


### PR DESCRIPTION
Mostly smaller changes to all our streams-classes, without changing the way they function.

i.e.
- move inline functions to named methods, to clean up `onListen`/`listen` blocks
- use simple counter variables instead of Lists (i.e. keeping track of completed Streams in `combineLatest`)
- try to remove clutter where possible, see for example the removal of `isUsed` in defer

one test in exhaustMap was flaky, as the old test had intervals on 20 and 100ms, which sometimes caused the test to fail, as 2 actions took place on the same time interval (we had failing builds before on this one, where the next try it passed).
So changed that test with 30 and 70ms intervals.