### PR TITLE
Add onDoneResume extension method for Stream

### DIFF
--- a/lib/src/transformers/on_done_resume.dart
+++ b/lib/src/transformers/on_done_resume.dart
@@ -1,0 +1,15 @@
+import 'package:rxdart/rxdart.dart';
+
+/// Adds extension methods that fired when this stream emits all events
+extension OnDoneExtensions<T> on Stream<T> {
+  /// Intercepts done event and and switches to stream created by [onDoneStreamCreator].
+  /// 
+  /// ### Example
+  ///   
+  ///     downloadStream
+  ///       .map((progress) => State(progress: progress, isFinished: false))
+  ///       .onDoneResume(() => State(progress: 100, isFinished: true))
+  Stream<T> onDoneResume(Stream<T> Function() onDoneStreamCreator) {
+    return concatWith([onDoneStreamCreator()]);
+  }
+}

--- a/lib/src/transformers/on_done_resume.dart
+++ b/lib/src/transformers/on_done_resume.dart
@@ -3,12 +3,12 @@ import 'package:rxdart/rxdart.dart';
 /// Adds extension methods that fired when this stream emits all events
 extension OnDoneExtensions<T> on Stream<T> {
   /// Intercepts done event and and switches to stream created by [onDoneStreamCreator].
-  /// 
+  ///
   /// ### Example
-  ///   
+  ///
   ///     downloadStream
   ///       .map((progress) => State(progress: progress, isFinished: false))
-  ///       .onDoneResume(() => State(progress: 100, isFinished: true))
+  ///       .onDoneResume(() => Stream.value(State(progress: 100, isFinished: true)))
   Stream<T> onDoneResume(Stream<T> Function() onDoneStreamCreator) {
     return concatWith([onDoneStreamCreator()]);
   }

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -55,3 +55,10 @@ class CompositeSubscription {
     _isDisposed = true;
   }
 }
+
+/// Extends the [StreamSubscription] class with the ability to be added to [CompositeSubscription] container.
+extension AddToCompositeSubscriptionExtension<T> on StreamSubscription<T> {
+  /// Adds this subscription to composite container for subscriptions.
+  void addTo(CompositeSubscription compositeSubscription) =>
+      compositeSubscription.add(this);
+}

--- a/test/transformers/on_done_resume_test.dart
+++ b/test/transformers/on_done_resume_test.dart
@@ -1,0 +1,14 @@
+import 'package:test/test.dart';
+
+import 'package:rxdart/src/transformers/on_done_resume.dart';
+
+Stream<int> _initStream() => Stream.fromIterable([0, 1, 2]);
+
+Stream<int> _onDoneStream() => Stream.fromIterable(([3, 3]));
+
+void main() {
+  test('Rx.onDoneResume', () {
+    expectLater(_initStream().onDoneResume(() => _onDoneStream()),
+        emitsInOrder(<dynamic>[0, 1, 2, 3, 3, emitsDone]));
+  });
+}


### PR DESCRIPTION
Stream.onDoneResume intercepts done event and switches to new stream.

Example

```dart
// Part of UploadBloc
  @override
  Stream<UploadState> mapEventToState(UploadEvent event) async* {
    yield* _repository
        .upload(event.file)
        .map((progress) => UploadState(
              progress: progress.floor(),
              isFinished: false,
              hasError: false,
            ))
        .onDoneResume(() => _onFinished())
        .onErrorResume((_) => _onError());
  }

  Stream<UploadState> _onFinished() async* {
    yield state.copyWith.call(isFinished: true);
  }

  Stream<UploadState> _onError() async* {
    yield state.copyWith.call(hasError: true);
  }
```