### PR TITLE
Sync Streams behavior

### DIFF
--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -45,8 +45,8 @@ class PublishConnectableStream<T> extends ConnectableStream<T> {
   /// Constructs a [Stream] which only begins emitting events when
   /// the [connect] method is called, this [Stream] acts like a
   /// [PublishSubject].
-  factory PublishConnectableStream(Stream<T> source) {
-    return PublishConnectableStream<T>._(source, PublishSubject<T>(sync: true));
+  factory PublishConnectableStream(Stream<T> source, {bool sync = false}) {
+    return PublishConnectableStream<T>._(source, PublishSubject<T>(sync: sync));
   }
 
   PublishConnectableStream._(Stream<T> source, this._subject)
@@ -112,22 +112,20 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   /// Constructs a [Stream] which only begins emitting events when
   /// the [connect] method is called, this [Stream] acts like a
   /// [BehaviorSubject].
-  factory ValueConnectableStream(Stream<T> source) =>
+  factory ValueConnectableStream(Stream<T> source, {bool sync = false}) =>
       ValueConnectableStream<T>._(
         source,
-        BehaviorSubject<T>(sync: true),
+        BehaviorSubject<T>(sync: sync),
       );
 
   /// Constructs a [Stream] which only begins emitting events when
   /// the [connect] method is called, this [Stream] acts like a
   /// [BehaviorSubject.seeded].
-  factory ValueConnectableStream.seeded(
-    Stream<T> source,
-    T seedValue,
-  ) =>
+  factory ValueConnectableStream.seeded(Stream<T> source, T seedValue,
+          {bool sync = false}) =>
       ValueConnectableStream<T>._(
         source,
-        BehaviorSubject<T>.seeded(seedValue, sync: true),
+        BehaviorSubject<T>.seeded(seedValue, sync: sync),
       );
 
   @override
@@ -189,10 +187,11 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
   /// Constructs a [Stream] which only begins emitting events when
   /// the [connect] method is called, this [Stream] acts like a
   /// [ReplaySubject].
-  factory ReplayConnectableStream(Stream<T> stream, {int maxSize}) {
+  factory ReplayConnectableStream(Stream<T> stream,
+      {int maxSize, bool sync = false}) {
     return ReplayConnectableStream<T>._(
       stream,
-      ReplaySubject<T>(maxSize: maxSize, sync: true),
+      ReplaySubject<T>(maxSize: maxSize, sync: sync),
     );
   }
 
@@ -314,7 +313,8 @@ extension ConnectableStreamExtensions<T> on Stream<T> {
   /// // Subject
   /// subscription.cancel();
   /// ```
-  ConnectableStream<T> publish() => PublishConnectableStream<T>(this);
+  ConnectableStream<T> publish() =>
+      PublishConnectableStream<T>(this, sync: true);
 
   /// Convert the current Stream into a [ValueConnectableStream]
   /// that can be listened to multiple times. It will not begin emitting items
@@ -347,7 +347,8 @@ extension ConnectableStreamExtensions<T> on Stream<T> {
   /// // BehaviorSubject
   /// subscription.cancel();
   /// ```
-  ValueConnectableStream<T> publishValue() => ValueConnectableStream<T>(this);
+  ValueConnectableStream<T> publishValue() =>
+      ValueConnectableStream<T>(this, sync: true);
 
   /// Convert the current Stream into a [ValueConnectableStream]
   /// that can be listened to multiple times, providing an initial seeded value.
@@ -417,7 +418,7 @@ extension ConnectableStreamExtensions<T> on Stream<T> {
   /// subscription.cancel();
   /// ```
   ReplayConnectableStream<T> publishReplay({int maxSize}) =>
-      ReplayConnectableStream<T>(this, maxSize: maxSize);
+      ReplayConnectableStream<T>(this, maxSize: maxSize, sync: true);
 
   /// Convert the current Stream into a new Stream that can be listened
   /// to multiple times. It will automatically begin emitting items when first

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -46,7 +46,7 @@ class PublishConnectableStream<T> extends ConnectableStream<T> {
   /// the [connect] method is called, this [Stream] acts like a
   /// [PublishSubject].
   factory PublishConnectableStream(Stream<T> source) {
-    return PublishConnectableStream<T>._(source, PublishSubject<T>());
+    return PublishConnectableStream<T>._(source, PublishSubject<T>(sync: true));
   }
 
   PublishConnectableStream._(Stream<T> source, this._subject)
@@ -115,7 +115,7 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   factory ValueConnectableStream(Stream<T> source) =>
       ValueConnectableStream<T>._(
         source,
-        BehaviorSubject<T>(),
+        BehaviorSubject<T>(sync: true),
       );
 
   /// Constructs a [Stream] which only begins emitting events when
@@ -127,7 +127,7 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   ) =>
       ValueConnectableStream<T>._(
         source,
-        BehaviorSubject<T>.seeded(seedValue),
+        BehaviorSubject<T>.seeded(seedValue, sync: true),
       );
 
   @override
@@ -192,7 +192,7 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
   factory ReplayConnectableStream(Stream<T> stream, {int maxSize}) {
     return ReplayConnectableStream<T>._(
       stream,
-      ReplaySubject<T>(maxSize: maxSize),
+      ReplaySubject<T>(maxSize: maxSize, sync: true),
     );
   }
 

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -101,14 +101,14 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   }
 
   static Stream<T> Function() _deferStream<T>(
-          _Wrapper<T> wrapper, StreamController<T> controller, bool isSync) =>
+          _Wrapper<T> wrapper, StreamController<T> controller, bool sync) =>
       () {
         if (wrapper.latestIsError) {
           return controller.stream.transform(StartWithErrorStreamTransformer(
-              wrapper.latestError, wrapper.latestStackTrace, isSync));
+              wrapper.latestError, wrapper.latestStackTrace, sync));
         } else if (wrapper.latestIsValue) {
           return controller.stream.transform(
-              StartWithStreamTransformer(wrapper.latestValue, isSync: isSync));
+              StartWithStreamTransformer(wrapper.latestValue, sync: sync));
         }
 
         return controller.stream;

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -68,7 +68,7 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
 
     return BehaviorSubject<T>._(
         controller,
-        Rx.defer<T>(_deferStream(wrapper, controller), reusable: true),
+        Rx.defer<T>(_deferStream(wrapper, controller, sync), reusable: true),
         wrapper);
   }
 
@@ -95,20 +95,20 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
 
     return BehaviorSubject<T>._(
       controller,
-      Rx.defer<T>(_deferStream(wrapper, controller), reusable: true),
+      Rx.defer<T>(_deferStream(wrapper, controller, sync), reusable: true),
       wrapper,
     );
   }
 
   static Stream<T> Function() _deferStream<T>(
-          _Wrapper<T> wrapper, StreamController<T> controller) =>
+          _Wrapper<T> wrapper, StreamController<T> controller, bool isSync) =>
       () {
         if (wrapper.latestIsError) {
           return controller.stream.transform(StartWithErrorStreamTransformer(
-              wrapper.latestError, wrapper.latestStackTrace));
+              wrapper.latestError, wrapper.latestStackTrace, isSync));
         } else if (wrapper.latestIsValue) {
-          return controller.stream
-              .transform(StartWithStreamTransformer(wrapper.latestValue));
+          return controller.stream.transform(
+              StartWithStreamTransformer(wrapper.latestValue, isSync: isSync));
         }
 
         return controller.stream;

