### PR TITLE
Remove assertion for a specific number of items on Zip and CombineLatest

### DIFF
--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -53,7 +53,6 @@ class CombineLatestStream<T, R> extends StreamView<R> {
     R combiner(List<T> values),
   )   : assert(streams != null && streams.every((s) => s != null),
             'streams cannot be null'),
-        assert(streams.length > 1, 'provide at least 2 streams'),
         assert(combiner != null, 'must provide a combiner function'),
         super(_buildController(streams, combiner).stream);
 

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -28,7 +28,6 @@ class ZipStream<T, R> extends StreamView<R> {
     R zipper(List<T> values),
   )   : assert(streams != null && streams.every((s) => s != null),
             'streams cannot be null'),
-        assert(streams.length > 1, 'provide at least 2 streams'),
         assert(zipper != null, 'must provide a zipper function'),
         super(_buildController(streams, zipper).stream);
 


### PR DESCRIPTION
Now that we allow a list of Streams to be provided which can contain any number of streams, we should no longer check if there are a specific number of streams provided.