### PR TITLE
Bug/fix start with and forward stream

### DIFF
--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
 import 'package:rxdart/src/rx.dart';
+import 'package:rxdart/src/streams/connectable_stream.dart';
 import 'package:rxdart/src/streams/value_stream.dart';
 import 'package:rxdart/src/subjects/subject.dart';
+import 'package:rxdart/src/transformers/do.dart';
 import 'package:rxdart/src/transformers/start_with.dart';
 import 'package:rxdart/src/transformers/start_with_error.dart';
 
@@ -148,6 +150,17 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   /// Get the latest error emitted by the Subject
   @override
   Object get error => _wrapper.latestError;
+
+  @override
+  Stream<S> transform<S>(StreamTransformer<T, S> streamTransformer) {
+    final transformed = super.transform(streamTransformer);
+
+    if (transformed is! ValueStream) {
+      return transformed.publishValue();
+    }
+
+    return transformed;
+  }
 }
 
 class _Wrapper<T> {

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -4,7 +4,6 @@ import 'package:rxdart/src/rx.dart';
 import 'package:rxdart/src/streams/connectable_stream.dart';
 import 'package:rxdart/src/streams/value_stream.dart';
 import 'package:rxdart/src/subjects/subject.dart';
-import 'package:rxdart/src/transformers/do.dart';
 import 'package:rxdart/src/transformers/start_with.dart';
 import 'package:rxdart/src/transformers/start_with_error.dart';
 

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -104,11 +104,19 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
           _Wrapper<T> wrapper, StreamController<T> controller, bool sync) =>
       () {
         if (wrapper.latestIsError) {
+          if (sync) {
+            wrapper.setError(wrapper.latestError, wrapper.latestStackTrace);
+          }
+
           return controller.stream.transform(StartWithErrorStreamTransformer(
-              wrapper.latestError, wrapper.latestStackTrace, sync));
+              wrapper.latestError, wrapper.latestStackTrace));
         } else if (wrapper.latestIsValue) {
-          return controller.stream.transform(
-              StartWithStreamTransformer(wrapper.latestValue, sync: sync));
+          if (sync) {
+            wrapper.setValue(wrapper.latestValue);
+          }
+
+          return controller.stream
+              .transform(StartWithStreamTransformer(wrapper.latestValue));
         }
 
         return controller.stream;

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -105,17 +105,9 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
           _Wrapper<T> wrapper, StreamController<T> controller, bool sync) =>
       () {
         if (wrapper.latestIsError) {
-          if (sync) {
-            wrapper.setError(wrapper.latestError, wrapper.latestStackTrace);
-          }
-
           return controller.stream.transform(StartWithErrorStreamTransformer(
               wrapper.latestError, wrapper.latestStackTrace));
         } else if (wrapper.latestIsValue) {
-          if (sync) {
-            wrapper.setValue(wrapper.latestValue);
-          }
-
           return controller.stream
               .transform(StartWithStreamTransformer(wrapper.latestValue));
         }
@@ -155,7 +147,7 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
     final transformed = super.transform(streamTransformer);
 
     if (transformed is! ValueStream) {
-      return transformed.publishValue();
+      return transformed.shareValue();
     }
 
     return transformed;

--- a/lib/src/subjects/replay_subject.dart
+++ b/lib/src/subjects/replay_subject.dart
@@ -3,7 +3,6 @@ import 'dart:collection';
 
 import 'package:rxdart/rxdart.dart';
 import 'package:rxdart/src/rx.dart';
-import 'package:rxdart/src/streams/connectable_stream.dart';
 import 'package:rxdart/src/streams/replay_stream.dart';
 import 'package:rxdart/src/subjects/subject.dart';
 import 'package:rxdart/src/transformers/start_with_error.dart';

--- a/lib/src/subjects/replay_subject.dart
+++ b/lib/src/subjects/replay_subject.dart
@@ -76,11 +76,9 @@ class ReplaySubject<T> extends Subject<T> implements ReplayStream<T> {
           if (event.isError) {
             return stream.transform(StartWithErrorStreamTransformer(
                 event.errorAndStackTrace.error,
-                event.errorAndStackTrace.stackTrace,
-                sync));
+                event.errorAndStackTrace.stackTrace));
           } else {
-            return stream
-                .transform(StartWithStreamTransformer(event.event, sync: sync));
+            return stream.transform(StartWithStreamTransformer(event.event));
           }
         }),
         reusable: true,

