### PR TITLE
Add UsingStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can construct the Streams provided by RxDart in two ways. The following exam
 - [ForkJoinStream](https://pub.dev/documentation/rxdart/latest/rx/ForkJoinStream-class.html) (join2, join3... join9) / [Rx.forkJoin2](https://pub.dev/documentation/rxdart/latest/rx/Rx/forkJoin2.html)...[Rx.forkJoin9](https://pub.dev/documentation/rxdart/latest/rx/Rx/forkJoin9.html)
 - [RangeStream](https://pub.dev/documentation/rxdart/latest/rx/RangeStream-class.html) / [Rx.range](https://pub.dev/documentation/rxdart/latest/rx/Rx/range.html)
 - [ZipStream](https://pub.dev/documentation/rxdart/latest/rx/ZipStream-class.html) (zip2, zip3, zip4, ..., zip9) / [Rx.zip](https://pub.dev/documentation/rxdart/latest/rx/Rx/zip2.html)...[Rx.zip9](https://pub.dev/documentation/rxdart/latest/rx/Rx/zip9.html)
+- [UsingStream](https://pub.dev/documentation/rxdart/latest/rx/UsingStream-class.html) / [Rx.using](https://pub.dev/documentation/rxdart/latest/rx/Rx/using.html)
 - ** If you're looking for an [Interval](http://reactivex.io/documentation/operators/interval.html) equivalent, check out Dart's [Stream.periodic](https://api.dart.dev/stable/2.7.2/dart-async/Stream/Stream.periodic.html) for similar behavior.
 
 ### Extension Methods

--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -916,7 +916,25 @@ abstract class Rx {
   static Stream<T> timer<T>(T value, Duration duration) =>
       (TimerStream<T>(value, duration));
 
-  /// TODO: using
+  /// When listener listens to it, creates a resource object from resource factory function,
+  /// and creates a [Stream] from the given factory function and resource as argument.
+  /// Finally when the stream finishes emitting items or stream subscription
+  /// is cancelled (call [StreamSubscription.cancel] or `Stream.listen(cancelOnError: true)`),
+  /// call the disposer function on resource object.
+  ///
+  /// The [UsingStream] is a way you can instruct an Stream to create
+  /// a resource that exists only during the lifespan of the Stream
+  /// and is disposed of when the Stream terminates.
+  ///
+  /// [Marble diagram](http://reactivex.io/documentation/operators/images/using.c.png)
+  ///
+  /// ### Example
+  ///
+  ///     Rx.using<int, Queue<int>>(
+  ///       () => Queue.of([1, 2, 3]),
+  ///       (r) => Stream.fromIterable(r),
+  ///       (r) => r.clear(),
+  ///     ).listen(print); // prints 1, 2, 3
   static Stream<T> using<T, R>(
     R Function() resourceFactory,
     Stream<T> Function(R) streamFactory,

--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -916,6 +916,14 @@ abstract class Rx {
   static Stream<T> timer<T>(T value, Duration duration) =>
       (TimerStream<T>(value, duration));
 
+  /// TODO: using
+  static Stream<T> using<T, R>(
+    R Function() resourceFactory,
+    Stream<T> Function(R) streamFactory,
+    FutureOr<void> Function(R) disposer,
+  ) =>
+      UsingStream(resourceFactory, streamFactory, disposer);
+
   /// Merges the specified streams into one stream sequence using the given
   /// zipper function whenever all of the stream sequences have produced
   /// an element at a corresponding index.

--- a/lib/src/streams/using.dart
+++ b/lib/src/streams/using.dart
@@ -6,16 +6,23 @@ import 'dart:async';
 /// is cancelled (call [StreamSubscription.cancel] or `Stream.listen(cancelOnError: true)`),
 /// call the disposer function on resource object.
 ///
+/// The [UsingStream] is a way you can instruct an Stream to create
+/// a resource that exists only during the lifespan of the Stream
+/// and is disposed of when the Stream terminates.
+///
+/// [Marble diagram](http://reactivex.io/documentation/operators/images/using.c.png)
+///
 /// ### Example
 ///
-///     UsingStream(
-///       () => res,
-///       (res) => Stream.value(1),
-///       (res) => res.close(),
-///     ).listen(print); // prints 1
-/// TODO: using
+///     UsingStream<int, Queue<int>>(
+///       () => Queue.of([1, 2, 3]),
+///       (r) => Stream.fromIterable(r),
+///       (r) => r.clear(),
+///     ).listen(print); // prints 1, 2, 3
 class UsingStream<T, R> extends StreamView<T> {
-  /// TODO: using
+  /// Construct a [UsingStream] that creates a resource object from [resourceFactory],
+  /// and then creates a [Stream] from [streamFactory] and resource as argument.
+  /// When the Stream terminates, call [disposer] on resource object.
   UsingStream(
     R Function() resourceFactory,
     Stream<T> Function(R) streamFactory,

--- a/lib/src/streams/using.dart
+++ b/lib/src/streams/using.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+/// When listener listens to it, creates a resource object from resource factory function,
+/// and creates a [Stream] from the given factory function and resource as argument.
+/// Finally when the stream finishes emitting items or stream subscription
+/// is cancelled (call [StreamSubscription.cancel] or `Stream.listen(cancelOnError: true)`),
+/// call the disposer function on resource object.
+///
+/// ### Example
+///
+///     UsingStream(
+///       () => res,
+///       (res) => Stream.value(1),
+///       (res) => res.close(),
+///     ).listen(print); // prints 1
+/// TODO: using
+class UsingStream<T, R> extends StreamView<T> {
+  /// TODO: using
+  UsingStream(
+    R Function() resourceFactory,
+    Stream<T> Function(R) streamFactory,
+    FutureOr<void> Function(R) disposer,
+  ) : super(_buildStream(resourceFactory, streamFactory, disposer));
+
+  static Stream<T> _buildStream<T, R>(
+    R Function() resourceFactory,
+    Stream<T> Function(R) streamFactory,
+    FutureOr<void> Function(R) disposer,
+  ) {
+    ArgumentError.checkNotNull(resourceFactory, 'resourceFactory');
+    ArgumentError.checkNotNull(streamFactory, 'streamFactory');
+    ArgumentError.checkNotNull(disposer, 'disposer');
+
+    StreamController<T> controller;
+    var resourceCreated = false;
+    R resource;
+    StreamSubscription<T> subscription;
+
+    controller = StreamController<T>(
+      sync: true,
+      onListen: () {
+        try {
+          resource = resourceFactory();
+          resourceCreated = true;
+        } catch (e, s) {
+          controller.addError(e, s);
+          controller.close();
+          return;
+        }
+
+        Stream<T> stream;
+        try {
+          stream = streamFactory(resource);
+        } catch (e, s) {
+          controller.addError(e, s);
+          controller.close();
+          return;
+        }
+
+        subscription = stream.listen(
+          controller.add,
+          onError: controller.addError,
+          onDone: controller.close,
+        );
+      },
+      onPause: () => subscription.pause(),
+      onResume: () => subscription.resume(),
+      onCancel: () async {
+        final futureOr = resourceCreated ? disposer(resource) : null;
+        final cancelFuture = subscription?.cancel();
+
+        final futures = [
+          // ignore: unnecessary_cast
+          if (futureOr is Future<void>) futureOr as Future<void>,
+          if (cancelFuture is Future<void>) cancelFuture,
+        ];
+        if (futures.isNotEmpty) {
+          await Future.wait(futures);
+        }
+      },
+    );
+
+    return controller.stream;
+  }
+}

--- a/lib/streams.dart
+++ b/lib/streams.dart
@@ -17,6 +17,7 @@ export 'src/streams/retry_when.dart';
 export 'src/streams/sequence_equal.dart';
 export 'src/streams/switch_latest.dart';
 export 'src/streams/timer.dart';
+export 'src/streams/using.dart';
 export 'src/streams/utils.dart';
 export 'src/streams/value_stream.dart';
 export 'src/streams/zip.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -21,6 +21,7 @@ import 'streams/retry_when_test.dart' as retry_when_test;
 import 'streams/sequence_equals_test.dart' as sequence_equals_test;
 import 'streams/switch_latest_test.dart' as switch_latest_test;
 import 'streams/timer_test.dart' as timer_test;
+import 'streams/using_test.dart' as using_test;
 import 'streams/value_connectable_stream_test.dart'
     as value_connectable_stream_test;
 import 'streams/zip_test.dart' as zip_test;
@@ -51,8 +52,8 @@ import 'transformers/dematerialize_test.dart' as dematerialize_test;
 import 'transformers/distinct_test.dart' as distinct_test;
 import 'transformers/distinct_unique_test.dart' as distinct_unique_test;
 import 'transformers/do_test.dart' as do_test;
-import 'transformers/end_with_test.dart' as end_with_test;
 import 'transformers/end_with_many_test.dart' as end_with_many_test;
+import 'transformers/end_with_test.dart' as end_with_test;
 import 'transformers/exhaust_map_test.dart' as exhaust_map_test;
 import 'transformers/flat_map_iterable_test.dart' as flat_map_iterable_test;
 import 'transformers/flat_map_test.dart' as flat_map_test;
@@ -99,6 +100,7 @@ void main() {
   retry_when_test.main();
   sequence_equals_test.main();
   switch_latest_test.main();
+  using_test.main();
   zip_test.main();
 
   // StreamTransformers

--- a/test/streams/using_test.dart
+++ b/test/streams/using_test.dart
@@ -1,0 +1,250 @@
+import 'dart:async';
+
+import 'package:mockito/mockito.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:rxdart/src/streams/using.dart';
+import 'package:test/test.dart';
+
+class MockResource extends Mock {
+  Future<void> close();
+
+  void closeSync();
+}
+
+Future<void> main() async {
+  MockResource Function() resourceFactory;
+  MockResource resource;
+
+  setUp(() {
+    resourceFactory = () {
+      resource = MockResource();
+      when(resource.close())
+          .thenAnswer((_) => Future.delayed(const Duration(milliseconds: 10)));
+      return resource;
+    };
+  });
+
+  test('Rx.using.done', () async {
+    final stream = Rx.using<int, MockResource>(
+      resourceFactory,
+      (resource) => Stream.value(resource).mapTo(1),
+      (resource) => resource.close(),
+    );
+
+    await expectLater(
+      stream,
+      emitsInOrder(<dynamic>[
+        1,
+        emitsDone,
+      ]),
+    );
+
+    verify(resource.close()).called(1);
+  });
+
+  test('Rx.using.resourceFactory.throws', () async {
+    var calledStreamFactory = false;
+    var callDisposer = false;
+
+    final stream = Rx.using<int, MockResource>(
+      () => throw Exception(),
+      (resource) {
+        calledStreamFactory = true;
+        return Rx.range(0, 3);
+      },
+      (resource) {
+        callDisposer = true;
+        return resource.close();
+      },
+    );
+
+    await expectLater(
+      stream,
+      emitsInOrder(<dynamic>[emitsError(isException), emitsDone]),
+    );
+
+    expect(calledStreamFactory, false);
+    expect(callDisposer, false);
+  });
+
+  test('Rx.using.streamFactory.throws', () async {
+    final stream = Rx.using<int, MockResource>(
+      resourceFactory,
+      (resource) => throw Exception(),
+      (resource) => resource.close(),
+    );
+
+    await expectLater(
+      stream,
+      emitsInOrder(<dynamic>[emitsError(isException), emitsDone]),
+    );
+
+    verify(resource.close()).called(1);
+  });
+
+  test('Rx.using.cancel.A', () async {
+    final subscription = Rx.using<int, MockResource>(
+      resourceFactory,
+      (resource) => Rx.concat([
+        Rx.range(0, 5),
+        Stream.error(Exception()),
+        Rx.range(0, 1000).interval(const Duration(milliseconds: 100)),
+      ]),
+      (resource) => resource.close(),
+    ).listen(
+      null,
+      onError: (Object e, StackTrace s) {},
+      cancelOnError: false,
+    );
+
+    await Future<void>.delayed(const Duration(seconds: 1));
+    await subscription.cancel();
+    verify(resource.close()).called(1);
+  });
+
+  test('Rx.using.cancel.B', () async {
+    final subscription = Rx.using<int, MockResource>(
+      resourceFactory,
+      (resource) => Rx.concat([
+        Rx.range(0, 5),
+        Stream.error(Exception()),
+        Rx.range(0, 1000).interval(const Duration(milliseconds: 100)),
+      ]),
+      (resource) => resource.close(),
+    ).listen(
+      expectAsync1((v) => expect(true, false), count: 0),
+      onError: expectAsync2(
+        (Object e, StackTrace stackTrace) => expect(true, false),
+        count: 0,
+      ),
+      onDone: expectAsync0(() => expect(true, false), count: 0),
+    );
+
+    await subscription.cancel();
+  });
+
+  test('Rx.using.errors.notCancelOnError', () async {
+    Rx.using<int, MockResource>(
+      resourceFactory,
+      (resource) => Rx.concat([
+        Rx.range(0, 5),
+        Stream.error(Exception()),
+        Rx.range(0, 1000).interval(const Duration(milliseconds: 100)),
+      ]),
+      (resource) => resource.close(),
+    ).listen(
+      null,
+      onError: (Object e, StackTrace s) {},
+      cancelOnError: false,
+    );
+
+    await Future<void>.delayed(const Duration(seconds: 1));
+    verifyNever(resource.close());
+  });
+
+  test('Rx.using.errors.shouldThrows', () {
+    expect(
+      () => UsingStream<int, int>(null, (_) => Stream.value(1), (_) {}),
+      throwsArgumentError,
+    );
+
+    expect(
+      () => UsingStream<int, int>(() => 1, null, (_) {}),
+      throwsArgumentError,
+    );
+
+    expect(
+      () => UsingStream<int, int>(() => 1, (_) => Stream.value(1), null),
+      throwsArgumentError,
+    );
+  });
+
+  test('Rx.using.errors.cancelOnError', () async {
+    Rx.using<int, MockResource>(
+      resourceFactory,
+      (resource) => Rx.concat([
+        Rx.range(0, 5),
+        Stream.error(Exception()),
+        Rx.range(0, 1000).interval(const Duration(milliseconds: 100)),
+      ]),
+      (resource) => resource.close(),
+    ).listen(
+      null,
+      onError: (Object e, StackTrace s) {},
+      cancelOnError: true,
+    );
+
+    await Future<void>.delayed(const Duration(seconds: 1));
+    verify(resource.close()).called(1);
+  });
+
+  test('Rx.using.disposer.sync', () async {
+    final stream = Rx.using<int, MockResource>(
+      resourceFactory,
+      (resource) => Rx.range(0, 3),
+      (resource) => resource.closeSync(),
+    );
+
+    await expectLater(
+      stream,
+      emitsInOrder(<dynamic>[0, 1, 2, 3, emitsDone]),
+    );
+
+    verify(resource.closeSync()).called(1);
+  });
+
+  test('Rx.using.single.subscription', () async {
+    final stream = Rx.using<int, MockResource>(
+      resourceFactory,
+      (resource) => Rx.range(0, 3),
+      (resource) => resource.close(),
+    );
+    stream.listen(null);
+    expect(() => stream.listen(null), throwsStateError);
+  });
+
+  test('Rx.using.asBroadcastStream', () async {
+    final stream = Rx.using<int, MockResource>(
+      resourceFactory,
+      (resource) => Stream.periodic(
+        const Duration(milliseconds: 50),
+        (i) => i,
+      ),
+      (resource) => resource.close(),
+    ).asBroadcastStream(onCancel: (s) => s.cancel());
+
+    final s1 = stream.listen(null);
+    final s2 = stream.listen(null);
+
+    expect(true, true);
+
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await s1.cancel();
+    await s2.cancel();
+
+    verify(resource.close()).called(1);
+  });
+
+  test('Rx.using.pause.resume', () async {
+    StreamSubscription<int> subscription;
+
+    subscription = Rx.using<int, MockResource>(
+      resourceFactory,
+      (resource) => Stream.periodic(
+        const Duration(milliseconds: 20),
+        (i) => i,
+      ),
+      (resource) => resource.close(),
+    ).listen(
+      expectAsync1(
+        (value) {
+          subscription.cancel();
+          expect(value, 0);
+        },
+        count: 1,
+      ),
+    );
+
+    subscription.pause(Future<void>.delayed(const Duration(milliseconds: 50)));
+  });
+}


### PR DESCRIPTION
Add `UsingStream` [ReactiveX-Doc](http://reactivex.io/documentation/operators/using.html)
> The Using operator is a way you can instruct an Observable to create a resource that exists only during the lifespan of the Observable and is disposed of when the Observable terminates.