### PR TITLE
Rx.combineLatestList([]) emits a single empty result.

### DIFF
--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -287,6 +287,11 @@ class CombineLatestStream<T, R> extends StreamView<R> {
     Iterable<Stream<T>> streams,
     R Function(List<T> values) combiner,
   ) {
+    if (streams.isEmpty) {
+      return StreamController()
+        ..add(combiner([]))
+        ..close();
+    }
     final len = streams.length;
     List<StreamSubscription<dynamic>> subscriptions;
     StreamController<R> controller;

--- a/test/streams/combine_latest_test.dart
+++ b/test/streams/combine_latest_test.dart
@@ -18,6 +18,11 @@ Stream<bool> get streamC {
 }
 
 void main() {
+  test('Rx.combineLatestList.isEmpty', () {
+    expect(Rx.combineLatestList<dynamic>([]),
+        emitsInOrder(<dynamic>[<dynamic>[]]));
+  });
+
   test('Rx.combineLatestList', () async {
     final combined = Rx.combineLatestList<int>([
       Stream.fromIterable([1, 2, 3]),


### PR DESCRIPTION
* Before this change: `Rx.combineLatestList([])` never emits, and never completes.
* After this change: it emits a single empty list, and then completes.

The latter behavior is consistent with RxSwift https://github.com/ReactiveX/RxSwift/commit/5289de9a1cb531b36733db2601c925ee23a554e4

The behavior of rxjs is to complete immediately and emit nothing, but this seems less useful and counter-intuitive: https://rxjs-dev.firebaseapp.com/api/index/function/combineLatest