### PR TITLE
switchIfEmpty: close stream when errored

### DIFF
--- a/lib/src/transformers/switch_if_empty.dart
+++ b/lib/src/transformers/switch_if_empty.dart
@@ -60,7 +60,10 @@ class SwitchIfEmptyStreamTransformer<T> extends StreamTransformerBase<T, T> {
                   hasEvent = true;
                   controller.add(value);
                 },
-                onError: controller.addError,
+                onError: (Object err, [StackTrace stacktrace]) {
+                  hasEvent = true;
+                  controller.addError(err, stacktrace);
+                },
                 onDone: () {
                   if (hasEvent) {
                     controller.close();

--- a/test/transformers/switch_if_empty_test.dart
+++ b/test/transformers/switch_if_empty_test.dart
@@ -60,7 +60,7 @@ void main() {
     final observableWithError = Observable(ErrorStream<int>(Exception()))
         .switchIfEmpty(Observable.just(1));
 
-    observableWithError.listen(null,
+    observableWithError.listen((data) => expect(true, false),
         onError: expectAsync2((Exception e, StackTrace s) {
       expect(e, isException);
     }));


### PR DESCRIPTION
Hi,

the behavior of switchIfEmpty doesn't handle exceptions in the stream: when an exception is thrown, you receive an error but you **also** get the fallback value. I'm not too much into ReactiveX, but the following code works in RxJava:

```kotlin
val observer = TestObserver<Int>()
Observable
        .error<Int>(RuntimeException())
        .switchIfEmpty(Observable.just(1))
        .subscribe(observer)

observer.assertNoValues()
observer.assertError(RuntimeException::class.java)
```

But it doesn't work in rxdart.

PS: Is there an `assert(false)` in Dart? `expect(true, false)` does the job, but …