### PR TITLE
Fix for issue 445

### DIFF
--- a/lib/src/subjects/subject.dart
+++ b/lib/src/subjects/subject.dart
@@ -113,7 +113,7 @@ abstract class Subject<T> extends StreamView<T> implements StreamController<T> {
     source.listen((T event) {
       _add(event);
     }, onError: (dynamic e, StackTrace s) {
-      _controller.addError(e, s);
+      _addError(e, s);
 
       if (cancelOnError) {
         complete();


### PR DESCRIPTION
@brianegan Seems the problem is in this line: https://github.com/ReactiveX/rxdart/blob/master/lib/src/subjects/subject.dart#L116

The error is added straight to the `StreamController`, and does not travel via our `addError` method (which in its turn, calls `onAddError`, which is required for correct handling).
https://github.com/ReactiveX/rxdart/issues/445