### PR TITLE
fix: compilation errors in examples applying `dartanalyzer`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
   - set -e
   - sh tool/check_format.sh
   - dartanalyzer --fatal-infos --fatal-warnings ./
+  - dartanalyzer --fatal-infos --fatal-warnings ./example
   - pub run test test/rxdart_test.dart
   - pub global activate coverage
   - dart --enable-vm-service=8111 --pause-isolates-on-exit test/rxdart_test.dart &

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ void main() {
     KeyCode.A];
 
   final result = querySelector('#result');
-  final keyUp = new Observable<KeyboardEvent>(document.onKeyUp);
+  final keyUp = Observable<KeyboardEvent>(document.onKeyUp);
 
   keyUp
     .map((event) => event.keyCode)

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,7 +1,6 @@
 analyzer:
   errors:
     argument_type_not_assignable: ignore
-    deprecated_member_use: ignore
     extends_non_class: ignore
     implements_non_class: ignore
     non_type_as_type_argument: ignore

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,3 +1,4 @@
+include: package:pedantic/analysis_options.yaml
 analyzer:
   errors:
     argument_type_not_assignable: ignore

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,20 @@
+analyzer:
+  errors:
+    argument_type_not_assignable: ignore
+    deprecated_member_use: ignore
+    extends_non_class: ignore
+    implements_non_class: ignore
+    non_type_as_type_argument: ignore
+    override_on_non_overriding_method: ignore
+    undefined_annotation: ignore
+    undefined_class: ignore
+    undefined_function: ignore
+    undefined_identifier: ignore
+    undefined_method: ignore
+    undefined_named_parameter: ignore
+    undefined_super_method: ignore
+    uri_does_not_exist: ignore
+    type_test_with_undefined_name: ignore
+linter:
+  rules:
+    - unnecessary_new

--- a/example/example.dart
+++ b/example/example.dart
@@ -30,7 +30,7 @@ void main(List<String> arguments) {
       // value each time a [Stream] event occurs
       // in this case, the accumulated value is always
       // the latest Fibonacci number
-      .scan((IndexedPair seq, _, __) => new IndexedPair.next(seq), seed)
+      .scan((IndexedPair seq, _, __) => IndexedPair.next(seq), seed)
       // finally, print the output
       .listen(print, onDone: () => print('done!'));
 }
