### PR TITLE
fix: missing null check

### DIFF
--- a/lib/src/transformers/switch_map.dart
+++ b/lib/src/transformers/switch_map.dart
@@ -73,7 +73,7 @@ class SwitchMapStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
           onCancel: () async {
             await subscription.cancel();
 
-            if (hasMainEvent) await otherSubscription.cancel();
+            if (hasMainEvent) await otherSubscription?.cancel();
           });
 
       return controller.stream.listen(null);


### PR DESCRIPTION
I noticed that if something threw an Exception inside a switchMap, line 76 would crash with calling `cancel()` on a null. I looked at the file, and every other cancel of `otherSubscription`, already has the null check, so it just appears to be an oversight.

Do note that if `otherSubscription` is null, the line:
`if (hasMainEvent) await otherSubscription?.cancel();`
effectively becomes:
`if (hasMainEvent) await null;`

FYI `await` supports nulls, so there's no need to check for it.