### PR TITLE
export StreamSubscription

### DIFF
--- a/lib/rxdart.dart
+++ b/lib/rxdart.dart
@@ -1,5 +1,7 @@
 library rx;
 
+export 'dart:async' show StreamSubscription;
+
 export 'package:rxdart/futures.dart';
 export 'package:rxdart/src/observables/connectable_observable.dart';
 export 'package:rxdart/src/observables/observable.dart';
@@ -9,5 +11,3 @@ export 'package:rxdart/streams.dart';
 export 'package:rxdart/subjects.dart';
 export 'package:rxdart/transformers.dart';
 export 'package:rxdart/src/utils/composite_subscription.dart';
-
-export 'dart:async' show StreamSubscription;

--- a/lib/rxdart.dart
+++ b/lib/rxdart.dart
@@ -9,3 +9,5 @@ export 'package:rxdart/streams.dart';
 export 'package:rxdart/subjects.dart';
 export 'package:rxdart/transformers.dart';
 export 'package:rxdart/src/utils/composite_subscription.dart';
+
+export 'dart:async' show StreamSubscription;


### PR DESCRIPTION
Hi there, instead of making an issue I just made a lite-PR. I'm always importing StreamSubscription to manage subscriptions and I'm wondering if we should just export it in rxdart. Thoughts?