### PR TITLE
switchMap: controller closes prematurely

### DIFF
--- a/lib/src/transformers/switch_map.dart
+++ b/lib/src/transformers/switch_map.dart
@@ -42,6 +42,9 @@ class SwitchMapStreamTransformer<T, S> extends StreamTransformerBase<T, S> {
                   try {
                     otherSubscription?.cancel();
 
+                    // Since we start a new listener on mapper(value),
+                    // this state needs to be set to false again.
+                    rightClosed = false;
                     hasMainEvent = true;
 
                     otherSubscription = mapper(value).listen(controller.add,

--- a/test/transformers/switch_map_test.dart
+++ b/test/transformers/switch_map_test.dart
@@ -119,4 +119,18 @@ void main() {
     subscription.pause();
     subscription.resume();
   });
+
+  test('rx.Observable.switchMap stream close after switch', () async {
+    final controller = StreamController<int>();
+
+    Observable(controller.stream)
+        .switchMap((it) => Stream.fromIterable([it, it]))
+        .toList();
+
+    controller.add(1);
+    await Future<void>.delayed(Duration(microseconds: 1));
+    controller.add(2);
+
+    await controller.close();
+  });
 }


### PR DESCRIPTION
As observed here: https://github.com/ReactiveX/rxdart/issues/345

We keep a `rightClosed` flag, which switches to `true` once the secondary `Stream` closes.
However when the primary `Stream` fires a new `event`, causing a new `listen` on a secondary `Stream`, this flag is not being reset to `false`.