--- a/lib/src/subjects/replay_subject.dart
+++ b/lib/src/subjects/replay_subject.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 
 import 'package:rxdart/rxdart.dart';
 import 'package:rxdart/src/rx.dart';
+import 'package:rxdart/src/streams/connectable_stream.dart';
 import 'package:rxdart/src/streams/replay_stream.dart';
 import 'package:rxdart/src/subjects/subject.dart';
 import 'package:rxdart/src/transformers/start_with_error.dart';

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -182,6 +182,7 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
           onPause,
           onResume,
         ),
+        inheritParentType: true,
       );
 }
 

--- a/lib/src/transformers/start_with.dart
+++ b/lib/src/transformers/start_with.dart
@@ -5,10 +5,9 @@ import 'package:rxdart/src/utils/forwarding_stream.dart';
 
 class _StartWithStreamSink<S> implements ForwardingSink<S, S> {
   final S _startValue;
-  final bool _sync;
   var _isFirstEventAdded = false;
 
-  _StartWithStreamSink(this._sync, this._startValue);
+  _StartWithStreamSink(this._startValue);
 
   @override
   void add(EventSink<S> sink, S data) {
@@ -33,9 +32,7 @@ class _StartWithStreamSink<S> implements ForwardingSink<S, S> {
 
   @override
   void onListen(EventSink<S> sink) {
-    _sync
-        ? _safeAddFirstEvent(sink)
-        : scheduleMicrotask(() => _safeAddFirstEvent(sink));
+    scheduleMicrotask(() => _safeAddFirstEvent(sink));
   }
 
   @override
@@ -70,17 +67,13 @@ class StartWithStreamTransformer<S> extends StreamTransformerBase<S, S> {
   /// The starting event of this [Stream]
   final S startValue;
 
-  /// @internal
-  /// Forces startWith to happen either sync or async
-  final bool sync;
-
   /// Constructs a [StreamTransformer] which prepends the source [Stream]
   /// with [startValue].
-  StartWithStreamTransformer(this.startValue, {this.sync = false});
+  StartWithStreamTransformer(this.startValue);
 
   @override
   Stream<S> bind(Stream<S> stream) =>
-      forwardStream(stream, _StartWithStreamSink(sync, startValue));
+      forwardStream(stream, _StartWithStreamSink(startValue));
 }
 
 /// Extends the [Stream] class with the ability to emit the given value as the

--- a/lib/src/transformers/start_with_error.dart
+++ b/lib/src/transformers/start_with_error.dart
@@ -4,12 +4,11 @@ import 'package:rxdart/src/utils/forwarding_sink.dart';
 import 'package:rxdart/src/utils/forwarding_stream.dart';
 
 class _StartWithErrorStreamSink<S> implements ForwardingSink<S, S> {
-  final bool _sync;
   final Object _e;
   final StackTrace _st;
   var _isFirstEventAdded = false;
 
-  _StartWithErrorStreamSink(this._sync, this._e, this._st);
+  _StartWithErrorStreamSink(this._e, this._st);
 
   @override
   void add(EventSink<S> sink, S data) {
@@ -34,9 +33,7 @@ class _StartWithErrorStreamSink<S> implements ForwardingSink<S, S> {
 
   @override
   void onListen(EventSink<S> sink) {
-    _sync
-        ? _safeAddFirstEvent(sink)
-        : scheduleMicrotask(() => _safeAddFirstEvent(sink));
+    scheduleMicrotask(() => _safeAddFirstEvent(sink));
   }
 
   @override
@@ -73,16 +70,11 @@ class StartWithErrorStreamTransformer<S> extends StreamTransformerBase<S, S> {
   /// The starting stackTrace of this [Stream]
   final StackTrace stackTrace;
 
-  /// @internal
-  /// Forces startWithError to happen either sync or async
-  final bool sync;
-
   /// Constructs a [StreamTransformer] which starts with the provided [error]
   /// and then outputs all events from the source [Stream].
-  StartWithErrorStreamTransformer(this.error,
-      [this.stackTrace, this.sync = false]);
+  StartWithErrorStreamTransformer(this.error, [this.stackTrace]);
 
   @override
   Stream<S> bind(Stream<S> stream) =>
-      forwardStream(stream, _StartWithErrorStreamSink(sync, error, stackTrace));
+      forwardStream(stream, _StartWithErrorStreamSink(error, stackTrace));
 }

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -68,14 +68,8 @@ Stream<R> forwardStream<T, R>(
         );
 
     if (inheritParentType) {
-      if (stream is BehaviorSubject) {
+      if (stream is ValueStream) {
         controller = BehaviorSubject<R>(
-          onListen: onListen,
-          onCancel: onCancel,
-          sync: true,
-        );
-      } else if (stream is ReplaySubject) {
-        controller = ReplaySubject<R>(
           onListen: onListen,
           onCancel: onCancel,
           sync: true,

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:rxdart/rxdart.dart';
 import 'package:rxdart/src/utils/forwarding_sink.dart';
 
 import 'forwarding_sink.dart';
@@ -61,11 +62,25 @@ Stream<R> forwardStream<T, R>(
   // Create a new Controller, which will serve as a trampoline for
   // forwarded events.
   if (stream.isBroadcast) {
-    controller = StreamController<R>.broadcast(
-      onListen: onListen,
-      onCancel: onCancel,
-      sync: true,
-    );
+    if (stream is BehaviorSubject) {
+      controller = BehaviorSubject<R>(
+        onListen: onListen,
+        onCancel: onCancel,
+        sync: true,
+      );
+    } else if (stream is ReplaySubject) {
+      controller = ReplaySubject<R>(
+        onListen: onListen,
+        onCancel: onCancel,
+        sync: true,
+      );
+    } else {
+      controller = StreamController<R>.broadcast(
+        onListen: onListen,
+        onCancel: onCancel,
+        sync: true,
+      );
+    }
   } else {
     controller = StreamController<R>(
       onListen: onListen,

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -11,9 +11,8 @@ import 'forwarding_sink.dart';
 /// It captures events such as onListen, onPause, onResume and onCancel,
 /// which can be used in pair with a [ForwardingSink]
 Stream<R> forwardStream<T, R>(
-  Stream<T> stream,
-  ForwardingSink<T, R> connectedSink,
-) {
+    Stream<T> stream, ForwardingSink<T, R> connectedSink,
+    {bool inheritParentType = false}) {
   ArgumentError.checkNotNull(stream, 'stream');
   ArgumentError.checkNotNull(connectedSink, 'connectedSink');
 
@@ -62,24 +61,30 @@ Stream<R> forwardStream<T, R>(
   // Create a new Controller, which will serve as a trampoline for
   // forwarded events.
   if (stream.isBroadcast) {
-    if (stream is BehaviorSubject) {
-      controller = BehaviorSubject<R>(
-        onListen: onListen,
-        onCancel: onCancel,
-        sync: true,
-      );
-    } else if (stream is ReplaySubject) {
-      controller = ReplaySubject<R>(
-        onListen: onListen,
-        onCancel: onCancel,
-        sync: true,
-      );
+    final buildBroadcastType = () => controller = StreamController<R>.broadcast(
+          onListen: onListen,
+          onCancel: onCancel,
+          sync: true,
+        );
+
+    if (inheritParentType) {
+      if (stream is BehaviorSubject) {
+        controller = BehaviorSubject<R>(
+          onListen: onListen,
+          onCancel: onCancel,
+          sync: true,
+        );
+      } else if (stream is ReplaySubject) {
+        controller = ReplaySubject<R>(
+          onListen: onListen,
+          onCancel: onCancel,
+          sync: true,
+        );
+      } else {
+        controller = buildBroadcastType();
+      }
     } else {
-      controller = StreamController<R>.broadcast(
-        onListen: onListen,
-        onCancel: onCancel,
-        sync: true,
-      );
+      controller = buildBroadcastType();
     }
   } else {
     controller = StreamController<R>(

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -549,7 +549,8 @@ void main() {
       expect(subject.hasError, isFalse);
     });
 
-    test('hasError returns false for an unseeded subject after an emission', () {
+    test('hasError returns false for an unseeded subject after an emission',
+        () {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>();
 
@@ -619,7 +620,8 @@ void main() {
       expect(seeded.error, isException);
     });
 
-    test('emits event after error to every subscriber, ensures error is null', () async {
+    test('emits event after error to every subscriber, ensures error is null',
+        () async {
       // ignore: close_sinks
       final unseeded = BehaviorSubject<int>(),
           // ignore: close_sinks
@@ -666,7 +668,7 @@ void main() {
       expect(mappedStream.value, equals(1));
 
       await subject.close();
-    });
+    }, skip: true);
 
     test('issue/419: sync throughput', () async {
       final subject = BehaviorSubject.seeded(1, sync: true);

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -380,7 +380,7 @@ void main() {
       expect(mappedStream.value, equals(1));
 
       await subject.close();
-    });
+    }, skip: true);
 
     test('issue/419: sync throughput', () async {
       final subject = ReplaySubject<int>(sync: true)..add(1);

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -130,13 +130,13 @@ void main() {
 
       await controller.close();
 
-      controller.stream.doOnData(actual.add).listen(null);
-      await expectLater(actual, const [1, 2]);
+      expect(await controller.stream.doOnData(actual.add).drain(actual),
+          const [1, 2]);
 
       actual.clear();
 
-      controller.stream.doOnData(actual.add).listen(null);
-      await expectLater(actual, const [1, 2]);
+      expect(await controller.stream.doOnData(actual.add).drain(actual),
+          const [1, 2]);
     });
 
     test('emits onEach Notifications for Data, Error, and Done', () async {


### PR DESCRIPTION
We've got a few connected issues that were reported over the past few months, and I've been cracking my skull on how exactly to solve this given the built-in Dart Stream constraints.

This PR is an attempt at fixing those issues, I'm not very happy with these changes, so I'm just putting this PR up to see if we can tackle them in a cleaner way.

First, I had to roll back on adding events during onListen, this affects startWith & friends.
see: https://github.com/dart-lang/sdk/issues/41969

As a result, I'm unable to support this test (similar one on replay subject):
```
test('issue/419: sync behavior', () async {
      final subject = BehaviorSubject.seeded(1, sync: true);
      final mappedStream = subject.map((event) => event).shareValue();

      mappedStream.listen(null);

      expect(mappedStream.value, equals(1));

      await subject.close();
    }, skip: true);
```
This is unfortunate, but a workaround is that you just need to wait for the first event to be added before expecting `value` to be set.
Since we no longer can add on `onListen`, there's always a small delay before the starting event will be dispatched.

Next up, there's this reported issue: https://github.com/ReactiveX/rxdart/issues/477

From the ticket:
```
test("rxdart 23.1 -> 24.1", () async {
  final a = BehaviorSubject.seeded('a');
  final bug = a.switchMap((_) => BehaviorSubject.seeded('b'));
  bug.listen((b) => print('data! $b'));
  print(await bug.first);
  print(await bug.first); // hangs here with rxdart 24.1, passes with rxdart 23.1
});
```

...the reason why the second print 'hangs', is because we use transform, and use our forwardStream to delegate,
however, inside forwardStream, we always create a new broadcast `StreamTransformer` and return its stream.

So when using `switchMap`, the transformed Stream is now a standard SDK broadcast Stream, the second await on first fails, because with the first await, the event is already played, and it is not replayed with the second await.

Now we can control what `switchMap` does, but not what default ops do, like `map` for example.

To keep yielding a `ValueStream`, I overruled the default `transform` method on our Subjects.

...this fixed the issue, but caused issues with our `DoStreamTransformer`, which is a special case.

If we apply the above override on transform, but have a `doOnX` operator attached, then those `doOnX` calls happen on the wrong `Stream`.
To counter this, I've added an extra property on `forwardStream` to tell it to keep the original `Type` of the source `Stream`.
Then in the overridden transform, we check to see if the override is actually necessary when the transformed `Stream` is already of the expected `Type`.

Given all these changes all tests do work again, except those that were skipped (see above), 
but again, not too happy with these ugly 'workarounds'.
