### PR TITLE
Refactor stream transformer

### DIFF
--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -135,7 +135,7 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   set value(T newValue) => add(newValue);
 
   @override
-  StreamController<T> createForwardingController({
+  StreamController<R> createForwardingController<R>({
     void Function() onListen,
     void Function() onCancel,
     bool sync = false,

--- a/lib/src/subjects/publish_subject.dart
+++ b/lib/src/subjects/publish_subject.dart
@@ -48,7 +48,7 @@ class PublishSubject<T> extends Subject<T> {
   }
 
   @override
-  StreamController<T> createForwardingController({
+  StreamController<R> createForwardingController<R>({
     void Function() onListen,
     void Function() onCancel,
     bool sync = false,

--- a/lib/src/subjects/replay_subject.dart
+++ b/lib/src/subjects/replay_subject.dart
@@ -129,7 +129,7 @@ class ReplaySubject<T> extends Subject<T> implements ReplayStream<T> {
       .toList(growable: false);
 
   @override
-  StreamController<T> createForwardingController({
+  StreamController<R> createForwardingController<R>({
     void Function() onListen,
     void Function() onCancel,
     bool sync = false,

--- a/lib/src/subjects/subject.dart
+++ b/lib/src/subjects/subject.dart
@@ -159,7 +159,7 @@ abstract class Subject<T> extends StreamView<T> implements StreamController<T> {
   /// Creates a trampoline StreamController, which can forward events
   /// in the same manner as the original [Subject] does.
   /// e.g. replay or startWith on subscribe.
-  StreamController<T> createForwardingController({
+  StreamController<R> createForwardingController<R>({
     void Function() onListen,
     void Function() onCancel,
     bool sync = false,

--- a/lib/src/transformers/backpressure/backpressure.dart
+++ b/lib/src/transformers/backpressure/backpressure.dart
@@ -22,7 +22,7 @@ enum WindowStrategy {
   onHandler
 }
 
-class _BackpressureStreamSink<S, T> implements ForwardingSink<S> {
+class _BackpressureStreamSink<S, T> implements ForwardingSink<S, T> {
   final WindowStrategy _strategy;
   final Stream<dynamic> Function(S event) _windowStreamFactory;
   final T Function(S event) _onWindowStart;
@@ -31,14 +31,12 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S> {
   final bool Function(List<S> queue) _closeWindowWhen;
   final bool _ignoreEmptyWindows;
   final bool _dispatchOnClose;
-  final EventSink<T> _outputSink;
   final queue = <S>[];
   var skip = 0;
   var _hasData = false;
   StreamSubscription<dynamic> _windowSubscription;
 
   _BackpressureStreamSink(
-      this._outputSink,
       this._strategy,
       this._windowStreamFactory,
       this._onWindowStart,
@@ -49,9 +47,9 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S> {
       this._dispatchOnClose);
 
   @override
-  void add(S data) {
+  void add(EventSink<T> sink, S data) {
     _hasData = true;
-    maybeCreateWindow(data);
+    maybeCreateWindow(data, sink);
 
     if (skip == 0) {
       queue.add(data);
@@ -61,68 +59,68 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S> {
       skip--;
     }
 
-    maybeCloseWindow();
+    maybeCloseWindow(sink);
   }
 
   @override
-  void addError(e, [st]) => _outputSink.addError(e, st);
+  void addError(EventSink<T> sink, dynamic e, [st]) => sink.addError(e, st);
 
   @override
-  void close() {
+  void close(EventSink<T> sink) {
     // treat the final event as a Window that opens
     // and immediately closes again
     if (_dispatchOnClose && queue.isNotEmpty) {
-      resolveWindowStart(queue.last);
+      resolveWindowStart(queue.last, sink);
     }
 
-    resolveWindowEnd(true);
+    resolveWindowEnd(sink, true);
 
     queue.clear();
 
     _windowSubscription?.cancel();
-    _outputSink.close();
+    sink.close();
   }
 
   @override
-  FutureOr onCancel(EventSink<S> sink) => _windowSubscription?.cancel();
+  FutureOr onCancel(EventSink<T> sink) => _windowSubscription?.cancel();
 
   @override
-  void onListen(EventSink<S> sink) {}
+  void onListen(EventSink<T> sink) {}
 
   @override
-  void onPause(EventSink<S> sink, [Future resumeSignal]) =>
+  void onPause(EventSink<T> sink, [Future resumeSignal]) =>
       _windowSubscription?.pause(resumeSignal);
 
   @override
-  void onResume(EventSink<S> sink) => _windowSubscription?.resume();
+  void onResume(EventSink<T> sink) => _windowSubscription?.resume();
 
-  void maybeCreateWindow(S event) {
+  void maybeCreateWindow(S event, EventSink<T> sink) {
     switch (_strategy) {
       // for example throttle
       case WindowStrategy.eventAfterLastWindow:
         if (_windowSubscription != null) return;
 
-        _windowSubscription = singleWindow(event);
+        _windowSubscription = singleWindow(event, sink);
 
-        resolveWindowStart(event);
+        resolveWindowStart(event, sink);
 
         break;
       // for example scan
       case WindowStrategy.firstEventOnly:
         if (_windowSubscription != null) return;
 
-        _windowSubscription = multiWindow(event);
+        _windowSubscription = multiWindow(event, sink);
 
-        resolveWindowStart(event);
+        resolveWindowStart(event, sink);
 
         break;
       // for example debounce
       case WindowStrategy.everyEvent:
         _windowSubscription?.cancel();
 
-        _windowSubscription = singleWindow(event);
+        _windowSubscription = singleWindow(event, sink);
 
-        resolveWindowStart(event);
+        resolveWindowStart(event, sink);
 
         break;
       case WindowStrategy.onHandler:
@@ -130,23 +128,30 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S> {
     }
   }
 
-  void maybeCloseWindow() {
+  void maybeCloseWindow(EventSink<T> sink) {
     if (_closeWindowWhen != null &&
         _closeWindowWhen(UnmodifiableListView(queue))) {
-      resolveWindowEnd();
+      resolveWindowEnd(sink);
     }
   }
 
-  StreamSubscription<dynamic> singleWindow(S event) => buildStream(event)
-      .take(1)
-      .listen(null, onError: _outputSink.addError, onDone: resolveWindowEnd);
+  StreamSubscription<dynamic> singleWindow(S event, EventSink<T> sink) =>
+      buildStream(event, sink).take(1).listen(
+            null,
+            onError: sink.addError,
+            onDone: () => resolveWindowEnd(sink),
+          );
+
   // opens a new Window which is kept open until the main Stream
   // closes.
-  StreamSubscription<dynamic> multiWindow(S event) =>
-      buildStream(event).listen((dynamic _) => resolveWindowEnd(),
-          onError: _outputSink.addError, onDone: resolveWindowEnd);
+  StreamSubscription<dynamic> multiWindow(S event, EventSink<T> sink) =>
+      buildStream(event, sink).listen(
+        (dynamic _) => resolveWindowEnd(sink),
+        onError: sink.addError,
+        onDone: () => resolveWindowEnd(sink),
+      );
 
-  Stream<dynamic> buildStream(S event) {
+  Stream<dynamic> buildStream(S event, EventSink<T> sink) {
     Stream stream;
 
     _windowSubscription?.cancel();
@@ -154,19 +159,19 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S> {
     stream = _windowStreamFactory(event);
 
     if (stream == null) {
-      _outputSink.addError(ArgumentError.notNull('windowStreamFactory'));
+      sink.addError(ArgumentError.notNull('windowStreamFactory'));
     }
 
     return stream;
   }
 
-  void resolveWindowStart(S event) {
+  void resolveWindowStart(S event, EventSink<T> sink) {
     if (_onWindowStart != null) {
-      _outputSink.add(_onWindowStart(event));
+      sink.add(_onWindowStart(event));
     }
   }
 
-  void resolveWindowEnd([bool isControllerClosing = false]) {
+  void resolveWindowEnd(EventSink<T> sink, [bool isControllerClosing = false]) {
     if (isControllerClosing ||
         _strategy == WindowStrategy.eventAfterLastWindow ||
         _strategy == WindowStrategy.everyEvent) {
@@ -180,7 +185,7 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S> {
 
     if (_hasData && (queue.isNotEmpty || !_ignoreEmptyWindows)) {
       if (_onWindowEnd != null) {
-        _outputSink.add(_onWindowEnd(List<S>.unmodifiable(queue)));
+        sink.add(_onWindowEnd(List<S>.unmodifiable(queue)));
       }
 
       // prepare the buffer for the next window.
@@ -301,19 +306,16 @@ class BackpressureStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
 
   @override
   Stream<T> bind(Stream<S> stream) {
-    final forwardedStream = forwardStream<S>(stream);
-
-    return Stream.eventTransformed(
-        forwardedStream.stream,
-        (sink) => _BackpressureStreamSink<S, T>(
-            sink,
-            strategy,
-            windowStreamFactory,
-            onWindowStart,
-            onWindowEnd,
-            startBufferEvery,
-            closeWindowWhen,
-            ignoreEmptyWindows,
-            dispatchOnClose));
+    var sink = _BackpressureStreamSink(
+      strategy,
+      windowStreamFactory,
+      onWindowStart,
+      onWindowEnd,
+      startBufferEvery,
+      closeWindowWhen,
+      ignoreEmptyWindows,
+      dispatchOnClose,
+    );
+    return forwardStream(stream, sink);
   }
 }

--- a/lib/src/transformers/backpressure/throttle.dart
+++ b/lib/src/transformers/backpressure/throttle.dart
@@ -56,8 +56,13 @@ extension ThrottleExtensions<T> on Stream<T> {
   ///
   ///     Stream.fromIterable([1, 2, 3])
   ///       .throttleTime(Duration(seconds: 1))
-  Stream<T> throttleTime(Duration duration, {bool trailing = false}) =>
-      transform(ThrottleStreamTransformer<T>(
-          (_) => TimerStream<bool>(true, duration),
-          trailing: trailing));
+  Stream<T> throttleTime(Duration duration, {bool trailing = false}) {
+    ArgumentError.checkNotNull(duration, 'duration');
+    return transform(
+      ThrottleStreamTransformer<T>(
+        (_) => TimerStream<bool>(true, duration),
+        trailing: trailing,
+      ),
+    );
+  }
 }

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:rxdart/src/utils/forwarding_sink.dart';
 import 'package:rxdart/src/utils/forwarding_stream.dart';
@@ -14,74 +15,77 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
   final void Function(Future<dynamic> resumeSignal) _onPause;
   final void Function() _onResume;
 
-  final _HandlerCounter _bindHandlerCounter;
-  final _HandlerCounter _selfHandlerCounter = _HandlerCounter();
+//  final _HandlerCounter _bindHandlerCounter;
+//  final _HandlerCounter _selfHandlerCounter = _HandlerCounter();
 
   _DoStreamSink(
-      this._onCancel,
-      this._onData,
-      this._onDone,
-      this._onEach,
-      this._onError,
-      this._onListen,
-      this._onPause,
-      this._onResume,
-      this._bindHandlerCounter);
+    this._onCancel,
+    this._onData,
+    this._onDone,
+    this._onEach,
+    this._onError,
+    this._onListen,
+    this._onPause,
+    this._onResume,
+//    this._bindHandlerCounter,
+  );
 
   @override
   void add(EventSink<S> sink, S data) {
+    print('onData: $sink, $data');
+
     // test is this event already invoked doOnData
-    final canInvokeDoOnData =
-        _selfHandlerCounter.isSameOnDataIndexAs(_bindHandlerCounter);
+//    final canInvokeDoOnData =
+//        _selfHandlerCounter.isSameOnDataIndexAs(_bindHandlerCounter);
+//
+//    if (canInvokeDoOnData) {
+    // increment the bind-counter so that other potential sinks will not
+    // call doOnData for this event again.
+//      _bindHandlerCounter.incrementOnData();
 
-    if (canInvokeDoOnData) {
-      // increment the bind-counter so that other potential sinks will not
-      // call doOnData for this event again.
-      _bindHandlerCounter.incrementOnData();
-
-      try {
-        _onData?.call(data);
-      } catch (e, s) {
-        sink.addError(e, s);
-      }
-      try {
-        _onEach?.call(Notification.onData(data));
-      } catch (e, s) {
-        sink.addError(e, s);
-      }
+    try {
+      _onData?.call(data);
+    } catch (e, s) {
+      sink.addError(e, s);
     }
+    try {
+      _onEach?.call(Notification.onData(data));
+    } catch (e, s) {
+      sink.addError(e, s);
+    }
+//    }
 
     sink.add(data);
     // increment the self-counter, readying it for the next event.
-    _selfHandlerCounter.incrementOnData();
+//    _selfHandlerCounter.incrementOnData();
   }
 
   @override
   void addError(EventSink<S> sink, dynamic e, [st]) {
     // test is this error already invoked doOnData
-    final canInvokeDoOnError =
-        _selfHandlerCounter.isSameOnErrorIndexAs(_bindHandlerCounter);
+//    final canInvokeDoOnError =
+//        _selfHandlerCounter.isSameOnErrorIndexAs(_bindHandlerCounter);
 
-    if (canInvokeDoOnError) {
-      // increment the bind-counter so that other potential sinks will not
-      // call doOnError for this error again.
-      _bindHandlerCounter.incrementOnError();
+//    if (canInvokeDoOnError) {
+    // increment the bind-counter so that other potential sinks will not
+    // call doOnError for this error again.
+//      _bindHandlerCounter.incrementOnError();
 
-      try {
-        _onError?.call(e, st);
-      } catch (e, s) {
-        sink.addError(e, s);
-      }
-      try {
-        _onEach?.call(Notification.onError(e, st));
-      } catch (e, s) {
-        sink.addError(e, s);
-      }
+    try {
+      _onError?.call(e, st);
+    } catch (e, s) {
+      sink.addError(e, s);
     }
+    try {
+      _onEach?.call(Notification.onError(e, st));
+    } catch (e, s) {
+      sink.addError(e, s);
+    }
+//    }
 
     sink.addError(e, st);
     // increment the self-counter, readying it for the next error.
-    _selfHandlerCounter.incrementOnError();
+//    _selfHandlerCounter.incrementOnError();
   }
 
   @override
@@ -101,9 +105,9 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
 
   @override
   FutureOr onCancel(EventSink<S> sink) {
-    _selfHandlerCounter.reset();
-    _bindHandlerCounter.reset();
-
+//    _selfHandlerCounter.reset();
+//    _bindHandlerCounter.reset();
+//
     return _onCancel?.call();
   }
 
@@ -203,7 +207,7 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
 
   @override
   Stream<S> bind(Stream<S> stream) {
-    final handlerCounter = _HandlerCounter();
+//    final handlerCounter = _HandlerCounter();
     var sink = _DoStreamSink<S>(
       onCancel,
       onData,
@@ -213,7 +217,7 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
       onListen,
       onPause,
       onResume,
-      handlerCounter,
+//      handlerCounter,
     );
     return forwardStream(stream, sink);
   }
@@ -222,23 +226,23 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
 /// A utility class, used with doOnData and doOnError.
 /// The class simply holds counters, so that doOnData and doOnError handlers
 /// are only called once for multiple registered subscribers.
-class _HandlerCounter {
-  int _onDataCounter = 0, _onErrorCounter = 0;
-
-  void incrementOnData() => _onDataCounter++;
-
-  void incrementOnError() => _onErrorCounter++;
-
-  void reset() {
-    _onDataCounter = _onErrorCounter = 0;
-  }
-
-  bool isSameOnDataIndexAs(_HandlerCounter otherCounter) =>
-      _onDataCounter == otherCounter._onDataCounter;
-
-  bool isSameOnErrorIndexAs(_HandlerCounter otherCounter) =>
-      _onErrorCounter == otherCounter._onErrorCounter;
-}
+//class _HandlerCounter {
+//  int _onDataCounter = 0, _onErrorCounter = 0;
+//
+//  void incrementOnData() => _onDataCounter++;
+//
+//  void incrementOnError() => _onErrorCounter++;
+//
+//  void reset() {
+//    _onDataCounter = _onErrorCounter = 0;
+//  }
+//
+//  bool isSameOnDataIndexAs(_HandlerCounter otherCounter) =>
+//      _onDataCounter == otherCounter._onDataCounter;
+//
+//  bool isSameOnErrorIndexAs(_HandlerCounter otherCounter) =>
+//      _onErrorCounter == otherCounter._onErrorCounter;
+//}
 
 /// Extends the Stream class with the ability to execute a callback function
 /// at different points in the Stream's lifecycle.

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -39,8 +39,16 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
       // call doOnData for this event again.
       _bindHandlerCounter.incrementOnData();
 
-      _onData?.call(data);
-      _onEach?.call(Notification.onData(data));
+      try {
+        _onData?.call(data);
+      } catch (e, s) {
+        sink.addError(e, s);
+      }
+      try {
+        _onEach?.call(Notification.onData(data));
+      } catch (e, s) {
+        sink.addError(e, s);
+      }
     }
 
     sink.add(data);
@@ -59,8 +67,16 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
       // call doOnError for this error again.
       _bindHandlerCounter.incrementOnError();
 
-      _onError?.call(e, st);
-      _onEach?.call(Notification.onError(e, st));
+      try {
+        _onError?.call(e, st);
+      } catch (e, s) {
+        sink.addError(e, s);
+      }
+      try {
+        _onEach?.call(Notification.onError(e, st));
+      } catch (e, s) {
+        sink.addError(e, s);
+      }
     }
 
     sink.addError(e, st);
@@ -70,8 +86,16 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
 
   @override
   void close(EventSink<S> sink) {
-    _onDone?.call();
-    _onEach?.call(Notification.onDone());
+    try {
+      _onDone?.call();
+    } catch (e, s) {
+      sink.addError(e, s);
+    }
+    try {
+      _onEach?.call(Notification.onDone());
+    } catch (e, s) {
+      sink.addError(e, s);
+    }
     sink.close();
   }
 

--- a/lib/src/transformers/on_error_resume.dart
+++ b/lib/src/transformers/on_error_resume.dart
@@ -125,7 +125,7 @@ extension OnErrorExtensions<T> on Stream<T> {
   ///       .listen(print); // prints 1
   Stream<T> onErrorReturn(T returnValue) =>
       transform(OnErrorResumeStreamTransformer<T>(
-          (dynamic e) => Stream<T>.fromIterable([returnValue])));
+          (dynamic e) => Stream.value(returnValue)));
 
   /// instructs a Stream to emit a particular item created by the
   /// [returnFn] when it encounters an error, and then terminate normally.
@@ -148,5 +148,5 @@ extension OnErrorExtensions<T> on Stream<T> {
   ///       .listen(print); // prints 1
   Stream<T> onErrorReturnWith(T Function(dynamic error) returnFn) =>
       transform(OnErrorResumeStreamTransformer<T>(
-          (dynamic e) => Stream<T>.fromIterable([returnFn(e)])));
+          (dynamic e) => Stream.value(returnFn(e))));
 }

--- a/lib/src/transformers/take_while_inclusive.dart
+++ b/lib/src/transformers/take_while_inclusive.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 
-import 'package:rxdart/src/utils/forwarding_sink.dart';
-
-class _TakeWhileInclusiveStreamSink<S> implements ForwardingSink<S> {
+class _TakeWhileInclusiveStreamSink<S> implements EventSink<S> {
   final bool Function(S) _test;
   final EventSink<S> _outputSink;
 
@@ -34,18 +32,6 @@ class _TakeWhileInclusiveStreamSink<S> implements ForwardingSink<S> {
 
   @override
   void close() => _outputSink.close();
-
-  @override
-  FutureOr onCancel(EventSink<S> sink) {}
-
-  @override
-  void onListen(EventSink<S> sink) {}
-
-  @override
-  void onPause(EventSink<S> sink, [Future resumeSignal]) {}
-
-  @override
-  void onResume(EventSink<S> sink) {}
 }
 
 /// Emits values emitted by the source Stream so long as each value

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 /// Acts as a container for multiple subscriptions that can be canceled at once
-/// e.g. view subcriptions in Flutter that need to be canceled on view disposal
+/// e.g. view subscriptions in Flutter that need to be canceled on view disposal
 ///
 /// Can be cleared or disposed. When disposed, cannot be used again.
 /// ### Example
@@ -47,7 +47,7 @@ class CompositeSubscription {
     return subscription;
   }
 
-  /// Cancels subscripiton and removes it from this composite.
+  /// Cancels subscriptions and removes it from this composite.
   void remove(StreamSubscription<dynamic> subscription) {
     subscription.cancel();
     _subscriptionsList.remove(subscription);

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -47,7 +47,7 @@ class CompositeSubscription {
     return subscription;
   }
 
-  /// Cancels subscriptions and removes it from this composite.
+  /// Cancels subscription and removes it from this composite.
   void remove(StreamSubscription<dynamic> subscription) {
     subscription.cancel();
     _subscriptionsList.remove(subscription);

--- a/lib/src/utils/forwarding_sink.dart
+++ b/lib/src/utils/forwarding_sink.dart
@@ -8,16 +8,25 @@ import 'dart:async';
 /// The [ForwardingSink] has been designed to handle asynchronous events from
 /// [Stream]s. See, for example, [Stream.eventTransformed] which uses
 /// `EventSink`s to transform events.
-abstract class ForwardingSink<T> implements EventSink<T> {
+abstract class ForwardingSink<T, R> {
+  ///
+  void add(EventSink<R> sink, T data);
+
+  ///
+  void addError(EventSink<R> sink, dynamic error, [StackTrace st]);
+
+  ///
+  void close(EventSink<R> sink);
+
   /// Fires when a listener subscribes on the underlying [Stream].
-  void onListen(EventSink<T> sink);
+  void onListen(EventSink<R> sink);
 
   /// Fires when a subscriber pauses.
-  void onPause(EventSink<T> sink, [Future resumeSignal]);
+  void onPause(EventSink<R> sink, [Future resumeSignal]);
 
   /// Fires when a subscriber resumes after a pause.
-  void onResume(EventSink<T> sink);
+  void onResume(EventSink<R> sink);
 
   /// Fires when a subscriber cancels.
-  FutureOr onCancel(EventSink<T> sink);
+  FutureOr onCancel(EventSink<R> sink);
 }

--- a/lib/src/utils/forwarding_sink.dart
+++ b/lib/src/utils/forwarding_sink.dart
@@ -9,13 +9,13 @@ import 'dart:async';
 /// [Stream]s. See, for example, [Stream.eventTransformed] which uses
 /// `EventSink`s to transform events.
 abstract class ForwardingSink<T, R> {
-  ///
+  /// Handle data event
   void add(EventSink<R> sink, T data);
 
-  ///
+  /// Handle error event
   void addError(EventSink<R> sink, dynamic error, [StackTrace st]);
 
-  ///
+  /// Handle close event
   void close(EventSink<R> sink);
 
   /// Fires when a listener subscribes on the underlying [Stream].

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -34,8 +34,8 @@ Stream<R> forwardStream<T, R>(
     subscription = stream.listen(
       (data) => runCatching(() => connectedSink.add(controller, data)),
       onError: (dynamic e, StackTrace st) =>
-          connectedSink.addError(controller, e, st),
-      onDone: () => connectedSink.close(controller),
+          runCatching(() => connectedSink.addError(controller, e, st)),
+      onDone: () => runCatching(() => connectedSink.close(controller)),
     );
   };
 

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:rxdart/rxdart.dart';
 import 'package:rxdart/src/utils/forwarding_sink.dart';
 
 import 'forwarding_sink.dart';
@@ -61,13 +60,7 @@ Stream<R> forwardStream<T, R>(
 
   // Create a new Controller, which will serve as a trampoline for
   // forwarded events.
-  if (stream is Subject<T>) {
-    controller = stream.createForwardingController<R>(
-      onListen: onListen,
-      onCancel: onCancel,
-      sync: true,
-    );
-  } else if (stream.isBroadcast) {
+  if (stream.isBroadcast) {
     controller = StreamController<R>.broadcast(
       onListen: onListen,
       onCancel: onCancel,

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -61,7 +61,13 @@ Stream<R> forwardStream<T, R>(
 
   // Create a new Controller, which will serve as a trampoline for
   // forwarded events.
-  if (stream.isBroadcast) {
+  if (stream is Subject<T>) {
+    controller = stream.createForwardingController<R>(
+      onListen: onListen,
+      onCancel: onCancel,
+      sync: true,
+    );
+  } else if (stream.isBroadcast) {
     controller = StreamController<R>.broadcast(
       onListen: onListen,
       onCancel: onCancel,

--- a/test/streams/replay_connectable_stream_test.dart
+++ b/test/streams/replay_connectable_stream_test.dart
@@ -32,7 +32,7 @@ void main() {
       stream.listen(expectAsync1((int i) {
         expect(stream.values, items.sublist(0, i));
       }, count: items.length));
-    }, skip: true);
+    });
 
     test('stops emitting after the connection is cancelled', () async {
       final ConnectableStream<int> stream =

--- a/test/transformers/backpressure/throttle_test.dart
+++ b/test/transformers/backpressure/throttle_test.dart
@@ -84,7 +84,7 @@ void main() {
   test('Rx.throttle.error.shouldThrowB', () {
     expect(() => Stream.value(1).throttle(null),
         throwsA(const TypeMatcher<AssertionError>()));
-  }, skip: true);
+  });
 
   test('Rx.throttle.pause.resume', () async {
     StreamSubscription<int> subscription;

--- a/test/transformers/backpressure/throttle_time_test.dart
+++ b/test/transformers/backpressure/throttle_time_test.dart
@@ -54,9 +54,11 @@ void main() {
   });
 
   test('Rx.throttleTime.error.shouldThrowB', () {
-    expect(() => Stream.value(1).throttleTime(null),
-        throwsA(const TypeMatcher<AssertionError>()));
-  }, skip: true);
+    expect(
+      () => Stream.value(1).throttleTime(null),
+      throwsArgumentError,
+    );
+  });
 
   test('Rx.throttleTime.pause.resume', () async {
     StreamSubscription<int> subscription;

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -130,17 +130,12 @@ void main() {
 
       await controller.close();
 
-      final stream =
-          controller.stream.transform(DoStreamTransformer(onData: actual.add));
-
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-
-      await stream.listen(null);
+      controller.stream.doOnData(actual.add).listen(null);
       await expectLater(actual, const [1, 2]);
 
       actual.clear();
 
-      await stream.listen(null);
+      controller.stream.doOnData(actual.add).listen(null);
       await expectLater(actual, const [1, 2]);
     });
 
@@ -413,41 +408,41 @@ void main() {
         'B: 0',
         'pause',
         'A: 1',
-        'A: 2',
-        'A: 3',
-        'A: 4',
-        'A: 5',
-        'A: 6',
-        'A: 7',
-        'A: 8',
-        'A: 9',
-        'A: 10',
-        'A: 11',
-        'A: 12',
-        'A: 13',
-        'A: 14',
-        'A: 15',
-        'A: 16',
-        'A: 17',
-        'A: 18',
-        'A: 19',
         'B: 1',
+        'A: 2',
         'B: 2',
+        'A: 3',
         'B: 3',
+        'A: 4',
         'B: 4',
+        'A: 5',
         'B: 5',
         'pause',
-        'A: 20',
-        'A: 21',
-        'A: 22',
-        'A: 23',
-        'A: 24',
-        'A: 25',
-        'A: 26',
-        'A: 27',
-        'A: 28',
-        'A: 29',
-        'A: 30'
+        'A: 6',
+        'B: 6',
+        'A: 7',
+        'B: 7',
+        'A: 8',
+        'B: 8',
+        'A: 9',
+        'B: 9',
+        'A: 10',
+        'B: 10',
+        'pause',
+        'A: 11',
+        'B: 11',
+        'A: 12',
+        'B: 12',
+        'A: 13',
+        'B: 13',
+        'A: 14',
+        'B: 14',
+        'A: 15',
+        'B: 15',
+        'pause',
+        'A: 16',
+        'B: 16',
+        'A: 17',
       ];
       StreamSubscription<int> subscription;
 

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -264,22 +264,32 @@ void main() {
     test('should propagate errors', () {
       Stream.value(1)
           .doOnListen(() => throw Exception('catch me if you can! doOnListen'))
-          .listen(null,
-              onError: expectAsync2(
-                  (Exception e, [StackTrace s]) => expect(e, isException)));
+          .listen(
+            null,
+            onError: expectAsync2(
+              (Exception e, [StackTrace s]) => expect(e, isException),
+            ),
+          );
 
       Stream.value(1)
           .doOnData((_) => throw Exception('catch me if you can! doOnData'))
-          .listen(null,
-              onError: expectAsync2(
-                  (Exception e, [StackTrace s]) => expect(e, isException)));
+          .listen(
+            null,
+            onError: expectAsync2(
+              (Exception e, [StackTrace s]) => expect(e, isException),
+            ),
+          );
 
       Stream<void>.error(Exception('oh noes!'))
           .doOnError((dynamic _, dynamic __) =>
               throw Exception('catch me if you can! doOnError'))
-          .listen(null,
-              onError: expectAsync2(
-                  (Exception e, [StackTrace s]) => expect(e, isException)));
+          .listen(
+            null,
+            onError: expectAsync2(
+              (Exception e, [StackTrace s]) => expect(e, isException),
+              count: 2,
+            ),
+          );
 
       // a cancel() call may occur after the controller is already closed
       // in that case, the error is forwarded to the current [Zone]

--- a/test/transformers/switch_if_empty_test.dart
+++ b/test/transformers/switch_if_empty_test.dart
@@ -4,6 +4,29 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('aaaaa', () async {
+    var s = Stream.periodic(Duration(milliseconds: 200), (i) => i).doOnData((d) => print('>>>>:$d'));
+
+    var sub = Stream<int>.empty()
+        .switchIfEmpty(s)
+        .listen(print);
+
+    await Future<void>.delayed(Duration(seconds: 1));
+    print('Start pause');
+    sub.pause();
+    await Future<void>.delayed(Duration(seconds: 1));
+    print('Start resume');
+    sub.resume();
+
+    await Future<void>.delayed(Duration(seconds: 3));
+
+    print('Cancel');
+    await sub.cancel();
+
+    await Future<void>.delayed(Duration(seconds: 3));
+    print('done2');
+  });
+
   test('Rx.switchIfEmpty.whenEmpty', () async {
     expect(
       Stream<int>.empty().switchIfEmpty(Stream.value(1)),

--- a/test/transformers/switch_if_empty_test.dart
+++ b/test/transformers/switch_if_empty_test.dart
@@ -4,29 +4,6 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('aaaaa', () async {
-    var s = Stream.periodic(Duration(milliseconds: 200), (i) => i).doOnData((d) => print('>>>>:$d'));
-
-    var sub = Stream<int>.empty()
-        .switchIfEmpty(s)
-        .listen(print);
-
-    await Future<void>.delayed(Duration(seconds: 1));
-    print('Start pause');
-    sub.pause();
-    await Future<void>.delayed(Duration(seconds: 1));
-    print('Start resume');
-    sub.resume();
-
-    await Future<void>.delayed(Duration(seconds: 3));
-
-    print('Cancel');
-    await sub.cancel();
-
-    await Future<void>.delayed(Duration(seconds: 3));
-    print('done2');
-  });
-
   test('Rx.switchIfEmpty.whenEmpty', () async {
     expect(
       Stream<int>.empty().switchIfEmpty(Stream.value(1)),


### PR DESCRIPTION
* Rewriting forward stream transformer, now doesn't need `SafeClose` interface to fix close behavior
* Cancel subscriptions of other streams when source stream is cancelled
* Fix some typos in `CompositeSubscription`
* Using `Stream.value(value)` instead of `Stream.fromIterables([value])` in `OnErrorExtensions`
* `_TakeWhileInclusiveStreamSink` implements `EventSink` instead of `ForwardingSink`