### PR TITLE
Fixes withLatestFrom

### DIFF
--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -37,9 +37,13 @@ class _WithLatestFromStreamSink<S, T, R> implements ForwardingSink<S> {
 
   @override
   FutureOr onCancel(EventSink<S> sink) {
+    Iterable<Future> futures = <Future>[];
+
     if (_subscriptions != null && _subscriptions.isNotEmpty) {
-      return Future.wait<dynamic>(_subscriptions.map((it) => it.cancel()));
+      futures = _subscriptions.map((it) => it.cancel()).whereType<Future>();
     }
+
+    return futures.isNotEmpty ? Future.wait<dynamic>(futures) : null;
   }
 
   @override


### PR DESCRIPTION
I've noticed 2 issues with our current `withLatestFrom`:
- ~~it closes too early, it should close when: the source closes and all combined Streams close~~
- we kept a reference to a single Subscription only when listening to the combined Steams, now we keep a List and properly handle `cancel()` as well.