### PR TITLE
[Simplify implementation] concatWith, mergeWith, zipWith

### DIFF
--- a/lib/src/streams/concat.dart
+++ b/lib/src/streams/concat.dart
@@ -93,6 +93,5 @@ extension ConcatExtensions<T> on Stream<T> {
   ///         .concatWith([Stream.fromIterable([2])])
   ///         .listen(print); // prints 1, 2
   Stream<T> concatWith(Iterable<Stream<T>> other) =>
-      transform(StreamTransformer.fromBind(
-          (stream) => ConcatStream<T>([stream, ...other])));
+      ConcatStream<T>([this, ...other]);
 }

--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -81,6 +81,5 @@ extension MergeExtension<T> on Stream<T> {
   ///         .mergeWith([Stream.fromIterable([2])])
   ///         .listen(print); // prints 2, 1
   Stream<T> mergeWith(Iterable<Stream<T>> streams) =>
-      transform(StreamTransformer.fromBind(
-          (stream) => MergeStream<T>([stream, ...streams])));
+      MergeStream<T>([this, ...streams]);
 }

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -381,6 +381,5 @@ extension ZipWithExtension<T> on Stream<T> {
   ///         .zipWith(Stream.fromIterable([2]), (one, two) => one + two)
   ///         .listen(print); // prints 3
   Stream<R> zipWith<S, R>(Stream<S> other, R Function(T t, S s) zipper) =>
-      transform(StreamTransformer.fromBind(
-          (stream) => ZipStream.zip2(stream, other, zipper)));
+      ZipStream.zip2(this, other, zipper);
 }


### PR DESCRIPTION
Remove StreamTransformer.fromBind, return Stream directly