### PR TITLE
Add error and hasError to BehaviorSubject

### DIFF
--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -170,6 +170,12 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
 
   @override
   bool get hasValue => _subject.hasValue;
+
+  @override
+  Object get error => _subject.error;
+
+  @override
+  bool get hasError => _subject.hasError;
 }
 
 /// A [ConnectableStream] that converts a single-subscription Stream into

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -6,4 +6,11 @@ abstract class ValueStream<T> implements Stream<T> {
 
   /// A flag that turns true as soon as at least one event has been emitted.
   bool get hasValue;
+
+  /// Last emitted error, or null if no error added or value exists.
+  /// See [hasError]
+  Object get error;
+
+  /// A flag that turns true as soon as at an error event has been emitted.
+  bool get hasError;
 }

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -133,6 +133,12 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
 
   /// Set and emit the new value
   set value(T newValue) => add(newValue);
+
+  /// A flag that turns true as soon as at an error event has been emitted.
+  bool get hasError => _wrapper.latestIsError;
+
+  /// Get the latest error emitted by the Subject
+  Object get error => _wrapper.latestError;
 }
 
 class _Wrapper<T> {

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -134,10 +134,11 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   /// Set and emit the new value
   set value(T newValue) => add(newValue);
 
-  /// A flag that turns true as soon as at an error event has been emitted.
+  @override
   bool get hasError => _wrapper.latestIsError;
 
   /// Get the latest error emitted by the Subject
+  @override
   Object get error => _wrapper.latestError;
 }
 

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -142,6 +142,26 @@ void main() {
       }, count: items.length));
     });
 
+    test('provides access to the latest error', () async {
+      final source = StreamController<int>();
+      final stream = ValueConnectableStream(source.stream).autoConnect();
+
+      source.sink.add(1);
+      source.sink.add(2);
+      source.sink.add(3);
+      source.sink.addError(Exception('error'));
+
+      stream.listen(
+        null,
+        onError: (Object error) {
+          expect(stream.value, isNull);
+          expect(stream.hasValue, isFalse);
+          expect(stream.error, error);
+          expect(stream.hasError, isTrue);
+        },
+      );
+    });
+
     test('provide a function to autoconnect that stops listening', () async {
       final stream = Stream.fromIterable(const [1, 2, 3])
           .publishValue()

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -515,6 +515,118 @@ void main() {
       expect(subject.hasValue, isTrue);
     });
 
+    test('hasError returns false for an empty subject', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>();
+
+      expect(subject.hasError, isFalse);
+    });
+
+    test('hasError returns false for a seeded subject with non-null seed', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>.seeded(1);
+
+      expect(subject.hasError, isFalse);
+    });
+
+    test('hasError returns false for a seeded subject with null seed', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>.seeded(null);
+
+      expect(subject.hasError, isFalse);
+    });
+
+    test('hasError returns false for an unseeded subject after an emission', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>();
+
+      subject.add(1);
+
+      expect(subject.hasError, isFalse);
+    });
+
+    test('hasError returns true for an unseeded subject after addError', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>();
+
+      subject.add(1);
+      subject.addError('error');
+
+      expect(subject.hasError, isTrue);
+    });
+
+    test('hasError returns true for a seeded subject after addError', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>.seeded(1);
+
+      subject.addError('error');
+
+      expect(subject.hasError, isTrue);
+    });
+
+    test('error returns null for an empty subject', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>();
+
+      expect(subject.error, isNull);
+    });
+
+    test('error returns null for a seeded subject with non-null seed', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>.seeded(1);
+
+      expect(subject.error, isNull);
+    });
+
+    test('error returns null for a seeded subject with null seed', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>.seeded(null);
+
+      expect(subject.error, isNull);
+    });
+
+    test('can synchronously get the latest error', () async {
+      // ignore: close_sinks
+      final unseeded = BehaviorSubject<int>(),
+          // ignore: close_sinks
+          seeded = BehaviorSubject<int>.seeded(0);
+
+      unseeded.add(1);
+      unseeded.add(2);
+      unseeded.add(3);
+      expect(unseeded.error, isNull);
+      unseeded.addError(Exception('oh noes!'));
+      expect(unseeded.error, isException);
+
+      seeded.add(1);
+      seeded.add(2);
+      seeded.add(3);
+      expect(seeded.error, isNull);
+      seeded.addError(Exception('oh noes!'));
+      expect(seeded.error, isException);
+    });
+
+    test('emits event after error to every subscriber, ensures error is null', () async {
+      // ignore: close_sinks
+      final unseeded = BehaviorSubject<int>(),
+          // ignore: close_sinks
+          seeded = BehaviorSubject<int>.seeded(0);
+
+      unseeded.add(1);
+      unseeded.add(2);
+      unseeded.addError(Exception('oh noes!'));
+      expect(unseeded.error, isException);
+      unseeded.add(3);
+      expect(unseeded.error, isNull);
+
+      seeded.add(1);
+      seeded.add(2);
+      seeded.addError(Exception('oh noes!'));
+      expect(seeded.error, isException);
+      seeded.add(3);
+      expect(seeded.error, isNull);
+    });
+
     test(
         'issue/350: emits duplicate values when listening multiple times and starting with an Error',
         () async {


### PR DESCRIPTION
This fix allows to get the last added error and hasError, like value and hasValue.