### PR TITLE
Docs: Fix ZipStream example and usage of Stream.fromIterable()

### DIFF
--- a/lib/src/futures/stream_max_future.dart
+++ b/lib/src/futures/stream_max_future.dart
@@ -16,7 +16,7 @@ import 'package:rxdart/src/futures/wrapped_future.dart';
 ///
 /// ### Example with custom [Comparator]
 ///
-///     Stream<String> stream = new Stream.fromIterable("short", "loooooooong");
+///     Stream<String> stream = new Stream.fromIterable(["short", "loooooooong"]);
 ///     Comparator<String> stringLengthComparator = (a, b) => a.length - b.length;
 ///     String max = await new StreamMaxFuture(stream, stringLengthComparator);
 ///

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -2036,7 +2036,7 @@ class Observable<T> extends Stream<T> {
   ///
   /// ### Example with custom [Comparator]
   ///
-  ///     final observable = new Observable.fromIterable("short", "looooooong");
+  ///     final observable = new Observable.fromIterable(["short", "looooooong"]);
   ///     final max = await observable.max((a, b) => a.length - b.length);
   ///
   ///     print(max); // prints "looooooong"
@@ -2069,7 +2069,7 @@ class Observable<T> extends Stream<T> {
   ///
   /// ### Example with custom [Comparator]
   ///
-  ///     final observable = new Observable.fromIterable("short", "looooooong");
+  ///     final observable = new Observable.fromIterable(["short", "looooooong"]);
   ///     final min = await observable.min((a, b) => a.length - b.length);
   ///
   ///     print(min); // prints "short"

--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -42,7 +42,7 @@ import 'dart:async';
 /// [combine2] - [combine9] operators.
 ///
 ///     CombineLatestStream.combine2(
-///       Stream.fromIterable(1),
+///       Stream.fromIterable([1]),
 ///       Stream.fromIterable([2, 3]),
 ///       (a, b) => a + b,
 ///     )

--- a/lib/src/streams/fork_join.dart
+++ b/lib/src/streams/fork_join.dart
@@ -53,7 +53,7 @@ import 'dart:async';
 /// [combine2] - [combine9] operators.
 ///
 ///     ForkJoinStream.combine2(
-///       Stream.fromIterable(1),
+///       Stream.fromIterable([1]),
 ///       Stream.fromIterable([2, 3]),
 ///       (a, b) => a + b,
 ///     )

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -15,13 +15,28 @@ import 'dart:async';
 ///
 /// [Interactive marble diagram](http://rxmarbles.com/#zip)
 ///
-/// ### Example
+/// ### Basic Example
 ///
-///     new ZipStream([
-///         new Stream.fromIterable([1]),
-///         new Stream.fromIterable([2, 3])
-///       ], (a, b) => a + b)
-///       .listen(print); // prints 3
+///     ZipStream(
+///       [
+///         Stream.fromIterable(['A']),
+///         Stream.fromIterable(['B']),
+///         Stream.fromIterable(['C', 'D']),
+///       ],
+///       (values) => values.join(),
+///     ).listen(print); // prints 'ABC'
+///
+/// ### Example with a specific number of Streams
+///
+/// If you wish to zip a specific number of Streams together with proper types
+/// information for the value of each Stream, use the [zip2] - [zip9] operators.
+///
+///     ZipStream.zip2(
+///       Stream.fromIterable(['A']),
+///       Stream.fromIterable(['B', 'C']),
+///       (a, b) => a + b,
+///     )
+///     .listen(print); // prints 'AB'
 class ZipStream<T, R> extends StreamView<R> {
   ZipStream(
     Iterable<Stream<T>> streams,


### PR DESCRIPTION
1. Change examples using `Stream.fromIterable(a, b)` to `Stream.fromIterable([a, b])`.
2. ZipStream constructor accepts a zipper function `R zipper(List<T> values)` but the example was using `(a, b) => a + b` which doesn't match the function signature. Fixed and updated the example.
3. Added an example of `ZipStream.zip2` making the docs more consistent with e.g. `CombineLatestStream` and `ForkJoinStream`.