### PR TITLE
Remove resumeSignal parameter of onPause callback

### DIFF
--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -337,8 +337,8 @@ class CombineLatestStream<T, R> extends StreamView<R> {
           );
         }).toList(growable: false);
       },
-      onPause: ([Future<dynamic> resumeSignal]) => subscriptions
-          .forEach((subscription) => subscription.pause(resumeSignal)),
+      onPause: () =>
+          subscriptions.forEach((subscription) => subscription.pause()),
       onResume: () =>
           subscriptions.forEach((subscription) => subscription.resume()),
       onCancel: () => Future.wait<dynamic>(subscriptions

--- a/lib/src/streams/concat.dart
+++ b/lib/src/streams/concat.dart
@@ -77,8 +77,7 @@ class ConcatStream<T> extends Stream<T> {
 
           moveNext();
         },
-        onPause: ([Future<dynamic> resumeSignal]) =>
-            subscription?.pause(resumeSignal),
+        onPause: () => subscription?.pause(),
         onResume: () => subscription?.resume(),
         onCancel: () => subscription.cancel());
 

--- a/lib/src/streams/concat_eager.dart
+++ b/lib/src/streams/concat_eager.dart
@@ -96,8 +96,7 @@ class ConcatEagerStream<T> extends Stream<T> {
           // initially, the very first subscription is the active one
           activeSubscription = subscriptions.first;
         },
-        onPause: ([Future<dynamic> resumeSignal]) =>
-            activeSubscription.pause(resumeSignal),
+        onPause: () => activeSubscription.pause(),
         onResume: () => activeSubscription.resume(),
         onCancel: () => Future.wait<dynamic>(subscriptions
             .map((subscription) => subscription.cancel())

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -286,7 +286,7 @@ class ConnectableStreamSubscription<T> extends StreamSubscription<T> {
   void onError(Function handleError) => _source.onError(handleError);
 
   @override
-  void pause([Future<dynamic> resumeSignal]) => _source.pause(resumeSignal);
+  void pause([Future<void> resumeSignal]) => _source.pause(resumeSignal);
 
   @override
   void resume() => _source.resume();

--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -62,8 +62,8 @@ class MergeStream<T> extends Stream<T> {
                 onError: controller.addError, onDone: onDone);
           }
         },
-        onPause: ([Future<dynamic> resumeSignal]) => subscriptions
-            .forEach((subscription) => subscription.pause(resumeSignal)),
+        onPause: () =>
+            subscriptions.forEach((subscription) => subscription.pause()),
         onResume: () =>
             subscriptions.forEach((subscription) => subscription.resume()),
         onCancel: () => Future.wait<dynamic>(subscriptions

--- a/lib/src/streams/race.dart
+++ b/lib/src/streams/race.dart
@@ -72,8 +72,8 @@ class RaceStream<T> extends Stream<T> {
                   onError: controller.addError, onDone: controller.close))
               .toList();
         },
-        onPause: ([Future<dynamic> resumeSignal]) => subscriptions
-            .forEach((subscription) => subscription.pause(resumeSignal)),
+        onPause: () =>
+            subscriptions.forEach((subscription) => subscription.pause()),
         onResume: () =>
             subscriptions.forEach((subscription) => subscription.resume()),
         onCancel: () => Future.wait<dynamic>(subscriptions

--- a/lib/src/streams/repeat.dart
+++ b/lib/src/streams/repeat.dart
@@ -40,8 +40,7 @@ class RepeatStream<T> extends Stream<T> {
     _controller ??= StreamController<T>(
         sync: true,
         onListen: _maybeRepeatNext,
-        onPause: ([Future<dynamic> resumeSignal]) =>
-            _subscription.pause(resumeSignal),
+        onPause: () => _subscription.pause(),
         onResume: () => _subscription.resume(),
         onCancel: () => _subscription?.cancel());
 

--- a/lib/src/streams/retry.dart
+++ b/lib/src/streams/retry.dart
@@ -73,8 +73,7 @@ class RetryStream<T> extends Stream<T> {
     _controller ??= StreamController<T>(
         sync: true,
         onListen: retry,
-        onPause: ([Future<dynamic> resumeSignal]) =>
-            _subscription.pause(resumeSignal),
+        onPause: () => _subscription.pause(),
         onResume: () => _subscription.resume(),
         onCancel: () => _subscription.cancel());
 

--- a/lib/src/streams/retry_when.dart
+++ b/lib/src/streams/retry_when.dart
@@ -85,8 +85,7 @@ class RetryWhenStream<T> extends Stream<T> {
     _controller ??= StreamController<T>(
       sync: true,
       onListen: _retry,
-      onPause: ([Future<dynamic> resumeSignal]) =>
-          _subscription.pause(resumeSignal),
+      onPause: () => _subscription.pause(),
       onResume: () => _subscription.resume(),
       onCancel: () => _subscription.cancel(),
     );

--- a/lib/src/streams/sequence_equal.dart
+++ b/lib/src/streams/sequence_equal.dart
@@ -65,8 +65,7 @@ class SequenceEqualStream<S, T> extends Stream<bool> {
               .listen(emitAndClose,
                   onError: controller.addError, onDone: emitAndClose);
         },
-        onPause: ([Future<dynamic> resumeSignal]) =>
-            subscription.pause(resumeSignal),
+        onPause: () => subscription.pause(),
         onResume: () => subscription.resume(),
         onCancel: () => subscription.cancel());
 

--- a/lib/src/streams/switch_latest.dart
+++ b/lib/src/streams/switch_latest.dart
@@ -84,9 +84,9 @@ class SwitchLatestStream<T> extends Stream<T> {
             }
           }, onError: controller.addError, onDone: closeLeft);
         },
