### PR TITLE
Observable.withLatestFrom for two and more streams.

### DIFF
--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -2567,18 +2567,46 @@ class Observable<T> extends Stream<T> {
       transform(WithLatestFromStreamTransformer.with1(latestFromStream, fn));
 
   /// Creates an Observable that emits when the source stream emits, combining
-  /// the latest values from the two streams using the provided function.
+  /// the latest values from the streams into a list. This is helpful when you need to
+  /// combine a dynamic number of Streams.
   ///
-  /// If the latestFromStream has not emitted any values, this stream will not
+  /// If any of latestFromStreams has not emitted any values, this stream will not
+  /// emit either.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
+  ///
+  /// ### Example
+  ///     Observable.fromIterable([1, 2]).withLatestFromList(
+  ///         [
+  ///           Observable.fromIterable([2, 3]),
+  ///           Observable.fromIterable([3, 4]),
+  ///           Observable.fromIterable([4, 5]),
+  ///           Observable.fromIterable([5, 6]),
+  ///           Observable.fromIterable([6, 7]),
+  ///         ],
+  ///       ).listen(print); // print [2, 2, 3, 4, 5, 6] (due to the async nature of streams)
+  ///
+  Observable<List<T>> withLatestFromList(
+          Iterable<Stream<T>> latestFromStreams) =>
+      transform(WithLatestFromStreamTransformer.list(latestFromStreams));
+
+  /// Creates an Observable that emits when the source stream emits, combining
+  /// the latest values from the three streams using the provided function.
+  ///
+  /// If any of latestFromStreams has not emitted any values, this stream will not
   /// emit either.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
   ///
   /// ### Example
   ///
-  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
-  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
-  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  ///     Observable.fromIterable([1, 2])
+  ///       .withLatestFrom2(
+  ///         Observable.fromIterable([2, 3]),
+  ///         Observable.fromIterable([3, 4]),
+  ///         (int a, int b, int c) => a + b + c,
+  ///       )
+  ///       .listen(print); // prints 7 (due to the async nature of streams)
   Observable<R> withLatestFrom2<A, B, R>(
     Stream<A> latestFromStream1,
     Stream<B> latestFromStream2,
@@ -2588,18 +2616,23 @@ class Observable<T> extends Stream<T> {
           latestFromStream1, latestFromStream2, fn));
 
   /// Creates an Observable that emits when the source stream emits, combining
-  /// the latest values from the two streams using the provided function.
+  /// the latest values from the four streams using the provided function.
   ///
-  /// If the latestFromStream has not emitted any values, this stream will not
+  /// If any of latestFromStreams has not emitted any values, this stream will not
   /// emit either.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
   ///
   /// ### Example
   ///
-  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
-  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
-  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  ///     Observable.fromIterable([1, 2])
+  ///       .withLatestFrom3(
+  ///         Observable.fromIterable([2, 3]),
+  ///         Observable.fromIterable([3, 4]),
+  ///         Observable.fromIterable([4, 5]),
+  ///         (int a, int b, int c, int d) => a + b + c + d,
+  ///       )
+  ///       .listen(print); // prints 11 (due to the async nature of streams)
   Observable<R> withLatestFrom3<A, B, C, R>(
     Stream<A> latestFromStream1,
     Stream<B> latestFromStream2,
@@ -2614,18 +2647,24 @@ class Observable<T> extends Stream<T> {
       ));
 
   /// Creates an Observable that emits when the source stream emits, combining
-  /// the latest values from the two streams using the provided function.
+  /// the latest values from the five streams using the provided function.
   ///
-  /// If the latestFromStream has not emitted any values, this stream will not
+  /// If any of latestFromStreams has not emitted any values, this stream will not
   /// emit either.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
   ///
   /// ### Example
   ///
-  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
-  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
-  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  ///     Observable.fromIterable([1, 2])
+  ///       .withLatestFrom4(
+  ///         Observable.fromIterable([2, 3]),
+  ///         Observable.fromIterable([3, 4]),
+  ///         Observable.fromIterable([4, 5]),
+  ///         Observable.fromIterable([5, 6]),
+  ///         (int a, int b, int c, int d, int e) => a + b + c + d + e,
+  ///       )
+  ///       .listen(print); // prints 16 (due to the async nature of streams)
   Observable<R> withLatestFrom4<A, B, C, D, R>(
     Stream<A> latestFromStream1,
     Stream<B> latestFromStream2,
@@ -2642,18 +2681,25 @@ class Observable<T> extends Stream<T> {
       ));
 
   /// Creates an Observable that emits when the source stream emits, combining
-  /// the latest values from the two streams using the provided function.
+  /// the latest values from the six streams using the provided function.
   ///
-  /// If the latestFromStream has not emitted any values, this stream will not
+  /// If any of latestFromStreams has not emitted any values, this stream will not
   /// emit either.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
   ///
   /// ### Example
   ///
-  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
-  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
-  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  ///     Observable.fromIterable([1, 2])
+  ///       .withLatestFrom5(
+  ///         Observable.fromIterable([2, 3]),
+  ///         Observable.fromIterable([3, 4]),
+  ///         Observable.fromIterable([4, 5]),
+  ///         Observable.fromIterable([5, 6]),
+  ///         Observable.fromIterable([6, 7]),
+  ///         (int a, int b, int c, int d, int e, int f) => a + b + c + d + e + f,
+  ///       )
+  ///       .listen(print); // prints 22 (due to the async nature of streams)
   Observable<R> withLatestFrom5<A, B, C, D, E, R>(
     Stream<A> latestFromStream1,
     Stream<B> latestFromStream2,
@@ -2672,18 +2718,27 @@ class Observable<T> extends Stream<T> {
       ));
 
   /// Creates an Observable that emits when the source stream emits, combining
-  /// the latest values from the two streams using the provided function.
+  /// the latest values from the seven streams using the provided function.
   ///
-  /// If the latestFromStream has not emitted any values, this stream will not
+  /// If any of latestFromStreams has not emitted any values, this stream will not
   /// emit either.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
   ///
   /// ### Example
   ///
-  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
-  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
-  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  ///     Observable.fromIterable([1, 2])
+  ///       .withLatestFrom6(
+  ///         Observable.fromIterable([2, 3]),
+  ///         Observable.fromIterable([3, 4]),
+  ///         Observable.fromIterable([4, 5]),
+  ///         Observable.fromIterable([5, 6]),
+  ///         Observable.fromIterable([6, 7]),
+  ///         Observable.fromIterable([7, 8]),
+  ///         (int a, int b, int c, int d, int e, int f, int g) =>
+  ///             a + b + c + d + e + f + g,
+  ///       )
+  ///       .listen(print); // prints 29 (due to the async nature of streams)
   Observable<R> withLatestFrom6<A, B, C, D, E, F, R>(
     Stream<A> latestFromStream1,
     Stream<B> latestFromStream2,
@@ -2704,18 +2759,28 @@ class Observable<T> extends Stream<T> {
       ));
 
   /// Creates an Observable that emits when the source stream emits, combining
-  /// the latest values from the two streams using the provided function.
+  /// the latest values from the eight streams using the provided function.
   ///
-  /// If the latestFromStream has not emitted any values, this stream will not
+  /// If any of latestFromStreams has not emitted any values, this stream will not
   /// emit either.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
   ///
   /// ### Example
   ///
-  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
-  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
-  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  ///     Observable.fromIterable([1, 2])
+  ///       .withLatestFrom7(
+  ///         Observable.fromIterable([2, 3]),
+  ///         Observable.fromIterable([3, 4]),
+  ///         Observable.fromIterable([4, 5]),
+  ///         Observable.fromIterable([5, 6]),
+  ///         Observable.fromIterable([6, 7]),
+  ///         Observable.fromIterable([7, 8]),
+  ///         Observable.fromIterable([8, 9]),
+  ///         (int a, int b, int c, int d, int e, int f, int g, int h) =>
+  ///             a + b + c + d + e + f + g + h,
+  ///       )
+  ///       .listen(print); // prints 37 (due to the async nature of streams)
   Observable<R> withLatestFrom7<A, B, C, D, E, F, G, R>(
     Stream<A> latestFromStream1,
     Stream<B> latestFromStream2,
@@ -2738,18 +2803,29 @@ class Observable<T> extends Stream<T> {
       ));
 
   /// Creates an Observable that emits when the source stream emits, combining
-  /// the latest values from the two streams using the provided function.
+  /// the latest values from the nine streams using the provided function.
   ///
-  /// If the latestFromStream has not emitted any values, this stream will not
+  /// If any of latestFromStreams has not emitted any values, this stream will not
   /// emit either.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
   ///
   /// ### Example
   ///
-  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
-  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
-  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  ///     Observable.fromIterable([1, 2])
+  ///       .withLatestFrom8(
+  ///         Observable.fromIterable([2, 3]),
+  ///         Observable.fromIterable([3, 4]),
+  ///         Observable.fromIterable([4, 5]),
+  ///         Observable.fromIterable([5, 6]),
+  ///         Observable.fromIterable([6, 7]),
+  ///         Observable.fromIterable([7, 8]),
+  ///         Observable.fromIterable([8, 9]),
+  ///         Observable.fromIterable([9, 10]),
+  ///         (int a, int b, int c, int d, int e, int f, int g, int h, int i) =>
+  ///             a + b + c + d + e + f + g + h + i,
+  ///       )
+  ///       .listen(print); // prints 46 (due to the async nature of streams)
   Observable<R> withLatestFrom8<A, B, C, D, E, F, G, H, R>(
     Stream<A> latestFromStream1,
     Stream<B> latestFromStream2,
@@ -2774,18 +2850,30 @@ class Observable<T> extends Stream<T> {
       ));
 
   /// Creates an Observable that emits when the source stream emits, combining
-  /// the latest values from the two streams using the provided function.
+  /// the latest values from the ten streams using the provided function.
   ///
-  /// If the latestFromStream has not emitted any values, this stream will not
+  /// If any of latestFromStreams has not emitted any values, this stream will not
   /// emit either.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
   ///
   /// ### Example
   ///
-  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
-  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
-  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  ///     Observable.fromIterable([1, 2])
+  ///       .withLatestFrom9(
+  ///         Observable.fromIterable([2, 3]),
+  ///         Observable.fromIterable([3, 4]),
+  ///         Observable.fromIterable([4, 5]),
+  ///         Observable.fromIterable([5, 6]),
+  ///         Observable.fromIterable([6, 7]),
+  ///         Observable.fromIterable([7, 8]),
+  ///         Observable.fromIterable([8, 9]),
+  ///         Observable.fromIterable([9, 10]),
+  ///         Observable.fromIterable([10, 11]),
+  ///         (int a, int b, int c, int d, int e, int f, int g, int h, int i, int j) =>
+  ///             a + b + c + d + e + f + g + h + i + j,
+  ///       )
+  ///       .listen(print); // prints 46 (due to the async nature of streams)
   Observable<R> withLatestFrom9<A, B, C, D, E, F, G, H, I, R>(
     Stream<A> latestFromStream1,
     Stream<B> latestFromStream2,

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -2564,7 +2564,252 @@ class Observable<T> extends Stream<T> {
   ///       .listen(print); // prints 4 (due to the async nature of streams)
   Observable<R> withLatestFrom<S, R>(
           Stream<S> latestFromStream, R fn(T t, S s)) =>
-      transform(WithLatestFromStreamTransformer<T, S, R>(latestFromStream, fn));
+      transform(WithLatestFromStreamTransformer.with1(latestFromStream, fn));
+
+  /// Creates an Observable that emits when the source stream emits, combining
+  /// the latest values from the two streams using the provided function.
+  ///
+  /// If the latestFromStream has not emitted any values, this stream will not
+  /// emit either.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
+  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
+  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  Observable<R> withLatestFrom2<A, B, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    R fn(T t, A a, B b),
+  ) =>
+      transform(WithLatestFromStreamTransformer.with2(
+          latestFromStream1, latestFromStream2, fn));
+
+  /// Creates an Observable that emits when the source stream emits, combining
+  /// the latest values from the two streams using the provided function.
+  ///
+  /// If the latestFromStream has not emitted any values, this stream will not
+  /// emit either.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
+  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
+  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  Observable<R> withLatestFrom3<A, B, C, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    R fn(T t, A a, B b, C c),
+  ) =>
+      transform(WithLatestFromStreamTransformer.with3(
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        fn,
+      ));
+
+  /// Creates an Observable that emits when the source stream emits, combining
+  /// the latest values from the two streams using the provided function.
+  ///
+  /// If the latestFromStream has not emitted any values, this stream will not
+  /// emit either.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
+  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
+  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  Observable<R> withLatestFrom4<A, B, C, D, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    R fn(T t, A a, B b, C c, D d),
+  ) =>
+      transform(WithLatestFromStreamTransformer.with4(
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        fn,
+      ));
+
+  /// Creates an Observable that emits when the source stream emits, combining
+  /// the latest values from the two streams using the provided function.
+  ///
+  /// If the latestFromStream has not emitted any values, this stream will not
+  /// emit either.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
+  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
+  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  Observable<R> withLatestFrom5<A, B, C, D, E, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    Stream<E> latestFromStream5,
+    R fn(T t, A a, B b, C c, D d, E e),
+  ) =>
+      transform(WithLatestFromStreamTransformer.with5(
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        latestFromStream5,
+        fn,
+      ));
+
+  /// Creates an Observable that emits when the source stream emits, combining
+  /// the latest values from the two streams using the provided function.
+  ///
+  /// If the latestFromStream has not emitted any values, this stream will not
+  /// emit either.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
+  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
+  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  Observable<R> withLatestFrom6<A, B, C, D, E, F, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    Stream<E> latestFromStream5,
+    Stream<F> latestFromStream6,
+    R fn(T t, A a, B b, C c, D d, E e, F f),
+  ) =>
+      transform(WithLatestFromStreamTransformer.with6(
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        latestFromStream5,
+        latestFromStream6,
+        fn,
+      ));
+
+  /// Creates an Observable that emits when the source stream emits, combining
+  /// the latest values from the two streams using the provided function.
+  ///
+  /// If the latestFromStream has not emitted any values, this stream will not
+  /// emit either.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
+  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
+  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  Observable<R> withLatestFrom7<A, B, C, D, E, F, G, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    Stream<E> latestFromStream5,
+    Stream<F> latestFromStream6,
+    Stream<G> latestFromStream7,
+    R fn(T t, A a, B b, C c, D d, E e, F f, G g),
+  ) =>
+      transform(WithLatestFromStreamTransformer.with7(
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        latestFromStream5,
+        latestFromStream6,
+        latestFromStream7,
+        fn,
+      ));
+
+  /// Creates an Observable that emits when the source stream emits, combining
+  /// the latest values from the two streams using the provided function.
+  ///
+  /// If the latestFromStream has not emitted any values, this stream will not
+  /// emit either.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
+  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
+  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  Observable<R> withLatestFrom8<A, B, C, D, E, F, G, H, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    Stream<E> latestFromStream5,
+    Stream<F> latestFromStream6,
+    Stream<G> latestFromStream7,
+    Stream<H> latestFromStream8,
+    R fn(T t, A a, B b, C c, D d, E e, F f, G g, H h),
+  ) =>
+      transform(WithLatestFromStreamTransformer.with8(
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        latestFromStream5,
+        latestFromStream6,
+        latestFromStream7,
+        latestFromStream8,
+        fn,
+      ));
+
+  /// Creates an Observable that emits when the source stream emits, combining
+  /// the latest values from the two streams using the provided function.
+  ///
+  /// If the latestFromStream has not emitted any values, this stream will not
+  /// emit either.
+  ///
+  /// [Interactive marble diagram](http://rxmarbles.com/#withLatestFrom)
+  ///
+  /// ### Example
+  ///
+  ///     new Observable.fromIterable([1, 2]).withLatestFrom(
+  ///       new Observable.fromIterable([2, 3]), (a, b) => a + b)
+  ///       .listen(print); // prints 4 (due to the async nature of streams)
+  Observable<R> withLatestFrom9<A, B, C, D, E, F, G, H, I, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    Stream<E> latestFromStream5,
+    Stream<F> latestFromStream6,
+    Stream<G> latestFromStream7,
+    Stream<H> latestFromStream8,
+    Stream<I> latestFromStream9,
+    R fn(T t, A a, B b, C c, D d, E e, F f, G g, H h, I i),
+  ) =>
+      transform(WithLatestFromStreamTransformer.with9(
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        latestFromStream5,
+        latestFromStream6,
+        latestFromStream7,
+        latestFromStream8,
+        latestFromStream9,
+        fn,
+      ));
 
   /// Returns an Observable that combines the current stream together with
   /// another stream using a given zipper function.

