### PR TITLE
Streams: deal with empty Iterable of streams

### DIFF
--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -83,6 +83,9 @@ abstract class Rx {
   /// The Stream will not emit any lists of values until all of the source
   /// streams have emitted at least one value.
   ///
+  /// If the provided streams is empty, the resulting sequence completes immediately
+  /// without emitting any items and without any calls to the combiner function.
+  ///
   /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
   ///
   /// ### Example
@@ -102,6 +105,9 @@ abstract class Rx {
   ///
   /// The Stream will not emit any lists of values until all of the source
   /// streams have emitted at least one value.
+  ///
+  /// If the provided streams is empty, the resulting sequence completes immediately
+  /// without emitting any items and without any calls to the combiner function.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
   ///
@@ -376,6 +382,9 @@ abstract class Rx {
   /// It does this by subscribing to each stream one by one, emitting all items
   /// and completing before subscribing to the next stream.
   ///
+  /// If the provided streams is empty, the resulting sequence completes immediately
+  /// without emitting any items.
+  ///
   /// [Interactive marble diagram](http://rxmarbles.com/#concat)
   ///
   /// ### Example
@@ -396,6 +405,9 @@ abstract class Rx {
   /// the next, all streams are immediately subscribed to. The events are then
   /// captured and emitted at the correct time, after the previous stream has
   /// finished emitting items.
+  ///
+  /// If the provided streams is empty, the resulting sequence completes immediately
+  /// without emitting any items.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#concat)
   ///
@@ -451,6 +463,9 @@ abstract class Rx {
   ///
   /// In these cases you may better off with an operator like combineLatest or zip.
   ///
+  /// If the provided streams is empty, the resulting sequence completes immediately
+  /// without emitting any items and without any calls to the combiner function.
+  ///
   /// ### Example
   ///
   ///    Rx.forkJoin([
@@ -465,6 +480,9 @@ abstract class Rx {
   /// Merges the given Streams into a single Stream that emits a List of the
   /// last values emitted by the source stream(s). This is helpful when you need to
   /// forkJoin a dynamic number of Streams.
+  ///
+  /// If the provided streams is empty, the resulting sequence completes immediately
+  /// without emitting any items and without any calls to the combiner function.
   ///
   /// ### Example
   ///
@@ -689,6 +707,9 @@ abstract class Rx {
 
   /// Flattens the items emitted by the given [streams] into a single Stream
   /// sequence.
+  ///
+  /// If the provided streams is empty, the resulting sequence completes immediately
+  /// without emitting any items.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#merge)
   ///

--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -107,7 +107,7 @@ abstract class Rx {
   /// streams have emitted at least one value.
   ///
   /// If the provided streams is empty, the resulting sequence completes immediately
-  /// without emitting any items and without any calls to the combiner function.
+  /// without emitting any items.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
   ///
@@ -482,7 +482,7 @@ abstract class Rx {
   /// forkJoin a dynamic number of Streams.
   ///
   /// If the provided streams is empty, the resulting sequence completes immediately
-  /// without emitting any items and without any calls to the combiner function.
+  /// without emitting any items.
   ///
   /// ### Example
   ///
@@ -739,6 +739,9 @@ abstract class Rx {
   /// Given two or more source [streams], emit all of the items from only
   /// the first of these [streams] to emit an item or notification.
   ///
+  /// If the provided streams is empty, the resulting sequence completes immediately
+  /// without emitting any items.
+  ///
   /// [Interactive marble diagram](http://rxmarbles.com/#amb)
   ///
   /// ### Example
@@ -952,6 +955,9 @@ abstract class Rx {
   /// many items as the number of items emitted by the source Stream that
   /// emits the fewest items.
   ///
+  /// If the provided streams is empty, the resulting sequence completes immediately
+  /// without emitting any items and without any calls to the zipper function.
+  ///
   /// [Interactive marble diagram](http://rxmarbles.com/#zip)
   ///
   /// ### Example
@@ -980,6 +986,9 @@ abstract class Rx {
   /// second item emitted by Stream #2; and so forth. It will only emit as
   /// many items as the number of items emitted by the source Stream that
   /// emits the fewest items.
+  ///
+  /// If the provided streams is empty, the resulting sequence completes immediately
+  /// without emitting any items.
   ///
   /// [Interactive marble diagram](http://rxmarbles.com/#zip)
   ///

--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -7,6 +7,9 @@ import 'dart:async';
 /// The Stream will not emit until all Streams have emitted at least one
 /// item.
 ///
+/// If the provided streams is empty, the resulting sequence completes immediately
+/// without emitting any items and without any calls to the combiner function.
+///
 /// [Interactive marble diagram](http://rxmarbles.com/#combineLatest)
 ///
 /// ### Basic Example
@@ -287,6 +290,10 @@ class CombineLatestStream<T, R> extends StreamView<R> {
     Iterable<Stream<T>> streams,
     R Function(List<T> values) combiner,
   ) {
+    if (streams.isEmpty) {
+      return StreamController<R>()..close();
+    }
+
     final len = streams.length;
     List<StreamSubscription<dynamic>> subscriptions;
     StreamController<R> controller;

--- a/lib/src/streams/concat.dart
+++ b/lib/src/streams/concat.dart
@@ -6,6 +6,9 @@ import 'dart:async';
 /// It does this by subscribing to each stream one by one, emitting all items
 /// and completing before subscribing to the next stream.
 ///
+/// If the provided streams is empty, the resulting sequence completes immediately
+/// without emitting any items.
+///
 /// [Interactive marble diagram](http://rxmarbles.com/#concat)
 ///
 /// ### Example
@@ -39,9 +42,11 @@ class ConcatStream<T> extends Stream<T> {
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {
       throw ArgumentError('Streams cannot be null');
-    } else if (streams.isEmpty) {
-      throw ArgumentError('At least 1 stream needs to be provided');
-    } else if (streams.any((Stream<T> stream) => stream == null)) {
+    }
+    if (streams.isEmpty) {
+      return StreamController<T>()..close();
+    }
+    if (streams.any((Stream<T> stream) => stream == null)) {
       throw ArgumentError('One of the provided streams is null');
     }
 

--- a/lib/src/streams/concat_eager.dart
+++ b/lib/src/streams/concat_eager.dart
@@ -10,6 +10,9 @@ import 'package:rxdart/src/streams/concat.dart';
 /// captured and emitted at the correct time, after the previous stream has
 /// finished emitting items.
 ///
+/// If the provided streams is empty, the resulting sequence completes immediately
+/// without emitting any items.
+///
 /// [Interactive marble diagram](http://rxmarbles.com/#concat)
 ///
 /// ### Example
@@ -41,9 +44,11 @@ class ConcatEagerStream<T> extends Stream<T> {
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {
       throw ArgumentError('streams cannot be null');
-    } else if (streams.isEmpty) {
-      throw ArgumentError('at least 1 stream needs to be provided');
-    } else if (streams.any((Stream<T> stream) => stream == null)) {
+    }
+    if (streams.isEmpty) {
+      return StreamController<T>()..close();
+    }
+    if (streams.any((Stream<T> stream) => stream == null)) {
       throw ArgumentError('One of the provided streams is null');
     }
 

--- a/lib/src/streams/fork_join.dart
+++ b/lib/src/streams/fork_join.dart
@@ -20,6 +20,9 @@ import 'dart:async';
 ///
 /// In these cases you may better off with an operator like combineLatest or zip.
 ///
+/// If the provided streams is empty, the resulting sequence completes immediately
+/// without emitting any items and without any calls to the combiner function.
+///
 /// ### Basic Example
 ///
 /// This constructor takes in an `Iterable<Stream<T>>` and outputs a
@@ -67,7 +70,6 @@ class ForkJoinStream<T, R> extends StreamView<R> {
     R Function(List<T> values) combiner,
   )   : assert(streams != null && streams.every((s) => s != null),
             'streams cannot be null'),
-        assert(streams.isNotEmpty, 'provide at least 1 stream'),
         assert(combiner != null, 'must provide a combiner function'),
         super(_buildController(streams, combiner).stream);
 
@@ -300,6 +302,10 @@ class ForkJoinStream<T, R> extends StreamView<R> {
     Iterable<Stream<T>> streams,
     R Function(List<T> values) combiner,
   ) {
+    if (streams.isEmpty) {
+      return StreamController<R>()..close();
+    }
+
     StreamController<R> controller;
 
     controller = StreamController<R>(

--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -3,6 +3,9 @@ import 'dart:async';
 /// Flattens the items emitted by the given streams into a single Stream
 /// sequence.
 ///
+/// If the provided streams is empty, the resulting sequence completes immediately
+/// without emitting any items.
+///
 /// [Interactive marble diagram](http://rxmarbles.com/#merge)
 ///
 /// ### Example
@@ -29,9 +32,11 @@ class MergeStream<T> extends Stream<T> {
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {
       throw ArgumentError('streams cannot be null');
-    } else if (streams.isEmpty) {
-      throw ArgumentError('at least 1 stream needs to be provided');
-    } else if (streams.any((Stream<T> stream) => stream == null)) {
+    }
+    if (streams.isEmpty) {
+      return StreamController<T>()..close();
+    }
+    if (streams.any((Stream<T> stream) => stream == null)) {
       throw ArgumentError('One of the provided streams is null');
     }
 

--- a/lib/src/streams/race.dart
+++ b/lib/src/streams/race.dart
@@ -3,6 +3,9 @@ import 'dart:async';
 /// Given two or more source streams, emit all of the items from only
 /// the first of these streams to emit an item or notification.
 ///
+/// If the provided streams is empty, the resulting sequence completes immediately
+/// without emitting any items.
+///
 /// [Interactive marble diagram](http://rxmarbles.com/#amb)
 ///
 /// ### Example
@@ -32,8 +35,9 @@ class RaceStream<T> extends Stream<T> {
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     if (streams == null) {
       throw ArgumentError('streams cannot be null');
-    } else if (streams.isEmpty) {
-      throw ArgumentError('provide at least 1 stream');
+    }
+    if (streams.isEmpty) {
+      return StreamController<T>()..close();
     }
 
     List<StreamSubscription<T>> subscriptions;

--- a/test/streams/combine_latest_test.dart
+++ b/test/streams/combine_latest_test.dart
@@ -35,6 +35,11 @@ void main() {
     );
   });
 
+  test('Rx.combineLatestList.empty', () async {
+    final combined = Rx.combineLatestList<int>([]);
+    expect(combined, emitsDone);
+  });
+
   test('Rx.combineLatest', () async {
     final combined = Rx.combineLatest<int, int>(
       [

--- a/test/streams/concat_eager_test.dart
+++ b/test/streams/concat_eager_test.dart
@@ -106,10 +106,6 @@ void main() {
   });
 
   test('Rx.concatEager.error.shouldThrowC', () {
-    expect(() => Rx.concatEager<int>(const []), throwsArgumentError);
-  });
-
-  test('Rx.concatEager.error.shouldThrowD', () {
     expect(() => Rx.concatEager([Stream.value(1), null]), throwsArgumentError);
   });
 
@@ -131,5 +127,9 @@ void main() {
     }, count: 1));
 
     subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
+  });
+
+  test('Rx.concatEager.empty', () {
+    expect(Rx.concatEager<int>(const []), emitsDone);
   });
 }

--- a/test/streams/concat_test.dart
+++ b/test/streams/concat_test.dart
@@ -106,15 +106,15 @@ void main() {
   });
 
   test('Rx.concat.error.shouldThrowC', () {
-    expect(() => Rx.concat<int>(const []), throwsArgumentError);
-  });
-
-  test('Rx.concat.error.shouldThrowD', () {
     expect(
         () => [
               Rx.concat([Stream.value(1), null]),
               null
             ],
         throwsArgumentError);
+  });
+
+  test('Rx.concat.empty', () {
+    expect(Rx.concat<int>(const []), emitsDone);
   });
 }

--- a/test/streams/fork_join_test.dart
+++ b/test/streams/fork_join_test.dart
@@ -34,6 +34,10 @@ void main() {
     );
   });
 
+  test('Rx.forkJoin.empty', () {
+    expect(Rx.forkJoinList<int>([]), emitsDone);
+  });
+
   test('Rx.forkJoinList.singleStream', () async {
     final combined = Rx.forkJoinList<int>([
       Stream.fromIterable([1, 2, 3])

--- a/test/streams/merge_test.dart
+++ b/test/streams/merge_test.dart
@@ -50,10 +50,6 @@ void main() {
   });
 
   test('Rx.merge.error.shouldThrowC', () {
-    expect(() => Rx.merge<int>(const []), throwsArgumentError);
-  });
-
-  test('Rx.merge.error.shouldThrowD', () {
     expect(() => Rx.merge([Stream.value(1), null]), throwsArgumentError);
   });
 
@@ -74,5 +70,9 @@ void main() {
     }, count: 1));
 
     subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
+  });
+
+  test('Rx.merge.empty', () {
+    expect(Rx.merge<int>(const []), emitsDone);
   });
 }

--- a/test/streams/race_test.dart
+++ b/test/streams/race_test.dart
@@ -55,11 +55,7 @@ void main() {
     expect(() => Rx.race<Null>(null), throwsArgumentError);
   });
 
-  test('Rx.race.shouldThrowB', () {
-    expect(() => Rx.race<Null>(const []), throwsArgumentError);
-  });
-
-  test('Rx.race.shouldThrowC', () async {
+  test('Rx.race.shouldThrowB', () async {
     final stream = Rx.race([Stream<Null>.error(Exception('oh noes!'))]);
 
     // listen twice on same stream
@@ -82,5 +78,9 @@ void main() {
     }, count: 1));
 
     subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
+  });
+
+  test('Rx.race.empty', () {
+    expect(Rx.race<int>(const []), emitsDone);
   });
 }

--- a/test/streams/zip_test.dart
+++ b/test/streams/zip_test.dart
@@ -14,6 +14,10 @@ void main() {
     );
   });
 
+  test('Rx.zip.empty', () {
+    expect(Rx.zipList<int>([]), emitsDone);
+  });
+
   test('Rx.zipList', () async {
     expect(
       Rx.zipList([


### PR DESCRIPTION
Related to #457 
* Change for operators: `combineLatest`, `concat`, `concatEager`, `forkJoin`, `merge`, `race`, `zip`.
* Change: when passing an empty `Iterable<Stream>`, the resulting stream completes immediately without emitting any items. This behavior is the same that `rxjs`'s, `RxJava`'s operators.