### PR TITLE
fix: deal with NoSuchMethodError exception

### DIFF
--- a/lib/src/transformers/switch_map.dart
+++ b/lib/src/transformers/switch_map.dart
@@ -73,7 +73,7 @@ class SwitchMapStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
           onCancel: () async {
             await subscription.cancel();
 
-            if (hasMainEvent) await otherSubscription.cancel();
+            if (hasMainEvent) await otherSubscription?.cancel();
           });
 
       return controller.stream.listen(null);


### PR DESCRIPTION
I'm facing the following error. This PR tries fixing this error.

```
[VERBOSE-2:ui_dart_state.cc(148)] Unhandled Exception: NoSuchMethodError: The method 'cancel' was called on null.
Receiver: null
Tried calling: cancel()
#0      Object.noSuchMethod (dart:core/runtime/libobject_patch.dart:50:5)
#1      SwitchMapStreamTransformer._buildTransformer.<anonymous closure>.<anonymous closure> (package:rxdart/src/transformers/switch_map.dart:76:55)
<asynchronous suspension>
#2      _StreamController._recordCancel (dart:async/stream_controller.dart:713:20)
#3      _ControllerSubscription._onCancel (dart:async/stream_controller.dart:841:24)
#4      _BufferingStreamSubscription._cancel (dart:async/stream_impl.dart:242:21)
#5      _BufferingStreamSubscription.cancel (dart:async/stream_impl.dart:194:7)
#6      _StreamBuilderBaseState._unsubscribe (package:flutter/src/widgets/async.dart:154:21)
#7      _StreamBuilderBaseState.didUpdateWidget (package:flutter/src/widgets/async.dart:117:9)
#8      StatefulElement.update (package:flutter/src/widgets/framework.dart:3879:58)
#9      Ele<…>
```