--- a/lib/src/subjects/replay_subject.dart
+++ b/lib/src/subjects/replay_subject.dart
@@ -79,8 +79,8 @@ class ReplaySubject<T> extends Subject<T> implements ReplayStream<T> {
                 event.errorAndStackTrace.stackTrace,
                 sync));
           } else {
-            return stream.transform(
-                StartWithStreamTransformer(event.event, isSync: sync));
+            return stream
+                .transform(StartWithStreamTransformer(event.event, sync: sync));
           }
         }),
         reusable: true,

--- a/lib/src/subjects/replay_subject.dart
+++ b/lib/src/subjects/replay_subject.dart
@@ -76,9 +76,11 @@ class ReplaySubject<T> extends Subject<T> implements ReplayStream<T> {
           if (event.isError) {
             return stream.transform(StartWithErrorStreamTransformer(
                 event.errorAndStackTrace.error,
-                event.errorAndStackTrace.stackTrace));
+                event.errorAndStackTrace.stackTrace,
+                sync));
           } else {
-            return stream.transform(StartWithStreamTransformer(event.event));
+            return stream.transform(
+                StartWithStreamTransformer(event.event, isSync: sync));
           }
         }),
         reusable: true,

--- a/lib/src/transformers/start_with.dart
+++ b/lib/src/transformers/start_with.dart
@@ -5,11 +5,12 @@ import 'package:rxdart/src/utils/forwarding_stream.dart';
 
 class _StartWithStreamSink<S> implements ForwardingSink<S> {
   final S _startValue;
+  final bool _isSync;
   final EventSink<S> _outputSink;
   EventSink<S> _sink;
   var _isFirstEventAdded = false;
 
-  _StartWithStreamSink(this._outputSink, this._startValue);
+  _StartWithStreamSink(this._outputSink, this._isSync, this._startValue);
 
   @override
   void add(S data) {
@@ -36,7 +37,7 @@ class _StartWithStreamSink<S> implements ForwardingSink<S> {
   void onListen(EventSink<S> sink) {
     _sink = sink;
 
-    scheduleMicrotask(_safeAddFirstEvent);
+    _isSync ? _safeAddFirstEvent() : scheduleMicrotask(_safeAddFirstEvent);
   }
 
   @override
@@ -71,9 +72,13 @@ class StartWithStreamTransformer<S> extends StreamTransformerBase<S, S> {
   /// The starting event of this [Stream]
   final S startValue;
 
+  /// @internal
+  /// Forces startWith to happen either sync or async
+  final bool isSync;
+
   /// Constructs a [StreamTransformer] which prepends the source [Stream]
   /// with [startValue].
-  StartWithStreamTransformer(this.startValue);
+  StartWithStreamTransformer(this.startValue, {this.isSync = false});
 
   @override
   Stream<S> bind(Stream<S> stream) {
@@ -81,8 +86,8 @@ class StartWithStreamTransformer<S> extends StreamTransformerBase<S, S> {
 
     return Stream.eventTransformed(
         forwardedStream.stream,
-        (sink) =>
-            forwardedStream.connect(_StartWithStreamSink<S>(sink, startValue)));
+        (sink) => forwardedStream
+            .connect(_StartWithStreamSink<S>(sink, isSync, startValue)));
   }
 }
 

--- a/lib/src/transformers/start_with.dart
+++ b/lib/src/transformers/start_with.dart
@@ -5,12 +5,12 @@ import 'package:rxdart/src/utils/forwarding_stream.dart';
 
 class _StartWithStreamSink<S> implements ForwardingSink<S> {
   final S _startValue;
-  final bool _isSync;
+  final bool _sync;
   final EventSink<S> _outputSink;
   EventSink<S> _sink;
   var _isFirstEventAdded = false;
 
-  _StartWithStreamSink(this._outputSink, this._isSync, this._startValue);
+  _StartWithStreamSink(this._outputSink, this._sync, this._startValue);
 
   @override
   void add(S data) {
@@ -37,7 +37,7 @@ class _StartWithStreamSink<S> implements ForwardingSink<S> {
   void onListen(EventSink<S> sink) {
     _sink = sink;
 
-    _isSync ? _safeAddFirstEvent() : scheduleMicrotask(_safeAddFirstEvent);
+    _sync ? _safeAddFirstEvent() : scheduleMicrotask(_safeAddFirstEvent);
   }
 
   @override
@@ -74,11 +74,11 @@ class StartWithStreamTransformer<S> extends StreamTransformerBase<S, S> {
 
   /// @internal
   /// Forces startWith to happen either sync or async
-  final bool isSync;
+  final bool sync;
 
   /// Constructs a [StreamTransformer] which prepends the source [Stream]
   /// with [startValue].
-  StartWithStreamTransformer(this.startValue, {this.isSync = false});
+  StartWithStreamTransformer(this.startValue, {this.sync = false});
 
   @override
   Stream<S> bind(Stream<S> stream) {
@@ -87,7 +87,7 @@ class StartWithStreamTransformer<S> extends StreamTransformerBase<S, S> {
     return Stream.eventTransformed(
         forwardedStream.stream,
         (sink) => forwardedStream
-            .connect(_StartWithStreamSink<S>(sink, isSync, startValue)));
+            .connect(_StartWithStreamSink<S>(sink, sync, startValue)));
   }
 }
 

--- a/lib/src/transformers/start_with_error.dart
+++ b/lib/src/transformers/start_with_error.dart
@@ -5,13 +5,13 @@ import 'package:rxdart/src/utils/forwarding_stream.dart';
 
 class _StartWithErrorStreamSink<S> implements ForwardingSink<S> {
   final EventSink<S> _outputSink;
-  final bool _isSync;
+  final bool _sync;
   final Object _e;
   final StackTrace _st;
   EventSink<S> _sink;
   var _isFirstEventAdded = false;
 
-  _StartWithErrorStreamSink(this._outputSink, this._isSync, this._e, this._st);
+  _StartWithErrorStreamSink(this._outputSink, this._sync, this._e, this._st);
 
   @override
   void add(S data) {
@@ -38,7 +38,7 @@ class _StartWithErrorStreamSink<S> implements ForwardingSink<S> {
   void onListen(EventSink<S> sink) {
     _sink = sink;
 
-    _isSync ? _safeAddFirstEvent() : scheduleMicrotask(_safeAddFirstEvent);
+    _sync ? _safeAddFirstEvent() : scheduleMicrotask(_safeAddFirstEvent);
   }
 
   @override
@@ -78,12 +78,12 @@ class StartWithErrorStreamTransformer<S> extends StreamTransformerBase<S, S> {
 
   /// @internal
   /// Forces startWithError to happen either sync or async
-  final bool isSync;
+  final bool sync;
 
   /// Constructs a [StreamTransformer] which starts with the provided [error]
   /// and then outputs all events from the source [Stream].
   StartWithErrorStreamTransformer(this.error,
-      [this.stackTrace, this.isSync = false]);
+      [this.stackTrace, this.sync = false]);
 
   @override
   Stream<S> bind(Stream<S> stream) {
@@ -92,6 +92,6 @@ class StartWithErrorStreamTransformer<S> extends StreamTransformerBase<S, S> {
     return Stream.eventTransformed(
         forwardedStream.stream,
         (sink) => forwardedStream.connect(
-            _StartWithErrorStreamSink<S>(sink, isSync, error, stackTrace)));
+            _StartWithErrorStreamSink<S>(sink, sync, error, stackTrace)));
   }
 }

--- a/lib/src/transformers/start_with_error.dart
+++ b/lib/src/transformers/start_with_error.dart
@@ -5,12 +5,13 @@ import 'package:rxdart/src/utils/forwarding_stream.dart';
 
 class _StartWithErrorStreamSink<S> implements ForwardingSink<S> {
   final EventSink<S> _outputSink;
+  final bool _isSync;
   final Object _e;
   final StackTrace _st;
   EventSink<S> _sink;
   var _isFirstEventAdded = false;
 
-  _StartWithErrorStreamSink(this._outputSink, this._e, this._st);
+  _StartWithErrorStreamSink(this._outputSink, this._isSync, this._e, this._st);
 
   @override
   void add(S data) {
@@ -37,7 +38,7 @@ class _StartWithErrorStreamSink<S> implements ForwardingSink<S> {
   void onListen(EventSink<S> sink) {
     _sink = sink;
 
-    scheduleMicrotask(_safeAddFirstEvent);
+    _isSync ? _safeAddFirstEvent() : scheduleMicrotask(_safeAddFirstEvent);
   }
 
   @override
@@ -75,9 +76,14 @@ class StartWithErrorStreamTransformer<S> extends StreamTransformerBase<S, S> {
   /// The starting stackTrace of this [Stream]
   final StackTrace stackTrace;
 
+  /// @internal
+  /// Forces startWithError to happen either sync or async
+  final bool isSync;
+
   /// Constructs a [StreamTransformer] which starts with the provided [error]
   /// and then outputs all events from the source [Stream].
-  StartWithErrorStreamTransformer(this.error, [this.stackTrace]);
+  StartWithErrorStreamTransformer(this.error,
+      [this.stackTrace, this.isSync = false]);
 
   @override
   Stream<S> bind(Stream<S> stream) {
@@ -85,7 +91,7 @@ class StartWithErrorStreamTransformer<S> extends StreamTransformerBase<S, S> {
 
     return Stream.eventTransformed(
         forwardedStream.stream,
-        (sink) => forwardedStream
-            .connect(_StartWithErrorStreamSink<S>(sink, error, stackTrace)));
+        (sink) => forwardedStream.connect(
+            _StartWithErrorStreamSink<S>(sink, isSync, error, stackTrace)));
   }
 }

--- a/test/streams/publish_connectable_stream_test.dart
+++ b/test/streams/publish_connectable_stream_test.dart
@@ -73,7 +73,7 @@ void main() {
           .publish()
           .autoConnect(connection: (subscription) => subscription.cancel());
 
-      expect(stream, neverEmits(anything));
+      expect(await stream.isEmpty, true);
     });
   });
 }

--- a/test/streams/replay_connectable_stream_test.dart
+++ b/test/streams/replay_connectable_stream_test.dart
@@ -136,7 +136,7 @@ void main() {
           .publishReplay()
           .autoConnect(connection: (subscription) => subscription.cancel());
 
-      expect(stream, neverEmits(anything));
+      expect(await stream.isEmpty, true);
     });
   });
 }

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -147,7 +147,7 @@ void main() {
           .publishValue()
           .autoConnect(connection: (subscription) => subscription.cancel());
 
-      expect(stream, neverEmits(anything));
+      expect(await stream.isEmpty, true);
     });
   });
 }

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -530,5 +530,27 @@ void main() {
       await expectLater(subject,
           emitsInOrder(<StreamMatcher>[emitsError('error'), emitsDone]));
     });
