### PR TITLE
update(RangeStream): use Iterable.generate instead of List.generate

### DIFF
--- a/lib/src/streams/range.dart
+++ b/lib/src/streams/range.dart
@@ -28,6 +28,6 @@ class RangeStream extends Stream<int> {
         ? startInclusive - index
         : startInclusive + index;
 
-    return Stream.fromIterable(List.generate(length, nextValue));
+    return Stream.fromIterable(Iterable.generate(length, nextValue));
   }
 }


### PR DESCRIPTION
update(RangeStream): use `Iterable.generate` instead of `List.generate`
I think we can use `Iterable.generate` to avoid unnecessary buffer allocation

Simple measurement time in 2 cases
```dart
  test('RangeStream', () async {
    var watch = Stopwatch()..start();
    await RangeStream(0, 10000000).take(1000).forEach((_) {});
    print('elapsed: ${watch.elapsedMilliseconds}');
  });
```
* List.generate: ~ 140ms
* Iterable.generate: ~30 ms