@@ -40,7 +40,7 @@ class IndexedPair {
 
   const IndexedPair(this.n1, this.n2, this.index);
 
-  factory IndexedPair.next(IndexedPair prev) => new IndexedPair(
+  factory IndexedPair.next(IndexedPair prev) => IndexedPair(
       prev.n2, prev.index <= 1 ? prev.n1 : prev.n1 + prev.n2, prev.index + 1);
 
   @override

--- a/example/flutter/github_search/lib/search_bloc.dart
+++ b/example/flutter/github_search/lib/search_bloc.dart
@@ -15,7 +15,7 @@ class SearchBloc {
         // If the text has not changed, do not perform a new search
         .distinct()
         // Wait for the user to stop typing for 250ms before running a search
-        .debounce(const Duration(milliseconds: 250))
+        .debounceTime(const Duration(milliseconds: 250))
         // Call the Github api with the given search term and convert it to a
         // State. If another search term is entered, flatMapLatest will ensure
         // the previous search is discarded so we don't deliver stale results

--- a/example/flutter/github_search/test/search_bloc_test.dart
+++ b/example/flutter/github_search/test/search_bloc_test.dart
@@ -99,12 +99,12 @@ void main() {
   });
 }
 
-const noTerm = isInstanceOf<SearchNoTerm>();
+const noTerm = TypeMatcher<SearchNoTerm>();
 
-const loading = isInstanceOf<SearchLoading>();
+const loading = TypeMatcher<SearchLoading>();
 
-const empty = isInstanceOf<SearchEmpty>();
+const empty = TypeMatcher<SearchEmpty>();
 
-const populated = isInstanceOf<SearchPopulated>();
+const populated = TypeMatcher<SearchPopulated>();
 
-const error = isInstanceOf<SearchError>();
+const error = TypeMatcher<SearchError>();

--- a/example/web/dragdrop/dragdrop.dart
+++ b/example/web/dragdrop/dragdrop.dart
@@ -6,19 +6,19 @@ import 'package:rxdart/rxdart.dart';
 
 void main() {
   final dragTarget = querySelector('#dragTarget');
-  final mouseUp = new Observable<MouseEvent>(document.onMouseUp);
-  final mouseMove = new Observable<MouseEvent>(document.onMouseMove);
-  final mouseDown = new Observable<MouseEvent>(document.onMouseDown);
+  final mouseUp = Observable<MouseEvent>(document.onMouseUp);
+  final mouseMove = Observable<MouseEvent>(document.onMouseMove);
+  final mouseDown = Observable<MouseEvent>(document.onMouseDown);
 
   mouseDown
       // Use map() to calculate the left and top properties on mouseDown
-      .map((event) => new Point<num>(event.client.x - dragTarget.offset.left,
+      .map((event) => Point<num>(event.client.x - dragTarget.offset.left,
           event.client.y - dragTarget.offset.top))
       // Use switchMap() to get the mouse position on each mouseMove
       .switchMap((startPosition) {
     return mouseMove
         // Use map() to calculate the left and top properties on each mouseMove
-        .map((event) => new Point<num>(
+        .map((event) => Point<num>(
             event.client.x - startPosition.x, event.client.y - startPosition.y))
         // Use takeUntil() to stop calculations when a mouseUp occurs
         .takeUntil(mouseUp);

--- a/example/web/konami/konamicode.dart
+++ b/example/web/konami/konamicode.dart
@@ -20,7 +20,7 @@ void main() {
   ];
 
   final result = querySelector('#result');
-  final keyUp = new Observable<KeyboardEvent>(document.onKeyUp);
+  final keyUp = Observable<KeyboardEvent>(document.onKeyUp);
 
   keyUp
       // Use map() to get the keyCode

--- a/example/web/search_github/search_github.dart
+++ b/example/web/search_github/search_github.dart
@@ -7,7 +7,7 @@ import 'package:rxdart/rxdart.dart';
 void main() {
   final searchInput = querySelector('#searchInput');
   final resultsField = querySelector('#resultsField');
-  final keyUp = new Observable(searchInput.onKeyUp);
+  final keyUp = Observable(searchInput.onKeyUp);
 
   keyUp
       // return the event target
@@ -34,14 +34,14 @@ void main() {
       // entered, switchMap will cancel the previous request, and notify use
       // of the last result that comes in. Normal flatMap() would give us all
       // previous results as well.
-      .switchMap((term) => new Observable.fromFuture(_searchGithubFor(term)))
+      .switchMap((term) => Observable.fromFuture(_searchGithubFor(term)))
       .listen((result) => result.forEach((item) => resultsField.innerHtml +=
           "<li>${item['fullName']} (${item['url']})</li>"));
 }
 
 Future<List<Map<String, String>>> _searchGithubFor(String term) async {
   if (term.isEmpty) {
-    throw new ArgumentError('Need to provide a term');
+    throw ArgumentError('Need to provide a term');
   }
 
   final request = await HttpRequest.request(

--- a/example/web/search_github/search_github.dart
+++ b/example/web/search_github/search_github.dart
@@ -23,7 +23,7 @@ void main() {
       .where((term) => term.isNotEmpty)
       // Use debounce() to prevent calling the server on fast following
       // keystrokes
-      .debounce(const Duration(milliseconds: 250))
+      .debounceTime(const Duration(milliseconds: 250))
       // Use doOnData() to clear resultsField
       .doOnData((_) => resultsField.innerHtml = '')
       // Use switchMap to call the gitHub API

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,5 +16,6 @@ dev_dependencies:
   build_web_compilers: ^0.4.0
   coverage: '>=0.11.0 <0.13.0'
   mockito: ^3.0.0
+  pedantic: ^1.5.0
   stack_trace: ^1.9.2
   test: ^1.0.0


### PR DESCRIPTION
c.f. https://github.com/ReactiveX/rxdart/pull/262#issuecomment-482065922

This PR applies `dartanalyzer` to the dart files in `example` using another `analysis_options.yaml`.
The `analysis_options.yaml` ignores existing semantical errors but detects `unnecessary_new` errors.
I believe this approach is useful to maintain the dart files in `example`.