### PR TITLE
Improves pairwise() docs for first event emission.

### DIFF
--- a/lib/src/transformers/backpressure/pairwise.dart
+++ b/lib/src/transformers/backpressure/pairwise.dart
@@ -1,7 +1,8 @@
 import 'package:rxdart/src/streams/never.dart';
 import 'package:rxdart/src/transformers/backpressure/backpressure.dart';
 
-/// Emits the n-th and n-1th events as a pair..
+/// Emits the n-th and n-1th events as a pair.
+/// The first event won't be emitted until the second one arrives.
 ///
 /// ### Example
 ///
@@ -22,7 +23,7 @@ class PairwiseStreamTransformer<T>
 /// Extends the Stream class with the ability to emit the nth and n-1th events
 /// as a pair
 extension PairwiseExtension<T> on Stream<T> {
-  /// Emits the n-th and n-1th events as a pair..
+  /// Emits the n-th and n-1th events as a pair.
   ///
   /// ### Example
   ///

--- a/lib/src/transformers/backpressure/pairwise.dart
+++ b/lib/src/transformers/backpressure/pairwise.dart
@@ -24,6 +24,7 @@ class PairwiseStreamTransformer<T>
 /// as a pair
 extension PairwiseExtension<T> on Stream<T> {
   /// Emits the n-th and n-1th events as a pair.
+  /// The first event won't be emitted until the second one arrives.
   ///
   /// ### Example
   ///


### PR DESCRIPTION
Explains that pairwise() won't emit the first event until the second one arrives.

/// The first event won't be emitted until the second one arrives.