-        onPause: ([Future<dynamic> resumeSignal]) {
-          subscription.pause(resumeSignal);
-          otherSubscription?.pause(resumeSignal);
+        onPause: () {
+          subscription.pause();
+          otherSubscription?.pause();
         },
         onResume: () {
           subscription.resume();

--- a/lib/src/streams/timer.dart
+++ b/lib/src/streams/timer.dart
@@ -46,8 +46,7 @@ class TimerStream<T> extends Stream<T> {
           },
         );
       },
-      onPause: ([Future<dynamic> resumeSignal]) =>
-          subscription.pause(resumeSignal),
+      onPause: () => subscription.pause(),
       onResume: () => subscription.resume(),
       onCancel: () => subscription.cancel(),
     );

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -338,8 +338,8 @@ class ZipStream<T, R> extends StreamView<R> {
             controller.addError(e, s);
           }
         },
-        onPause: ([Future<dynamic> resumeSignal]) => pendingSubscriptions
-            .forEach((subscription) => subscription.pause(resumeSignal)),
+        onPause: () => pendingSubscriptions
+            .forEach((subscription) => subscription.pause()),
         onResume: () => pendingSubscriptions
             .forEach((subscription) => subscription.resume()),
         onCancel: () => Future.wait<dynamic>(subscriptions

--- a/lib/src/transformers/backpressure/backpressure.dart
+++ b/lib/src/transformers/backpressure/backpressure.dart
@@ -95,8 +95,7 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S, T> {
   void onListen(EventSink<T> sink) {}
 
   @override
-  void onPause(EventSink<T> sink, [Future resumeSignal]) =>
-      _windowSubscription?.pause(resumeSignal);
+  void onPause(EventSink<T> sink) => _windowSubscription?.pause();
 
   @override
   void onResume(EventSink<T> sink) => _windowSubscription?.resume();

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -11,7 +11,7 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
   final void Function(Notification<S> notification) _onEach;
   final Function _onError;
   final void Function() _onListen;
-  final void Function(Future<dynamic> resumeSignal) _onPause;
+  final void Function() _onPause;
   final void Function() _onResume;
 
   _DoStreamSink(
@@ -79,8 +79,7 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  void onPause(EventSink<S> sink, [Future resumeSignal]) =>
-      _onPause?.call(resumeSignal);
+  void onPause(EventSink<S> sink) => _onPause?.call();
 
   @override
   void onResume(EventSink<S> sink) => _onResume?.call();
@@ -141,7 +140,7 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
   final void Function() onListen;
 
   /// fires when the subscription pauses
-  final void Function(Future<dynamic> resumeSignal) onPause;
+  final void Function() onPause;
 
   /// fires when the subscription resumes
   final void Function() onResume;
@@ -270,7 +269,7 @@ extension DoExtensions<T> on Stream<T> {
   ///       .listen(null);
   ///
   ///     subscription.pause(); // prints 'Gimme a minute please'
-  Stream<T> doOnPause(void Function(Future<dynamic> resumeSignal) onPause) =>
+  Stream<T> doOnPause(void Function() onPause) =>
       transform(DoStreamTransformer<T>(onPause: onPause));
 
   /// Invokes the given callback function when the stream subscription

--- a/lib/src/transformers/exhaust_map.dart
+++ b/lib/src/transformers/exhaust_map.dart
@@ -48,8 +48,7 @@ class _ExhaustMapStreamSink<S, T> implements ForwardingSink<S, T> {
   void onListen(EventSink<T> sink) {}
 
   @override
-  void onPause(EventSink<T> sink, [Future resumeSignal]) =>
-      _mapperSubscription?.pause(resumeSignal);
+  void onPause(EventSink<T> sink) => _mapperSubscription?.pause();
 
   @override
   void onResume(EventSink<T> sink) => _mapperSubscription?.resume();

--- a/lib/src/transformers/flat_map.dart
+++ b/lib/src/transformers/flat_map.dart
@@ -55,8 +55,7 @@ class _FlatMapStreamSink<S, T> implements ForwardingSink<S, T> {
   void onListen(EventSink<T> sink) {}
 
   @override
-  void onPause(EventSink<T> sink, [Future resumeSignal]) =>
-      _subscriptions.forEach((s) => s.pause(resumeSignal));
+  void onPause(EventSink<T> sink) => _subscriptions.forEach((s) => s.pause());
 
   @override
   void onResume(EventSink<T> sink) => _subscriptions.forEach((s) => s.resume());

--- a/lib/src/transformers/interval.dart
+++ b/lib/src/transformers/interval.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-
 import 'dart:collection';
 
 class _IntervalStreamSink<S> implements EventSink<S> {

--- a/lib/src/transformers/on_error_resume.dart
+++ b/lib/src/transformers/on_error_resume.dart
@@ -57,9 +57,8 @@ class _OnErrorResumeStreamSink<S> implements ForwardingSink<S, S> {
   void onListen(EventSink<S> sink) {}
 
   @override
-  void onPause(EventSink<S> sink, [Future resumeSignal]) =>
-      _recoverySubscriptions
-          .forEach((subscription) => subscription.pause(resumeSignal));
+  void onPause(EventSink<S> sink) =>
+      _recoverySubscriptions.forEach((subscription) => subscription.pause());
 
   @override
   void onResume(EventSink<S> sink) =>

--- a/lib/src/transformers/skip_until.dart
+++ b/lib/src/transformers/skip_until.dart
@@ -35,8 +35,7 @@ class _SkipUntilStreamSink<S, T> implements ForwardingSink<S, S> {
       .listen(null, onError: sink.addError, onDone: () => _canAdd = true);
 
   @override
-  void onPause(EventSink<S> sink, [Future resumeSignal]) =>
-      _otherSubscription?.pause(resumeSignal);
+  void onPause(EventSink<S> sink) => _otherSubscription?.pause();
 
   @override
   void onResume(EventSink<S> sink) => _otherSubscription?.resume();

--- a/lib/src/transformers/start_with.dart
+++ b/lib/src/transformers/start_with.dart
@@ -36,7 +36,7 @@ class _StartWithStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  void onPause(EventSink<S> sink, [Future resumeSignal]) {}
+  void onPause(EventSink<S> sink) {}
 
   @override
   void onResume(EventSink<S> sink) {}

--- a/lib/src/transformers/start_with_error.dart
+++ b/lib/src/transformers/start_with_error.dart
@@ -37,7 +37,7 @@ class _StartWithErrorStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  void onPause(EventSink<S> sink, [Future resumeSignal]) {}
+  void onPause(EventSink<S> sink) {}
 
   @override
   void onResume(EventSink<S> sink) {}

--- a/lib/src/transformers/start_with_many.dart
+++ b/lib/src/transformers/start_with_many.dart
@@ -36,7 +36,7 @@ class _StartWithManyStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  void onPause(EventSink<S> sink, [Future resumeSignal]) {}
+  void onPause(EventSink<S> sink) {}
 
   @override
   void onResume(EventSink<S> sink) {}

--- a/lib/src/transformers/switch_if_empty.dart
+++ b/lib/src/transformers/switch_if_empty.dart
@@ -36,22 +36,16 @@ class _SwitchIfEmptyStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  FutureOr onCancel(EventSink<S> sink) {
-    return _fallbackSubscription?.cancel();
-  }
+  FutureOr onCancel(EventSink<S> sink) => _fallbackSubscription?.cancel();
 
   @override
   void onListen(EventSink<S> sink) {}
 
   @override
-  void onPause(EventSink<S> sink, [Future resumeSignal]) {
-    _fallbackSubscription?.pause(resumeSignal);
-  }
+  void onPause(EventSink<S> sink) => _fallbackSubscription?.pause();
 
   @override
-  void onResume(EventSink<S> sink) {
-    _fallbackSubscription?.resume();
-  }
+  void onResume(EventSink<S> sink) => _fallbackSubscription?.resume();
 }
 
 /// When the original stream emits no items, this operator subscribes to

--- a/lib/src/transformers/switch_map.dart
+++ b/lib/src/transformers/switch_map.dart
@@ -45,8 +45,7 @@ class _SwitchMapStreamSink<S, T> implements ForwardingSink<S, T> {
   void onListen(EventSink<T> sink) {}
 
   @override
-  void onPause(EventSink<T> sink, [Future resumeSignal]) =>
-      _mapperSubscription?.pause(resumeSignal);
+  void onPause(EventSink<T> sink) => _mapperSubscription?.pause();
 
   @override
   void onResume(EventSink<T> sink) => _mapperSubscription?.resume();

--- a/lib/src/transformers/take_until.dart
+++ b/lib/src/transformers/take_until.dart
@@ -30,8 +30,7 @@ class _TakeUntilStreamSink<S, T> implements ForwardingSink<S, S> {
       .listen(null, onError: sink.addError, onDone: sink.close);
 
   @override
-  void onPause(EventSink<S> sink, [Future resumeSignal]) =>
-      _otherSubscription?.pause(resumeSignal);
+  void onPause(EventSink<S> sink) => _otherSubscription?.pause();
 
   @override
   void onResume(EventSink<S> sink) => _otherSubscription?.resume();

--- a/lib/src/transformers/time_interval.dart
+++ b/lib/src/transformers/time_interval.dart
@@ -36,7 +36,7 @@ class _TimeIntervalStreamSink<S> implements ForwardingSink<S, TimeInterval<S>> {
   void onListen(EventSink<TimeInterval<S>> sink) => _stopwatch.start();
 
   @override
-  void onPause(EventSink<TimeInterval<S>> sink, [Future resumeSignal]) {}
+  void onPause(EventSink<TimeInterval<S>> sink) {}
 
   @override
   void onResume(EventSink<TimeInterval<S>> sink) {}

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -61,8 +61,8 @@ class _WithLatestFromStreamSink<S, T, R> implements ForwardingSink<S, R> {
   }
 
   @override
-  void onPause(EventSink<R> sink, [Future resumeSignal]) =>
-      _subscriptions?.forEach((it) => it.pause(resumeSignal));
+  void onPause(EventSink<R> sink) =>
+      _subscriptions?.forEach((it) => it.pause());
 
   @override
   void onResume(EventSink<R> sink) =>

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -70,7 +70,7 @@ class CompositeSubscription {
   }
 
   /// Pauses all subscriptions added to this composite.
-  void pauseAll([Future resumeSignal]) =>
+  void pauseAll([Future<void> resumeSignal]) =>
       _subscriptionsList.forEach((it) => it.pause(resumeSignal));
 
   /// Resumes all subscriptions added to this composite.

--- a/lib/src/utils/forwarding_sink.dart
+++ b/lib/src/utils/forwarding_sink.dart
@@ -22,7 +22,7 @@ abstract class ForwardingSink<T, R> {
   void onListen(EventSink<R> sink);
 
   /// Fires when a subscriber pauses.
-  void onPause(EventSink<R> sink, [Future resumeSignal]);
+  void onPause(EventSink<R> sink);
 
   /// Fires when a subscriber resumes after a pause.
   void onResume(EventSink<R> sink);

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -47,9 +47,9 @@ Stream<R> forwardStream<T, R>(
     return Future.wait<dynamic>(futures);
   };
 
-  final onPause = ([Future resumeSignal]) {
-    subscription.pause(resumeSignal);
-    runCatching(() => connectedSink.onPause(controller, resumeSignal));
+  final onPause = () {
+    subscription.pause();
+    runCatching(() => connectedSink.onPause(controller));
   };
 
   final onResume = () {

--- a/lib/subjects.dart
+++ b/lib/subjects.dart
@@ -1,6 +1,6 @@
 library rx_subjects;
 
-export 'src/subjects/subject.dart';
 export 'src/subjects/behavior_subject.dart';
 export 'src/subjects/publish_subject.dart';
 export 'src/subjects/replay_subject.dart';
+export 'src/subjects/subject.dart';

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -1,5 +1,11 @@
 library rx_transformers;
 
+export 'src/transformers/backpressure/buffer.dart';
+export 'src/transformers/backpressure/debounce.dart';
+export 'src/transformers/backpressure/pairwise.dart';
+export 'src/transformers/backpressure/sample.dart';
+export 'src/transformers/backpressure/throttle.dart';
+export 'src/transformers/backpressure/window.dart';
 export 'src/transformers/default_if_empty.dart';
 export 'src/transformers/delay.dart';
 export 'src/transformers/dematerialize.dart';
@@ -14,9 +20,9 @@ export 'src/transformers/ignore_elements.dart';
 export 'src/transformers/interval.dart';
 export 'src/transformers/map_to.dart';
 export 'src/transformers/materialize.dart';
-export 'src/transformers/on_error_resume.dart';
-export 'src/transformers/min.dart';
 export 'src/transformers/max.dart';
+export 'src/transformers/min.dart';
+export 'src/transformers/on_error_resume.dart';
 export 'src/transformers/scan.dart';
 export 'src/transformers/skip_until.dart';
 export 'src/transformers/start_with.dart';
@@ -30,10 +36,3 @@ export 'src/transformers/timestamp.dart';
 export 'src/transformers/where_type.dart';
 export 'src/transformers/with_latest_from.dart';
 export 'src/utils/notification.dart';
-
-export 'src/transformers/backpressure/buffer.dart';
-export 'src/transformers/backpressure/debounce.dart';
-export 'src/transformers/backpressure/pairwise.dart';
-export 'src/transformers/backpressure/sample.dart';
-export 'src/transformers/backpressure/throttle.dart';
-export 'src/transformers/backpressure/window.dart';

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -223,7 +223,7 @@ void main() {
 
     test('calls onPause and onResume when the subscription is', () async {
       var onPauseCalled = false, onResumeCalled = false;
-      final stream = Stream.value(1).doOnPause((_) {
+      final stream = Stream.value(1).doOnPause(() {
         onPauseCalled = true;
       }).doOnResume(() {
         onResumeCalled = true;
@@ -326,7 +326,7 @@ void main() {
           );
 
       Stream.value(1)
-          .doOnPause((_) => throw Exception('catch me if you can! doOnPause'))
+          .doOnPause(() => throw Exception('catch me if you can! doOnPause'))
           .listen(null,
               onError: expectAsync2(
                 (Exception e, [StackTrace s]) => expect(e, isException),
@@ -457,7 +457,7 @@ void main() {
 
       subscription = Stream.value(1)
           .exhaustMap((_) => stream.doOnData((data) => addToResult('A: $data')))
-          .doOnPause((_) => addToResult('pause'))
+          .doOnPause(() => addToResult('pause'))
           .doOnData((data) => addToResult('B: $data'))
           .take(expectedOutput.length)
           .listen((value) {


### PR DESCRIPTION
* Run small code as shown below, will print `null`:
```dart
import 'dart:async';

void main() {
  var ctrl = StreamController<int>(
    sync: true,
    onPause: ([Future<dynamic> resumeSignal]) {
      print(resumeSignal);
    },
  );

  ctrl.stream
      .listen(null)
      .pause(Future<void>.delayed(const Duration(seconds: 1)));
}
```
* **Breaking change**: `Stream<T> doOnPause(void Function(Future<dynamic> resumeSignal) onPause) ` → `Stream<T> doOnPause(void Function() onPause)`.
* This PR will remove `resumeSignal` parameter of `onPause` callback when constructing `StreamController`.
* Refer to [stream_controller.dart#L793](https://github.com/dart-lang/sdk/blob/79a9e3b54a0a54c7a64f156a629a9227dae14562/sdk/lib/async/stream_controller.dart#L793), [stream_controller.dart#L844](https://github.com/dart-lang/sdk/blob/79a9e3b54a0a54c7a64f156a629a9227dae14562/sdk/lib/async/stream_controller.dart#L844),  `onPause` callback will called without any argument.
* Refer to [_BufferingStreamSubscription.pause](https://github.com/dart-lang/sdk/blob/79a9e3b54a0a54c7a64f156a629a9227dae14562/sdk/lib/async/stream_impl.dart#L182), `StreamSubscription` will resume when `resumeSignal` completed by itself.