### PR TITLE
Fix: BehaviorSubject replays a data event instead of error for new subscriptions when using addStream

### DIFF
--- a/lib/src/subjects/subject.dart
+++ b/lib/src/subjects/subject.dart
@@ -113,7 +113,7 @@ abstract class Subject<T> extends StreamView<T> implements StreamController<T> {
     source.listen((T event) {
       _add(event);
     }, onError: (dynamic e, StackTrace s) {
-      _controller.addError(e, s);
+      _addError(e, s);
 
       if (cancelOnError) {
         complete();

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -286,6 +286,20 @@ void main() {
       await expectLater(seeded.stream, emits(3));
     });
 
+    test('replays the previously emitted errors from addStream', () async {
+      // ignore: close_sinks
+      final unseeded = BehaviorSubject<int>(),
+          // ignore: close_sinks
+          seeded = BehaviorSubject<int>.seeded(0);
+
+      await unseeded.addStream(Stream<int>.error('error'),
+          cancelOnError: false);
+      await seeded.addStream(Stream<int>.error('error'), cancelOnError: false);
+
+      await expectLater(unseeded.stream, emitsError('error'));
+      await expectLater(unseeded.stream, emitsError('error'));
+    });
+
     test('allows items to be added once addStream is complete', () async {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>();


### PR DESCRIPTION
Fixes #445 