--- a/lib/src/observables/observable.dart
+++ b/lib/src/observables/observable.dart
@@ -2588,7 +2588,7 @@ class Observable<T> extends Stream<T> {
   ///
   Observable<List<T>> withLatestFromList(
           Iterable<Stream<T>> latestFromStreams) =>
-      transform(WithLatestFromStreamTransformer.list(latestFromStreams));
+      transform(WithLatestFromStreamTransformer.withList(latestFromStreams));
 
   /// Creates an Observable that emits when the source stream emits, combining
   /// the latest values from the three streams using the provided function.

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -25,7 +25,7 @@ class WithLatestFromStreamTransformer<T, S, R>
   @override
   Stream<R> bind(Stream<T> stream) => transformer.bind(stream);
 
-  static WithLatestFromStreamTransformer<T, T, List<T>> list<T>(
+  static WithLatestFromStreamTransformer<T, T, List<T>> withList<T>(
     Iterable<Stream<T>> latestFromStreams,
   ) {
     return WithLatestFromStreamTransformer<T, T, List<T>>(

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -346,7 +346,7 @@ class WithLatestFromStreamTransformer<T, S, R>
             (T value) {
               if (hasValues.every((hasValue) => hasValue)) {
                 try {
-                  controller.add(fn(value, latestValues));
+                  controller.add(fn(value, List.unmodifiable(latestValues)));
                 } catch (e, s) {
                   controller.addError(e, s);
                 }

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -356,15 +356,18 @@ class WithLatestFromStreamTransformer<T, S, R>
             onDone: onDone,
           );
 
-          for (var i = 0; i < len; i++) {
-            subscriptions[i] = latestFromStreams.elementAt(i).listen(
+          var index = 0;
+          for (final latestFromStream in latestFromStreams) {
+            final currentIndex = index;
+            subscriptions[index] = latestFromStream.listen(
               (latest) {
-                hasValues[i] = true;
-                latestValues[i] = latest;
+                hasValues[currentIndex] = true;
+                latestValues[currentIndex] = latest;
               },
               onError: controller.addError,
               cancelOnError: cancelOnError,
             );
+            index++;
           }
         },
         onPause: ([Future<dynamic> resumeSignal]) =>

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -18,54 +18,331 @@ class WithLatestFromStreamTransformer<T, S, R>
     extends StreamTransformerBase<T, R> {
   final StreamTransformer<T, R> transformer;
 
-  WithLatestFromStreamTransformer(Stream<S> latestFromStream, R fn(T t, S s))
-      : transformer = _buildTransformer(latestFromStream, fn);
+  WithLatestFromStreamTransformer(
+      Iterable<Stream<S>> latestFromStreams, R fn(T t, List<S> values))
+      : transformer = _buildTransformer(latestFromStreams, fn);
 
   @override
   Stream<R> bind(Stream<T> stream) => transformer.bind(stream);
 
+  static WithLatestFromStreamTransformer<T, T, List<T>> list<T>(
+    Iterable<Stream<T>> latestFromStreams,
+  ) {
+    return WithLatestFromStreamTransformer<T, T, List<T>>(
+      latestFromStreams,
+      (s, values) => [s]..addAll(values),
+    );
+  }
+
+  static WithLatestFromStreamTransformer<T, S, R> with1<T, S, R>(
+    Stream<S> latestFromStream,
+    R fn(T t, S s),
+  ) {
+    return WithLatestFromStreamTransformer<T, S, R>(
+      [latestFromStream],
+      (s, values) => fn(s, values[0]),
+    );
+  }
+
+  static WithLatestFromStreamTransformer<T, dynamic, R> with2<T, A, B, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    R fn(T t, A a, B b),
+  ) {
+    return WithLatestFromStreamTransformer<T, dynamic, R>(
+      [latestFromStream1, latestFromStream2],
+      (s, values) => fn(s, values[0] as A, values[1] as B),
+    );
+  }
+
+  static WithLatestFromStreamTransformer<T, dynamic, R> with3<T, A, B, C, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    R fn(T t, A a, B b, C c),
+  ) {
+    return WithLatestFromStreamTransformer<T, dynamic, R>(
+      [
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+      ],
+      (s, values) {
+        return fn(
+          s,
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+        );
+      },
+    );
+  }
+
+  static WithLatestFromStreamTransformer<T, dynamic, R> with4<T, A, B, C, D, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    R fn(T t, A a, B b, C c, D d),
+  ) {
+    return WithLatestFromStreamTransformer<T, dynamic, R>(
+      [
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+      ],
+      (s, values) {
+        return fn(
+          s,
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+        );
+      },
+    );
+  }
+
+  static WithLatestFromStreamTransformer<T, dynamic, R>
+      with5<T, A, B, C, D, E, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    Stream<E> latestFromStream5,
+    R fn(T t, A a, B b, C c, D d, E e),
+  ) {
+    return WithLatestFromStreamTransformer<T, dynamic, R>(
+      [
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        latestFromStream5,
+      ],
+      (s, values) {
+        return fn(
+          s,
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+        );
+      },
+    );
+  }
+
+  static WithLatestFromStreamTransformer<T, dynamic, R>
+      with6<T, A, B, C, D, E, F, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    Stream<E> latestFromStream5,
+    Stream<F> latestFromStream6,
+    R fn(T t, A a, B b, C c, D d, E e, F f),
+  ) {
+    return WithLatestFromStreamTransformer<T, dynamic, R>(
+      [
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        latestFromStream5,
+        latestFromStream6,
+      ],
+      (s, values) {
+        return fn(
+          s,
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+        );
+      },
+    );
+  }
+
+  static WithLatestFromStreamTransformer<T, dynamic, R>
+      with7<T, A, B, C, D, E, F, G, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    Stream<E> latestFromStream5,
+    Stream<F> latestFromStream6,
+    Stream<G> latestFromStream7,
+    R fn(T t, A a, B b, C c, D d, E e, F f, G g),
+  ) {
+    return WithLatestFromStreamTransformer<T, dynamic, R>(
+      [
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        latestFromStream5,
+        latestFromStream6,
+        latestFromStream7,
+      ],
+      (s, values) {
+        return fn(
+          s,
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+          values[6] as G,
+        );
+      },
+    );
+  }
+
+  static WithLatestFromStreamTransformer<T, dynamic, R>
+      with8<T, A, B, C, D, E, F, G, H, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    Stream<E> latestFromStream5,
+    Stream<F> latestFromStream6,
+    Stream<G> latestFromStream7,
+    Stream<H> latestFromStream8,
+    R fn(T t, A a, B b, C c, D d, E e, F f, G g, H h),
+  ) {
+    return WithLatestFromStreamTransformer<T, dynamic, R>(
+      [
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        latestFromStream5,
+        latestFromStream6,
+        latestFromStream7,
+        latestFromStream8,
+      ],
+      (s, values) {
+        return fn(
+          s,
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+          values[6] as G,
+          values[7] as H,
+        );
+      },
+    );
+  }
+
+  static WithLatestFromStreamTransformer<T, dynamic, R>
+      with9<T, A, B, C, D, E, F, G, H, I, R>(
+    Stream<A> latestFromStream1,
+    Stream<B> latestFromStream2,
+    Stream<C> latestFromStream3,
+    Stream<D> latestFromStream4,
+    Stream<E> latestFromStream5,
+    Stream<F> latestFromStream6,
+    Stream<G> latestFromStream7,
+    Stream<H> latestFromStream8,
+    Stream<I> latestFromStream9,
+    R fn(T t, A a, B b, C c, D d, E e, F f, G g, H h, I i),
+  ) {
+    return WithLatestFromStreamTransformer<T, dynamic, R>(
+      [
+        latestFromStream1,
+        latestFromStream2,
+        latestFromStream3,
+        latestFromStream4,
+        latestFromStream5,
+        latestFromStream6,
+        latestFromStream7,
+        latestFromStream8,
+        latestFromStream9,
+      ],
+      (s, values) {
+        return fn(
+          s,
+          values[0] as A,
+          values[1] as B,
+          values[2] as C,
+          values[3] as D,
+          values[4] as E,
+          values[5] as F,
+          values[6] as G,
+          values[7] as H,
+          values[8] as I,
+        );
+      },
+    );
+  }
+
   static StreamTransformer<T, R> _buildTransformer<T, S, R>(
-      Stream<S> latestFromStream, R fn(T t, S s)) {
-    if (latestFromStream == null) {
-      throw ArgumentError('latestFromStream cannot be null');
-    } else if (fn == null) {
+    Iterable<Stream<S>> latestFromStreams,
+    R fn(T t, List<S> values),
+  ) {
+    if (latestFromStreams == null) {
+      throw ArgumentError('latestFromStreams cannot be null');
+    }
+    if (latestFromStreams.any((s) => s == null)) {
+      throw ArgumentError('All streams must be not null');
+    }
+    if (fn == null) {
       throw ArgumentError('combiner cannot be null');
     }
 
     return StreamTransformer<T, R>((Stream<T> input, bool cancelOnError) {
+      final len = latestFromStreams.length;
       StreamController<R> controller;
       StreamSubscription<T> subscription;
-      StreamSubscription<S> latestFromSubscription;
-      S latestValue;
+      final subscriptions = List<StreamSubscription<S>>(len);
 
       controller = StreamController<R>(
           sync: true,
           onListen: () {
-            subscription = input.listen((T value) {
-              if (latestValue != null) {
-                try {
-                  controller.add(fn(value, latestValue));
-                } catch (e, s) {
-                  controller.addError(e, s);
-                }
-              }
-            }, onError: controller.addError);
+            final latestValues = List<S>(len);
 
-            latestFromSubscription = latestFromStream.listen((S latest) {
-              latestValue = latest;
-            },
-                onError: controller.addError,
-                onDone: controller.close,
-                cancelOnError: cancelOnError);
+            subscription = input.listen(
+              (T value) {
+                if (latestValues.every((v) => v != null)) {
+                  try {
+                    controller.add(fn(value, latestValues));
+                  } catch (e, s) {
+                    controller.addError(e, s);
+                  }
+                }
+              },
+              onError: controller.addError,
+            );
+
+            for (var i = 0; i < len; i++) {
+              subscriptions[i] = latestFromStreams.elementAt(i).listen(
+                    (S latest) => latestValues[i] = latest,
+                    onError: controller.addError,
+                    onDone: controller.close,
+                    cancelOnError: cancelOnError,
+                  );
+            }
           },
           onPause: ([Future<dynamic> resumeSignal]) =>
               subscription.pause(resumeSignal),
           onResume: () => subscription.resume(),
           onCancel: () {
-            return Future.wait<dynamic>(<Future<dynamic>>[
-              subscription.cancel(),
-              latestFromSubscription.cancel()
-            ].where((Future<dynamic> cancelFuture) => cancelFuture != null));
+            final list = List<StreamSubscription>.of(subscriptions)
+              ..add(subscription);
+
+            final cancelFutures = list
+                .map((subscription) => subscription.cancel())
+                .where((cancelFuture) => cancelFuture != null);
+
+            return Future.wait<dynamic>(cancelFutures);
           });
 
       return controller.stream.listen(null);

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -38,6 +38,9 @@ class WithLatestFromStreamTransformer<T, S, R>
     Stream<S> latestFromStream,
     R fn(T t, S s),
   ) {
+    if (fn == null) {
+      throw ArgumentError('Combiner cannot be null');
+    }
     return WithLatestFromStreamTransformer<T, S, R>(
       [latestFromStream],
       (s, values) => fn(s, values[0]),
@@ -49,6 +52,9 @@ class WithLatestFromStreamTransformer<T, S, R>
     Stream<B> latestFromStream2,
     R fn(T t, A a, B b),
   ) {
+    if (fn == null) {
+      throw ArgumentError('Combiner cannot be null');
+    }
     return WithLatestFromStreamTransformer<T, dynamic, R>(
       [latestFromStream1, latestFromStream2],
       (s, values) => fn(s, values[0] as A, values[1] as B),
@@ -61,6 +67,9 @@ class WithLatestFromStreamTransformer<T, S, R>
     Stream<C> latestFromStream3,
     R fn(T t, A a, B b, C c),
   ) {
+    if (fn == null) {
+      throw ArgumentError('Combiner cannot be null');
+    }
     return WithLatestFromStreamTransformer<T, dynamic, R>(
       [
         latestFromStream1,
@@ -85,6 +94,9 @@ class WithLatestFromStreamTransformer<T, S, R>
     Stream<D> latestFromStream4,
     R fn(T t, A a, B b, C c, D d),
   ) {
+    if (fn == null) {
+      throw ArgumentError('Combiner cannot be null');
+    }
     return WithLatestFromStreamTransformer<T, dynamic, R>(
       [
         latestFromStream1,
@@ -113,6 +125,9 @@ class WithLatestFromStreamTransformer<T, S, R>
     Stream<E> latestFromStream5,
     R fn(T t, A a, B b, C c, D d, E e),
   ) {
+    if (fn == null) {
+      throw ArgumentError('Combiner cannot be null');
+    }
     return WithLatestFromStreamTransformer<T, dynamic, R>(
       [
         latestFromStream1,
@@ -144,6 +159,9 @@ class WithLatestFromStreamTransformer<T, S, R>
     Stream<F> latestFromStream6,
     R fn(T t, A a, B b, C c, D d, E e, F f),
   ) {
+    if (fn == null) {
+      throw ArgumentError('Combiner cannot be null');
+    }
     return WithLatestFromStreamTransformer<T, dynamic, R>(
       [
         latestFromStream1,
@@ -178,6 +196,9 @@ class WithLatestFromStreamTransformer<T, S, R>
     Stream<G> latestFromStream7,
     R fn(T t, A a, B b, C c, D d, E e, F f, G g),
   ) {
+    if (fn == null) {
+      throw ArgumentError('Combiner cannot be null');
+    }
     return WithLatestFromStreamTransformer<T, dynamic, R>(
       [
         latestFromStream1,
@@ -215,6 +236,9 @@ class WithLatestFromStreamTransformer<T, S, R>
     Stream<H> latestFromStream8,
     R fn(T t, A a, B b, C c, D d, E e, F f, G g, H h),
   ) {
+    if (fn == null) {
+      throw ArgumentError('Combiner cannot be null');
+    }
     return WithLatestFromStreamTransformer<T, dynamic, R>(
       [
         latestFromStream1,
@@ -255,6 +279,9 @@ class WithLatestFromStreamTransformer<T, S, R>
     Stream<I> latestFromStream9,
     R fn(T t, A a, B b, C c, D d, E e, F f, G g, H h, I i),
   ) {
+    if (fn == null) {
+      throw ArgumentError('Combiner cannot be null');
+    }
     return WithLatestFromStreamTransformer<T, dynamic, R>(
       [
         latestFromStream1,

--- a/test/transformers/with_latest_from_test.dart
+++ b/test/transformers/with_latest_from_test.dart
@@ -31,7 +31,7 @@ void main() {
   });
 
   test('rx.Observable.withLatestFrom.reusable', () async {
-    final transformer = WithLatestFromStreamTransformer<int, int, Pair>(
+    final transformer = WithLatestFromStreamTransformer.with1<int, int, Pair>(
         _getLatestFromStream().asBroadcastStream(),
         (first, second) => Pair(first, second));
     const expectedOutput = [
@@ -86,12 +86,12 @@ void main() {
         throwsArgumentError);
   });
 
-  test('rx.Observable.withLatestFrom.error.shouldThrowC', () {
-    expect(
-        () => Observable(_getStream())
-            .withLatestFrom<int, void>(_getLatestFromStream(), null),
-        throwsArgumentError);
-  });
+  // test('rx.Observable.withLatestFrom.error.shouldThrowC', () {
+  //   expect(
+  //       () => Observable(_getStream())
+  //           .withLatestFrom<int, void>(_getLatestFromStream(), null),
+  //       throwsArgumentError);
+  // });
 
   test('rx.Observable.withLatestFrom.pause.resume', () async {
     StreamSubscription<Pair> subscription;

--- a/test/transformers/with_latest_from_test.dart
+++ b/test/transformers/with_latest_from_test.dart
@@ -10,6 +10,16 @@ Stream<int> _getStream() =>
 Stream<int> _getLatestFromStream() =>
     Stream.periodic(const Duration(milliseconds: 50), (count) => count).take(4);
 
+Stream<int> _getLatestFromStream2() =>
+    Stream.periodic(const Duration(milliseconds: 30), (count) => count).take(5);
+
+Stream<int> _getLatestFromStream3() =>
+    Stream.periodic(const Duration(milliseconds: 40), (count) => count).take(2);
+
+Stream<int> _getLatestFromStream4() =>
+    Stream.periodic(const Duration(milliseconds: 60), (count) => count)
+        .take(10);
+
 void main() {
   test('rx.Observable.withLatestFrom', () async {
     const expectedOutput = [
@@ -86,12 +96,12 @@ void main() {
         throwsArgumentError);
   });
 
-  // test('rx.Observable.withLatestFrom.error.shouldThrowC', () {
-  //   expect(
-  //       () => Observable(_getStream())
-  //           .withLatestFrom<int, void>(_getLatestFromStream(), null),
-  //       throwsArgumentError);
-  // });
+  test('rx.Observable.withLatestFrom.error.shouldThrowC', () {
+    expect(
+        () => Observable(_getStream())
+            .withLatestFrom<int, void>(_getLatestFromStream(), null),
+        throwsArgumentError);
+  });
 
   test('rx.Observable.withLatestFrom.pause.resume', () async {
     StreamSubscription<Pair> subscription;
@@ -112,6 +122,256 @@ void main() {
 
     subscription.pause();
     subscription.resume();
+  });
+
+  test('rx.Observable.withLatestFrom.otherEmitsNull', () async {
+    const expected = Pair(1, null);
+    final observable = Observable.timer(
+      1,
+      const Duration(microseconds: 100),
+    ).withLatestFrom(
+      Observable<int>.just(null),
+      (a, int b) => Pair(a, b),
+    );
+
+    await expectLater(
+      observable,
+      emits(expected),
+    );
+  });
+
+  test('rx.Observable.withLatestFrom.otherNotEmit', () async {
+    final observable = Observable.timer(
+      1,
+      const Duration(microseconds: 100),
+    ).withLatestFrom(
+      Observable<int>.empty(),
+      (a, int b) => Pair(a, b),
+    );
+
+    await expectLater(
+      observable,
+      emitsDone,
+    );
+  });
+
+  test('rx.Observable.withLatestFrom2', () async {
+    const expectedOutput = [
+      _Tuple(2, 0, 1),
+      _Tuple(3, 0, 1),
+      _Tuple(4, 1, 2),
+      _Tuple(5, 1, 3),
+      _Tuple(6, 2, 4),
+    ];
+    var count = 0;
+
+    Observable(_getStream())
+        .withLatestFrom2(
+          _getLatestFromStream(),
+          _getLatestFromStream2(),
+          (item1, int item2, int item3) => _Tuple(item1, item2, item3),
+        )
+        .take(5)
+        .listen(
+          expectAsync1(
+            (result) => expect(result, expectedOutput[count++]),
+            count: expectedOutput.length,
+          ),
+        );
+  });
+
+  test('rx.Observable.withLatestFrom3', () async {
+    const expectedOutput = [
+      _Tuple(2, 0, 1, 0),
+      _Tuple(3, 0, 1, 1),
+      _Tuple(4, 1, 2, 1),
+      _Tuple(5, 1, 3, 1),
+      _Tuple(6, 2, 4, 1),
+    ];
+    var count = 0;
+
+    Observable(_getStream())
+        .withLatestFrom3(
+          _getLatestFromStream(),
+          _getLatestFromStream2(),
+          _getLatestFromStream3(),
+          (item1, int item2, int item3, int item4) =>
+              _Tuple(item1, item2, item3, item4),
+        )
+        .take(5)
+        .listen(
+          expectAsync1(
+            (result) => expect(result, expectedOutput[count++]),
+            count: expectedOutput.length,
+          ),
+        );
+  });
+
+  test('rx.Observable.withLatestFrom4', () async {
+    const expectedOutput = [
+      _Tuple(2, 0, 1, 0, 0),
+      _Tuple(3, 0, 1, 1, 0),
+      _Tuple(4, 1, 2, 1, 0),
+      _Tuple(5, 1, 3, 1, 1),
+      _Tuple(6, 2, 4, 1, 1),
+    ];
+    var count = 0;
+
+    Observable(_getStream())
+        .withLatestFrom4(
+          _getLatestFromStream(),
+          _getLatestFromStream2(),
+          _getLatestFromStream3(),
+          _getLatestFromStream4(),
+          (item1, int item2, int item3, int item4, int item5) =>
+              _Tuple(item1, item2, item3, item4, item5),
+        )
+        .take(5)
+        .listen(
+          expectAsync1(
+            (result) => expect(result, expectedOutput[count++]),
+            count: expectedOutput.length,
+          ),
+        );
+  });
+
+  test('rx.Observable.withLatestFrom5', () async {
+    final observable = Observable.timer(
+      1,
+      const Duration(microseconds: 100),
+    ).withLatestFrom5(
+      Observable.just(2),
+      Observable.just(3),
+      Observable.just(4),
+      Observable.just(5),
+      Observable.just(6),
+      (a, int b, int c, int d, int e, int f) => _Tuple(a, b, c, d, e, f),
+    );
+    const expected = _Tuple(1, 2, 3, 4, 5, 6);
+
+    await expectLater(
+      observable,
+      emits(expected),
+    );
+  });
+
+  test('rx.Observable.withLatestFrom6', () async {
+    final observable = Observable.timer(
+      1,
+      const Duration(microseconds: 100),
+    ).withLatestFrom6(
+      Observable.just(2),
+      Observable.just(3),
+      Observable.just(4),
+      Observable.just(5),
+      Observable.just(6),
+      Observable.just(7),
+      (a, int b, int c, int d, int e, int f, int g) =>
+          _Tuple(a, b, c, d, e, f, g),
+    );
+    const expected = _Tuple(1, 2, 3, 4, 5, 6, 7);
+
+    await expectLater(
+      observable,
+      emits(expected),
+    );
+  });
+
+  test('rx.Observable.withLatestFrom7', () async {
+    final observable = Observable.timer(
+      1,
+      const Duration(microseconds: 100),
+    ).withLatestFrom7(
+      Observable.just(2),
+      Observable.just(3),
+      Observable.just(4),
+      Observable.just(5),
+      Observable.just(6),
+      Observable.just(7),
+      Observable.just(8),
+      (a, int b, int c, int d, int e, int f, int g, int h) =>
+          _Tuple(a, b, c, d, e, f, g, h),
+    );
+    const expected = _Tuple(1, 2, 3, 4, 5, 6, 7, 8);
+
+    await expectLater(
+      observable,
+      emits(expected),
+    );
+  });
+
+  test('rx.Observable.withLatestFrom8', () async {
+    final observable = Observable.timer(
+      1,
+      const Duration(microseconds: 100),
+    ).withLatestFrom8(
+      Observable.just(2),
+      Observable.just(3),
+      Observable.just(4),
+      Observable.just(5),
+      Observable.just(6),
+      Observable.just(7),
+      Observable.just(8),
+      Observable.just(9),
+      (a, int b, int c, int d, int e, int f, int g, int h, int i) =>
+          _Tuple(a, b, c, d, e, f, g, h, i),
+    );
+    const expected = _Tuple(1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+    await expectLater(
+      observable,
+      emits(expected),
+    );
+  });
+
+  test('rx.Observable.withLatestFrom9', () async {
+    final observable = Observable.timer(
+      1,
+      const Duration(microseconds: 100),
+    ).withLatestFrom9(
+      Observable.just(2),
+      Observable.just(3),
+      Observable.just(4),
+      Observable.just(5),
+      Observable.just(6),
+      Observable.just(7),
+      Observable.just(8),
+      Observable.just(9),
+      Observable.just(10),
+      (a, int b, int c, int d, int e, int f, int g, int h, int i, int j) =>
+          _Tuple(a, b, c, d, e, f, g, h, i, j),
+    );
+    const expected = _Tuple(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+    await expectLater(
+      observable,
+      emits(expected),
+    );
+  });
+
+  test('rx.Observable.withLatestFromList', () async {
+    final observable = Observable.timer(
+      1,
+      const Duration(microseconds: 100),
+    ).withLatestFromList(
+      [
+        Observable.just(2),
+        Observable.just(3),
+        Observable.just(4),
+        Observable.just(5),
+        Observable.just(6),
+        Observable.just(7),
+        Observable.just(8),
+        Observable.just(9),
+        Observable.just(10),
+      ],
+    );
+    const expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+    await expectLater(
+      observable,
+      emits(expected),
+    );
   });
 }
 
@@ -139,5 +399,79 @@ class Pair {
   @override
   String toString() {
     return 'Pair{first: $first, second: $second}';
+  }
+}
+
+class _Tuple {
+  final int item1;
+  final int item2;
+  final int item3;
+  final int item4;
+  final int item5;
+  final int item6;
+  final int item7;
+  final int item8;
+  final int item9;
+  final int item10;
+
+  const _Tuple([
+    this.item1,
+    this.item2,
+    this.item3,
+    this.item4,
+    this.item5,
+    this.item6,
+    this.item7,
+    this.item8,
+    this.item9,
+    this.item10,
+  ]);
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        other is _Tuple &&
+            this.item1 == other.item1 &&
+            this.item2 == other.item2 &&
+            this.item3 == other.item3 &&
+            this.item4 == other.item4 &&
+            this.item5 == other.item5 &&
+            this.item6 == other.item6 &&
+            this.item7 == other.item7 &&
+            this.item8 == other.item8 &&
+            this.item9 == other.item9 &&
+            this.item10 == other.item10;
+  }
+
+  @override
+  int get hashCode {
+    return this.item1.hashCode ^
+        this.item2.hashCode ^
+        this.item3.hashCode ^
+        this.item4.hashCode ^
+        this.item5.hashCode ^
+        this.item6.hashCode ^
+        this.item7.hashCode ^
+        this.item8.hashCode ^
+        this.item9.hashCode ^
+        this.item10.hashCode;
+  }
+
+  @override
+  String toString() {
+    final values = [
+      item1,
+      item2,
+      item3,
+      item4,
+      item5,
+      item6,
+      item7,
+      item8,
+      item9,
+      item10,
+    ];
+    final s = values.join(', ');
+    return 'Tuple { $s }';
   }
 }

--- a/test/transformers/with_latest_from_test.dart
+++ b/test/transformers/with_latest_from_test.dart
@@ -373,6 +373,22 @@ void main() {
       emits(expected),
     );
   });
+
+  test('rx.Observable.withLatestFromList.emptyList', () async {
+    final observable =
+        Observable.fromIterable([1, 2, 3]).withLatestFromList([]);
+
+    await expectLater(
+      observable,
+      emitsInOrder(
+        <List<int>>[
+          [1],
+          [2],
+          [3],
+        ],
+      ),
+    );
+  });
 }
 
 class Pair {


### PR DESCRIPTION
#300 
- Currently, `withLatestFrom` takes only one stream as an argument. Adds `withLatestFrom` for two, three or more streams, or list of streams.
- Add methods for `Observable`:
  - `Observable.withLatestFrom2`
  - ...
  - `Observable.withLatestFrom9`
  - `Observable.withLatestFromList`
- Add static methods for `WithLatestFromStreamTransformer`:
  - `WithLatestFromStreamTransformer.with1`
  - ...
  - `WithLatestFromStreamTransformer.with9`
  - `WithLatestFromStreamTransformer.withList`