### PR TITLE
issue/389

### DIFF
--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -176,28 +176,29 @@ class DoStreamTransformer<T> extends StreamTransformerBase<T, T> {
 
         controller.close();
       };
+      final onListenDelegate = () {
+        var localEventIndex = 0;
+
+        streamEventIndex[input] = 0;
+
+        if (onListen != null) {
+          try {
+            onListen();
+          } catch (e, s) {
+            controller.addError(e, s);
+          }
+        }
+
+        subscription = input.listen(
+            (event) => onDataHandler(event, localEventIndex++, input),
+            onError: onErrorHandler,
+            onDone: onDoneHandler,
+            cancelOnError: cancelOnError);
+      };
 
       controller = StreamController<T>(
-          sync: true,
-          onListen: () {
-            var eventIndex = 0;
-
-            streamEventIndex[input] = 0;
-
-            if (onListen != null) {
-              try {
-                onListen();
-              } catch (e, s) {
-                controller.addError(e, s);
-              }
-            }
-
-            subscription = input.listen(
-                (event) => onDataHandler(event, eventIndex++, input),
-                onError: onErrorHandler,
-                onDone: onDoneHandler,
-                cancelOnError: cancelOnError);
-          },
+          sync: false,
+          onListen: onListenDelegate,
           onPause: ([Future<dynamic> resumeSignal]) {
             subscription.pause(resumeSignal);
 

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -185,16 +185,16 @@ class DoStreamTransformer<T> extends StreamTransformerBase<T, T> {
         }
 
         // checks if this input Stream is already handling onX...
-        final isOnDataHandled = onDataManifest.contains(input);
+        final isOnXHandled = onDataManifest.contains(input);
+        final maybeOnData = isOnXHandled ? null : onData;
+        final maybeOnError = isOnXHandled ? null : onError;
+        final maybeOnDone = isOnXHandled ? null : onDone;
+        final maybeOnEach = isOnXHandled ? null : onEach;
         // ...and if it does, pass null handlers to the onX handler,
         // resulting in this onX pass to be ignored
-        subscription = input.listen(
-            onDataHandler(isOnDataHandled ? null : onData,
-                isOnDataHandled ? null : onEach),
-            onError: onErrorHandler(isOnDataHandled ? null : onError,
-                isOnDataHandled ? null : onEach),
-            onDone: onDoneHandler(isOnDataHandled ? null : onDone,
-                isOnDataHandled ? null : onEach),
+        subscription = input.listen(onDataHandler(maybeOnData, maybeOnEach),
+            onError: onErrorHandler(maybeOnError, maybeOnEach),
+            onDone: onDoneHandler(maybeOnDone, maybeOnEach),
             cancelOnError: cancelOnError);
 
         // because we want to prevent duplicate onX handling

--- a/lib/src/utils/notification.dart
+++ b/lib/src/utils/notification.dart
@@ -32,7 +32,7 @@ class Notification<T> {
   /// Constructs a [Notification] which, depending on the [kind], wraps either
   /// [value], or [error] and [stackTrace], or neither if it is just a
   /// [Kind.OnData] event.
-  Notification(this.kind, this.value, this.error, this.stackTrace);
+  const Notification(this.kind, this.value, this.error, this.stackTrace);
 
   /// Constructs a [Notification] with [Kind.OnData] and wraps a [value]
   factory Notification.onData(T value) =>
@@ -40,7 +40,7 @@ class Notification<T> {
 
   /// Constructs a [Notification] with [Kind.OnDone]
   factory Notification.onDone() =>
-      Notification<T>(Kind.OnDone, null, null, null);
+      const Notification(Kind.OnDone, null, null, null);
 
   /// Constructs a [Notification] with [Kind.OnError] and wraps an [error] and [stackTrace]
   factory Notification.onError(dynamic error, StackTrace stackTrace) =>

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -198,13 +198,10 @@ void main() {
       final streamA = Stream.value(1).transform(transformer),
           streamB = Stream.value(1).transform(transformer);
 
-      streamA.listen(null, onDone: expectAsync0(() {
-        expect(callCount, 2);
-      }));
+      await expectLater(streamA, emitsInOrder(<dynamic>[1, emitsDone]));
+      await expectLater(streamB, emitsInOrder(<dynamic>[1, emitsDone]));
 
-      streamB.listen(null, onDone: expectAsync0(() {
-        expect(callCount, 2);
-      }));
+      expect(callCount, 2);
     });
 
     test('throws an error when no arguments are provided', () {
@@ -248,8 +245,8 @@ void main() {
                 ..cancel();
         },
         onError: expectAsync2(
-          (Exception e, [StackTrace s]) => expect(e, isException),
-        ),
+            (Exception e, [StackTrace s]) => expect(e, isException),
+            count: 2),
       );
 
       Stream.value(1)
@@ -290,20 +287,6 @@ void main() {
     });
 
     test(
-        'doOnListen correctly throws when subscribing multiple times on a single subscription stream',
-        () {
-      final controller = StreamController<int>();
-      final stream = controller.stream.doOnListen(() {
-        // do nothing
-      });
-
-      expectLater(stream, emitsDone);
-      expectLater(stream, emitsError(TypeMatcher<StateError>()));
-
-      controller.close();
-    });
-
-    test(
         'doOnListen correctly allows subscribing multiple times on a broadcast stream',
         () {
       final controller = StreamController<int>.broadcast();
@@ -311,10 +294,10 @@ void main() {
         // do nothing
       });
 
-      expectLater(stream, emitsDone);
-      expectLater(stream, emitsDone);
-
       controller.close();
+
+      expectLater(stream, emitsDone);
+      expectLater(stream, emitsDone);
     });
   });
 }

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -288,5 +288,33 @@ void main() {
             ..pause()
             ..resume();
     });
+
+    test(
+        'doOnListen correctly throws when subscribing multiple times on a single subscription stream',
+        () {
+      final controller = StreamController<int>();
+      final stream = controller.stream.doOnListen(() {
+        // do nothing
+      });
+
+      expectLater(stream, emitsDone);
+      expectLater(stream, emitsError(TypeMatcher<StateError>()));
+
+      controller.close();
+    });
+
+    test(
+        'doOnListen correctly allows subscribing multiple times on a broadcast stream',
+        () {
+      final controller = StreamController<int>.broadcast();
+      final stream = controller.stream.doOnListen(() {
+        // do nothing
+      });
+
+      expectLater(stream, emitsDone);
+      expectLater(stream, emitsDone);
+
+      controller.close();
+    });
   });
 }


### PR DESCRIPTION
@brianegan see https://github.com/ReactiveX/rxdart/issues/389

My fix looks very, very hacky, maybe we should think about a different approach for `doOnListen`?

- rewrites the subscribe time, so that single subscription Streams throw correctly when listening multiple times.
- for broadcast Streams, introduce a *dummy* listener, which allows external listeners to receive events correctly.

For the latter, this is the test that fails with our current master, but works when using the dummy approach:

```
test(
        'doOnListen correctly allows subscribing multiple times on a broadcast stream',
        () {
      final controller = StreamController<int>.broadcast();
      final stream = controller.stream.doOnListen(() {
        // do nothing
      });

      expectLater(stream, emitsDone);
      expectLater(stream, emitsDone);

      controller.close();
    });
```