### PR TITLE
Fix DeferStream: make streamFactory is called when DeferStream is listened to

### DIFF
--- a/lib/src/streams/defer.dart
+++ b/lib/src/streams/defer.dart
@@ -23,11 +23,10 @@ class DeferStream<T> extends Stream<T> {
   DeferStream(Stream<T> streamFactory(), {bool reusable = false})
       : _isReusable = reusable,
         _factory = reusable
-            ? (() => streamFactory())
+            ? streamFactory
             : (() {
-                final stream = streamFactory();
-
-                return () => stream;
+                Stream<T> stream;
+                return () => stream ??= streamFactory();
               }());
 
   @override

--- a/test/streams/defer_test.dart
+++ b/test/streams/defer_test.dart
@@ -28,6 +28,28 @@ void main() {
     }, count: 1));
   });
 
+  test('rx.Observable.defer.streamFactory.called', () async {
+    var count = 0;
+
+    streamFactory() {
+      ++count;
+      return Observable.just(1);
+    }
+
+    var deferStream = DeferStream(
+      streamFactory,
+      reusable: false,
+    );
+
+    expect(count, 0);
+
+    deferStream.listen(
+      expectAsync1((_) {
+        expect(count, 1);
+      }),
+    );
+  });
+
   test('rx.Observable.defer.reusable', () async {
     const value = 1;
 

--- a/test/streams/defer_test.dart
+++ b/test/streams/defer_test.dart
@@ -28,14 +28,42 @@ void main() {
     }, count: 1));
   });
 
+  test('rx.Observable.defer.reusable', () async {
+    const value = 1;
+
+    final observable = Observable.defer(
+      () => Stream.fromFuture(
+        Future.delayed(
+          Duration(seconds: 1),
+          () => value,
+        ),
+      ),
+      reusable: true,
+    );
+
+    observable.listen(
+      expectAsync1(
+        (actual) => expect(actual, value),
+        count: 1,
+      ),
+    );
+    observable.listen(
+      expectAsync1(
+        (actual) => expect(actual, value),
+        count: 1,
+      ),
+    );
+  });
+
   test('rx.Observable.defer.single.subscription', () async {
     final observable = _getDeferStream();
 
     try {
       observable.listen(null);
       observable.listen(null);
+      expect(true, false);
     } catch (e) {
-      await expectLater(e, isStateError);
+      expect(e, isStateError);
     }
   });
 


### PR DESCRIPTION
Fix #360 
Similar #358 
- Bug: `streamFactory` param is called immediately in constructor
- Expected behavior: `streamFactory` should be called when stream is listened to