### PR TITLE
revert: createForwardingSubject

### DIFF
--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -152,6 +152,18 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
 
     return transformed;
   }
+
+  @override
+  BehaviorSubject<R> createForwardingSubject<R>({
+    void Function() onListen,
+    void Function() onCancel,
+    bool sync = false,
+  }) =>
+      BehaviorSubject(
+        onListen: onListen,
+        onCancel: onCancel,
+        sync: sync,
+      );
 }
 
 class _Wrapper<T> {

--- a/lib/src/subjects/publish_subject.dart
+++ b/lib/src/subjects/publish_subject.dart
@@ -46,4 +46,16 @@ class PublishSubject<T> extends Subject<T> {
       controller.stream,
     );
   }
+
+  @override
+  PublishSubject<R> createForwardingSubject<R>({
+    void Function() onListen,
+    void Function() onCancel,
+    bool sync = false,
+  }) =>
+      PublishSubject(
+        onListen: onListen,
+        onCancel: onCancel,
+        sync: sync,
+      );
 }

--- a/lib/src/subjects/replay_subject.dart
+++ b/lib/src/subjects/replay_subject.dart
@@ -125,6 +125,19 @@ class ReplaySubject<T> extends Subject<T> implements ReplayStream<T> {
       .where((event) => event.isError)
       .map((event) => event.errorAndStackTrace.error)
       .toList(growable: false);
+
+  @override
+  ReplaySubject<R> createForwardingSubject<R>({
+    void Function() onListen,
+    void Function() onCancel,
+    bool sync = false,
+  }) =>
+      ReplaySubject(
+        maxSize: _maxSize,
+        onCancel: onCancel,
+        onListen: onListen,
+        sync: sync,
+      );
 }
 
 class _Event<T> {

--- a/lib/src/subjects/subject.dart
+++ b/lib/src/subjects/subject.dart
@@ -155,6 +155,15 @@ abstract class Subject<T> extends StreamView<T> implements StreamController<T> {
 
     return _controller.close();
   }
+
+  /// Creates a trampoline StreamController, which can forward events
+  /// in the same manner as the original [Subject] does.
+  /// e.g. replay or behavior on subscribe.
+  Subject<R> createForwardingSubject<R>({
+    void Function() onListen,
+    void Function() onCancel,
+    bool sync = false,
+  });
 }
 
 class _StreamSinkWrapper<T> implements StreamSink<T> {

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -182,7 +182,6 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
           onPause,
           onResume,
         ),
-        inheritParentType: true,
       );
 }
 

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -708,5 +708,29 @@ void main() {
 
       await subject.close();
     });
+
+    test('issue/477: get first after cancelled', () async {
+      final a = BehaviorSubject.seeded('a');
+      final bug = a.switchMap((v) => BehaviorSubject.seeded('b'));
+      await bug.listen(null).cancel();
+      expect(await bug.first, 'b');
+    });
+
+    test('issue/477: get first multiple times', () async {
+      final a = BehaviorSubject.seeded('a');
+      final bug = a.switchMap((_) => BehaviorSubject.seeded('b'));
+      bug.listen(null);
+      expect(await bug.first, 'b');
+      expect(await bug.first, 'b');
+    });
+
+    test('issue/478: get first multiple times', () async {
+      final a = BehaviorSubject.seeded('a');
+      final b = BehaviorSubject.seeded('b');
+      final bug =
+          Rx.combineLatest2(a, b, (String _a, String _b) => 'ab').shareValue();
+      expect(await bug.first, 'ab');
+      expect(await bug.first, 'ab');
+    });
   });
 }


### PR DESCRIPTION
Issue from comment: https://github.com/ReactiveX/rxdart/issues/477#issuecomment-668916047
```dart
test("rxdart 23.1 -> ^0.25.0-beta", () async {
  final a = BehaviorSubject.seeded('a');
  final bug = a.switchMap((_) => BehaviorSubject.seeded('b'));
  await bug.listen((b) => print('data! $b')).cancel();
  print(await bug.first);  // Bad state: No element
});

// stacktrace:
dart:async                                                          _StreamImpl.listen
package:rxdart/src/streams/defer.dart 37:18                         DeferStream.listen
dart:async                                                          Stream.first

Bad state: No element
```
When we uses `shareValue` https://github.com/ReactiveX/rxdart/blob/9342c2ad1e10ac41f833ee37bb096ba09904c253/lib/src/subjects/behavior_subject.dart#L150
After the first `StreamSubscription` is cancelled, `BehaviorSubject` is closed, and `Stream.first` receives `onDone`  event and throws `StateError("No element")`. https://github.com/ReactiveX/rxdart/blob/9342c2ad1e10ac41f833ee37bb096ba09904c253/lib/src/streams/connectable_stream.dart#L269

This PR revert to old way like before, `forwardStream` will call `Subject.createForwardingSubject`
Fixes #477
Fixes #478 