### PR TITLE
Streams/from callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ var myObservable = new Observable(myStream);
 - [concatEager](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.concat.html) / [ConcatEagerStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/ConcatEagerStream-class.html)
 - [defer](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.defer.html) / [DeferStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/DeferStream-class.html)
 - [error](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.error.html) / [ErrorStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/ErrorStream-class.html)
+- [fromCallable](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.fromCallable.html) / [FromCallableStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/FromCallableStream-class.html)
 - [just](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.just.html)
 - [merge](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.merge.html) / [MergeStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/MergeStream-class.html)
 - [never](https://www.dartdocs.org/documentation/rxdart/latest/rx/Observable/Observable.never.html) / [NeverStream](https://www.dartdocs.org/documentation/rxdart/latest/rx/NeverStream-class.html)

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -4,6 +4,7 @@ import 'package:rxdart/futures.dart';
 import 'package:rxdart/src/observables/connectable_observable.dart';
 import 'package:rxdart/src/observables/replay_observable.dart';
 import 'package:rxdart/src/observables/value_observable.dart';
+import 'package:rxdart/src/streams/from_callable.dart';
 import 'package:rxdart/streams.dart';
 import 'package:rxdart/transformers.dart';
 
@@ -729,7 +730,24 @@ class Observable<T> extends Stream<T> {
         ),
       );
 
-  /// Creates an Observable from the future.
+  /// Creates an [Observable] that, when subscribed upon,
+  /// invokes a function you specify and then emits the value returned from that function.
+  ///
+  /// The function expects a return type of [FutureOr]
+  /// - if you return a [Future], it will be auto-awaited, so there is no need
+  ///   to do [asyncMap] immediately.
+  /// - if you return a non-future, then that value is simply returned.
+  ///
+  /// [Observable]s created by fromCallable are always broadcast [Observable]s.
+  ///
+  /// ### Example
+  ///
+  ///     new FromCallableStream(() => 1).listen(print); //prints 1
+  ///     new FromCallableStream(() => Future.value(1)).listen(print); //prints 1
+  factory Observable.fromCallable(FutureOr<T> callable()) =>
+      Observable<T>(FromCallableStream<T>(callable));
+
+  /// Creates an Observable from a future.
   ///
   /// When the future completes, the stream will fire one event, either
   /// data or error, and then close with a done-event.

--- a/lib/src/streams/from_callable.dart
+++ b/lib/src/streams/from_callable.dart
@@ -34,7 +34,7 @@ class FromCallableStream<T> extends Stream<T> {
             } else {
               return Stream.fromIterable([result as T]);
             }
-          } catch (e, s) {
+          } catch (e) {
             return Observable.error(e);
           }
         });

--- a/lib/src/streams/from_callable.dart
+++ b/lib/src/streams/from_callable.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+
+/// Returns an [Observable] that, when subscribed upon,
+/// invokes a function you specify and then emits the value returned from that function.
+///
+/// The callable expects a return type of [FutureOr]
+/// - if you return a [Future], it will be auto-awaited, so there is no need
+///   to do [Observable.asyncMap] immediately.
+/// - if you return a non-future, then that value is simply returned.
+///
+/// A FromCallableStream is always a broadcast [Stream].
+///
+/// ### Example
+///
+///     new FromCallableStream(() => 1).listen(print); //prints 1
+///     new FromCallableStream(() => Future.value(1)).listen(print); //prints 1
+class FromCallableStream<T> extends Stream<T> {
+  final Stream<T> Function() _factory;
+
+  @override
+  bool get isBroadcast => true;
+
+  FromCallableStream(FutureOr<T> callable())
+      : _factory = (() {
+          FutureOr<T> result;
+
+          try {
+            result = callable();
+
+            if (result is Future<T>) {
+              return Stream.fromFuture(result);
+            } else {
+              return Stream.fromIterable([result as T]);
+            }
+          } catch (e, s) {
+            return Observable.error(e);
+          }
+        });
+
+  @override
+  StreamSubscription<T> listen(void onData(T event),
+          {Function onError, void onDone(), bool cancelOnError}) =>
+      _factory().listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+}

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -20,6 +20,7 @@ import 'streams/empty_test.dart' as empty_test;
 import 'streams/error_test.dart' as error_test;
 import 'streams/event_transformed_test.dart' as event_transformed_test;
 import 'streams/fork_join_test.dart' as fork_join_test;
+import 'streams/from_callable_test.dart' as from_callable_test;
 import 'streams/from_future_test.dart' as from_future_test;
 import 'streams/from_iterable_test.dart' as from_iterable_test;
 import 'streams/just_test.dart' as just_test;
@@ -130,6 +131,7 @@ void main() {
   error_test.main();
   event_transformed_test.main();
   fork_join_test.main();
+  from_callable_test.main();
   from_future_test.main();
   from_iterable_test.main();
   just_test.main();

--- a/test/streams/from_callable_test.dart
+++ b/test/streams/from_callable_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('rx.Observable.fromCallable', () async {
+    final callable = () => 1;
+    final observable = Observable.fromCallable(callable);
+
+    await expectLater(
+      observable,
+      emitsInOrder(<dynamic>[1, emitsDone]),
+    );
+  });
+
+  test('rx.Observable.fromCallable.asFuture', () async {
+    final callable = () => Future.value(1);
+    final observable = Observable.fromCallable(callable);
+
+    await expectLater(
+      observable,
+      emitsInOrder(<dynamic>[1, emitsDone]),
+    );
+  });
+
+  test('rx.Observable.fromCallable.multiple.listeners', () async {
+    var stepper = 1;
+    final callable = () => stepper++;
+    final observable = Observable.fromCallable(callable);
+
+    await expectLater(
+      observable,
+      emitsInOrder(<dynamic>[1, emitsDone]),
+    );
+
+    await expectLater(
+      observable,
+      emitsInOrder(<dynamic>[2, emitsDone]),
+    );
+  });
+
+  test('rx.Observable.fromCallable.future.multiple.listeners', () async {
+    var stepper = 1;
+    final callable = () => Future.value(stepper++);
+    final observable = Observable.fromCallable(callable);
+
+    await expectLater(
+      observable,
+      emitsInOrder(<dynamic>[1, emitsDone]),
+    );
+
+    await expectLater(
+      observable,
+      emitsInOrder(<dynamic>[2, emitsDone]),
+    );
+  });
+
+  test('rx.Observable.fromCallable.error.shouldThrow', () async {
+    final callable = () {
+      throw Exception();
+    };
+    final observableWithError = Observable.fromCallable(callable);
+
+    await expectLater(
+      observableWithError,
+      emitsInOrder(<dynamic>[emitsError(isException), emitsDone]),
+    );
+  });
+
+  test('rx.Observable.fromCallable.error.future.shouldThrow', () async {
+    final callable = () => Future<void>.error(Exception());
+    final observableWithError = Observable.fromCallable(callable);
+
+    await expectLater(
+      observableWithError,
+      emitsInOrder(<dynamic>[emitsError(isException), emitsDone]),
+    );
+  });
+}


### PR DESCRIPTION
Adds the fromCallable ctr.

This constructor allows you to create a new Observable from the result of a Function.

Each time you listen to the Observable, the Function should execute again.

The result is of type FutureOr<T>, the Observable will await a Future, if needed, and always yield a Stream of T.