+
+    test('issue/419: sync behavior', () async {
+      final subject = BehaviorSubject.seeded(1, sync: true);
+      final mappedStream = subject.map((event) => event).shareValue();
+
+      mappedStream.listen(null);
+
+      expect(mappedStream.value, equals(1));
+
+      await subject.close();
+    });
+
+    test('issue/419: async behavior', () async {
+      final subject = BehaviorSubject.seeded(1);
+      final mappedStream = subject.map((event) => event).shareValue();
+
+      mappedStream.listen(null);
+
+      expect(mappedStream.value, equals(isNull));
+
+      await subject.close();
+    });
   });
 }

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -542,11 +542,39 @@ void main() {
       await subject.close();
     });
 
+    test('issue/419: sync throughput', () async {
+      final subject = BehaviorSubject.seeded(1, sync: true);
+      final mappedStream = subject.map((event) => event).shareValue();
+
+      mappedStream.listen(null);
+
+      subject.add(2);
+
+      expect(mappedStream.value, equals(2));
+
+      await subject.close();
+    });
+
     test('issue/419: async behavior', () async {
       final subject = BehaviorSubject.seeded(1);
       final mappedStream = subject.map((event) => event).shareValue();
 
-      mappedStream.listen(null);
+      mappedStream.listen(null,
+          onDone: () => expect(mappedStream.value, equals(1)));
+
+      expect(mappedStream.value, equals(isNull));
+
+      await subject.close();
+    });
+
+    test('issue/419: async throughput', () async {
+      final subject = BehaviorSubject.seeded(1);
+      final mappedStream = subject.map((event) => event).shareValue();
+
+      mappedStream.listen(null,
+          onDone: () => expect(mappedStream.value, equals(2)));
+
+      subject.add(2);
 
       expect(mappedStream.value, equals(isNull));
 

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -382,11 +382,39 @@ void main() {
       await subject.close();
     });
 
+    test('issue/419: sync throughput', () async {
+      final subject = ReplaySubject<int>(sync: true)..add(1);
+      final mappedStream = subject.map((event) => event).shareValue();
+
+      mappedStream.listen(null);
+
+      subject.add(2);
+
+      expect(mappedStream.value, equals(2));
+
+      await subject.close();
+    });
+
     test('issue/419: async behavior', () async {
       final subject = ReplaySubject<int>()..add(1);
       final mappedStream = subject.map((event) => event).shareValue();
 
-      mappedStream.listen(null);
+      mappedStream.listen(null,
+          onDone: () => expect(mappedStream.value, equals(1)));
+
+      expect(mappedStream.value, equals(isNull));
+
+      await subject.close();
+    });
+
+    test('issue/419: async throughput', () async {
+      final subject = ReplaySubject<int>()..add(1);
+      final mappedStream = subject.map((event) => event).shareValue();
+
+      mappedStream.listen(null,
+          onDone: () => expect(mappedStream.value, equals(2)));
+
+      subject.add(2);
 
       expect(mappedStream.value, equals(isNull));
 

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -370,5 +370,27 @@ void main() {
       expect(subject.isBroadcast, isTrue);
       expect(stream.isBroadcast, isTrue);
     });
+
+    test('issue/419: sync behavior', () async {
+      final subject = ReplaySubject<int>(sync: true)..add(1);
+      final mappedStream = subject.map((event) => event).shareValue();
+
+      mappedStream.listen(null);
+
+      expect(mappedStream.value, equals(1));
+
+      await subject.close();
+    });
+
+    test('issue/419: async behavior', () async {
+      final subject = ReplaySubject<int>()..add(1);
+      final mappedStream = subject.map((event) => event).shareValue();
+
+      mappedStream.listen(null);
+
+      expect(mappedStream.value, equals(isNull));
+
+      await subject.close();
+    });
   });
 }


