### PR TITLE
Add addTo extension method for StreamSubscription

### DIFF
--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -55,3 +55,10 @@ class CompositeSubscription {
     _isDisposed = true;
   }
 }
+
+/// Extends the [StreamSubscription] class with the ability to be added to [CompositeSubscription] container.
+extension AddToCompositeSubscriptionExtension<T> on StreamSubscription<T> {
+  /// Adds this subscription to composite container for subscriptions.
+  void addTo(CompositeSubscription compositeSubscription) =>
+      compositeSubscription.add(this);
+}


### PR DESCRIPTION
addTo extension method - adds subscription to CompositeSubscription

Example
```dart
final subscriptions = CompositeSubscription();

stream
   .listen((data) => print(data))
   .addTo(subscriptions)
```