### PR TITLE
Bug/fix stream type after transforming using streams

### DIFF
--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -80,6 +80,9 @@ extension MergeExtension<T> on Stream<T> {
   ///     TimerStream(1, Duration(seconds: 10))
   ///         .mergeWith([Stream.fromIterable([2])])
   ///         .listen(print); // prints 2, 1
-  Stream<T> mergeWith(Iterable<Stream<T>> streams) =>
-      MergeStream<T>([this, ...streams]);
+  Stream<T> mergeWith(Iterable<Stream<T>> streams) {
+    final stream = MergeStream<T>([this, ...streams]);
+
+    return isBroadcast ? stream.asBroadcastStream() : stream;
+  }
 }

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -380,6 +380,9 @@ extension ZipWithExtension<T> on Stream<T> {
   ///     Stream.fromIterable([1])
   ///         .zipWith(Stream.fromIterable([2]), (one, two) => one + two)
   ///         .listen(print); // prints 3
-  Stream<R> zipWith<S, R>(Stream<S> other, R Function(T t, S s) zipper) =>
-      ZipStream.zip2(this, other, zipper);
+  Stream<R> zipWith<S, R>(Stream<S> other, R Function(T t, S s) zipper) {
+    final stream = ZipStream.zip2(this, other, zipper);
+
+    return isBroadcast ? stream.asBroadcastStream() : stream;
+  }
 }

--- a/test/transformers/merge_with_test.dart
+++ b/test/transformers/merge_with_test.dart
@@ -15,7 +15,7 @@ void main() {
     }, count: expected.length));
   });
 
-  test('Rx.flatMap accidental broadcast', () async {
+  test('Rx.mergeWith accidental broadcast', () async {
     final controller = StreamController<int>();
 
     final stream = controller.stream.mergeWith([Stream<int>.empty()]);
@@ -24,5 +24,28 @@ void main() {
     expect(() => stream.listen(null), throwsStateError);
 
     controller.add(1);
+  });
+
+  test('Rx.mergeWith on single stream should stay single ', () async {
+    final delayedStream = Rx.timer(1, Duration(milliseconds: 10));
+    final immediateStream = Stream.value(2);
+    final expected = [2, 1, emitsDone];
+
+    final concatenatedStream = delayedStream.mergeWith([immediateStream]);
+
+    expect(concatenatedStream.isBroadcast, isFalse);
+    expect(concatenatedStream, emitsInOrder(expected));
+  });
+
+  test('Rx.mergeWith on broadcast stream should stay broadcast ', () async {
+    final delayedStream =
+        Rx.timer(1, Duration(milliseconds: 10)).asBroadcastStream();
+    final immediateStream = Stream.value(2);
+    final expected = [2, 1, emitsDone];
+
+    final concatenatedStream = delayedStream.mergeWith([immediateStream]);
+
+    expect(concatenatedStream.isBroadcast, isTrue);
+    expect(concatenatedStream, emitsInOrder(expected));
   });
 }

--- a/test/transformers/merge_with_test.dart
+++ b/test/transformers/merge_with_test.dart
@@ -48,4 +48,15 @@ void main() {
     expect(concatenatedStream.isBroadcast, isTrue);
     expect(concatenatedStream, emitsInOrder(expected));
   });
+
+  test('Rx.mergeWith multiple subscriptions on single ', () async {
+    final delayedStream = Rx.timer(1, Duration(milliseconds: 10));
+    final immediateStream = Stream.value(2);
+
+    final concatenatedStream = delayedStream.mergeWith([immediateStream]);
+
+    expect(() => concatenatedStream.listen(null), returnsNormally);
+    expect(() => concatenatedStream.listen(null),
+        throwsA(TypeMatcher<StateError>()));
+  });
 }

--- a/test/transformers/zip_with_test.dart
+++ b/test/transformers/zip_with_test.dart
@@ -52,7 +52,6 @@ void main() {
   test('Rx.zipWith multiple subscriptions on single ', () async {
     final delayedStream = Rx.timer(1, Duration(milliseconds: 10));
     final immediateStream = Stream.value(2);
-    final expected = [3, emitsDone];
 
     final concatenatedStream =
         delayedStream.zipWith(immediateStream, (a, int b) => a + b);

--- a/test/transformers/zip_with_test.dart
+++ b/test/transformers/zip_with_test.dart
@@ -11,6 +11,7 @@ void main() {
           expect(result, 3);
         }, count: 1));
   });
+
   test('Rx.zipWith accidental broadcast', () async {
     final controller = StreamController<int>();
 
@@ -21,5 +22,30 @@ void main() {
     expect(() => stream.listen(null), throwsStateError);
 
     controller.add(1);
+  });
+
+  test('Rx.zipWith on single stream should stay single ', () async {
+    final delayedStream = Rx.timer(1, Duration(milliseconds: 10));
+    final immediateStream = Stream.value(2);
+    final expected = [3, emitsDone];
+
+    final concatenatedStream =
+        delayedStream.zipWith(immediateStream, (a, int b) => a + b);
+
+    expect(concatenatedStream.isBroadcast, isFalse);
+    expect(concatenatedStream, emitsInOrder(expected));
+  });
+
+  test('Rx.zipWith on broadcast stream should stay broadcast ', () async {
+    final delayedStream =
+        Rx.timer(1, Duration(milliseconds: 10)).asBroadcastStream();
+    final immediateStream = Stream.value(2);
+    final expected = [3, emitsDone];
+
+    final concatenatedStream =
+        delayedStream.zipWith(immediateStream, (a, int b) => a + b);
+
+    expect(concatenatedStream.isBroadcast, isTrue);
+    expect(concatenatedStream, emitsInOrder(expected));
   });
 }

--- a/test/transformers/zip_with_test.dart
+++ b/test/transformers/zip_with_test.dart
@@ -48,4 +48,17 @@ void main() {
     expect(concatenatedStream.isBroadcast, isTrue);
     expect(concatenatedStream, emitsInOrder(expected));
   });
+
+  test('Rx.zipWith multiple subscriptions on single ', () async {
+    final delayedStream = Rx.timer(1, Duration(milliseconds: 10));
+    final immediateStream = Stream.value(2);
+    final expected = [3, emitsDone];
+
+    final concatenatedStream =
+        delayedStream.zipWith(immediateStream, (a, int b) => a + b);
+
+    expect(() => concatenatedStream.listen(null), returnsNormally);
+    expect(() => concatenatedStream.listen(null),
+        throwsA(TypeMatcher<StateError>()));
+  });
 }


### PR DESCRIPTION
Keeps `Stream` type after transforming, whereas before, calling the operator would always yield a single subscription `Stream`, even if the source `Stream` is broadcast.