### PR DESCRIPTION
See issue 419: https://github.com/ReactiveX/rxdart/issues/419

...which is interesting,
sure we could argue that `Stream`s are async by design, and that expecting values to be available sync is not guaranteed, but *we do have sync Streams in Dart obviously*...

So, I took the same test as within that issue and made it expect sync instead of async:
```
test('shareValue does not work synchronously', () async {
    BehaviorSubject<int> controller = BehaviorSubject.seeded(1, sync: true);
    ValueStream<int> stream = controller.stream;

    int plusOne(int i) => i + 1;

    ValueStream<int> streamPlusOneNaive = stream.map(plusOne).shareValue();
    ValueStream<int> streamPlusOneSeeded = stream.hasValue
        ? stream.map(plusOne).shareValueSeeded(plusOne(stream.value))
        : stream.map(plusOne).shareValue();

    StreamSubscription<int> streamPlusOneNaiveSubscriber = streamPlusOneNaive.listen((_){});
    StreamSubscription<int> streamPlusOneSeededSubscriber = streamPlusOneSeeded.listen((_){});

    print('is: ${streamPlusOneNaive.value}');
    // ideally value would be available here without manual seeding it
    expect(stream.value, equals(1));
    expect(streamPlusOneNaive.value, equals(2));
    expect(streamPlusOneSeeded.value, equals(2));

    await Future<void>.delayed(Duration(milliseconds: 5));

    expect(stream.value, equals(1));
    expect(streamPlusOneNaive.value, equals(2));
    expect(streamPlusOneSeeded.value, equals(2));

    controller.add(2);

    // ideally values would be mapped here already
    expect(stream.value, equals(2));
    expect(streamPlusOneNaive.value, equals(3));
    expect(streamPlusOneSeeded.value, equals(3));

    await Future<void>.delayed(Duration(milliseconds: 5));

    expect(stream.value, equals(2));
    expect(streamPlusOneNaive.value, equals(3));
    expect(streamPlusOneSeeded.value, equals(3));

    streamPlusOneNaiveSubscriber.cancel();
    streamPlusOneSeededSubscriber.cancel();
  });
```

...which works in this PR, but:

- I use a special version of `startWith`/`startWithError` to make it work
- Only when the *source* is sync, then add the very first event (or error) sync as well

This then works, note that immediately emitting for async controllers does throw the RTE.
Following the rabbit hole of the stack trace, at some point in the SDK a `subscription` is created, with an `onListen` handler. This then in its turn does something when data is added.
Now when everything is sync, then this chain fires immediatly, and at some point, that subscription is being referenced. (which yields the RTE, since at this point, it is effectively null).

TL;DR that subscription is lazy (or late in Dart NNBD terms), but unfortunately lazy null-safety can still yield NPE's, as in this case.

TL;DR2 I do think that we should support true sync behavior, as expected by the test above, but I'm not too sure yet about the implementation here (just a PoC at this point).

Note: Yes, this PR also implies that Subjects created via share are sync, but so are all of our Transformers, again this won't magically turn the source into a sync one by doing this:
The source still emits async, but any effects afterwards run in sync, so in total, it is still async.