### PR TITLE
Updated forkJoin

### DIFF
--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -450,13 +450,11 @@ abstract class Rx {
   /// and only want to take action when a response has been received for all.
   ///
   /// In this way it is similar to how you might use [Future].wait.
+  /// When any Stream does not emit any values, Stream will complete immediately
+  /// without emitting any items and without any calls to the combiner function.
+  /// When any Stream emits an error, listening still continues unless
+  /// you set cancelOnError to true.
   ///
-  /// Be aware that if any of the inner streams supplied to forkJoin error
-  /// you will lose the value of any other streams that would or have already
-  /// completed if you do not catch the error correctly on the inner stream.
-  ///
-  /// If you are only concerned with all inner streams completing
-  /// successfully you can catch the error on the outside.
   /// It's also worth noting that if you have an stream
   /// that emits more than one item, and you are concerned with the previous
   /// emissions forkJoin is not the correct choice.

--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -449,12 +449,14 @@ abstract class Rx {
   /// requests on page load (or some other event)
   /// and only want to take action when a response has been received for all.
   ///
-  /// In this way it is similar to how you might use [Future].wait.
-  /// When any Stream does not emit any values, Stream will complete immediately
-  /// without emitting any items and without any calls to the combiner function.
-  /// When any Stream emits an error, listening still continues unless
-  /// you set cancelOnError to true.
+  /// In this way it is similar to how you might use [Future.wait].
   ///
+  /// Be aware that if any of the inner streams supplied to forkJoin error
+  /// you will lose the value of any other streams that would or have already
+  /// completed if you do not catch the error correctly on the inner stream.
+  ///
+  /// If you are only concerned with all inner streams completing
+  /// successfully you can catch the error on the outside.
   /// It's also worth noting that if you have an stream
   /// that emits more than one item, and you are concerned with the previous
   /// emissions forkJoin is not the correct choice.

--- a/lib/src/streams/fork_join.dart
+++ b/lib/src/streams/fork_join.dart
@@ -7,13 +7,11 @@ import 'dart:async';
 /// and only want to take action when a response has been received for all.
 ///
 /// In this way it is similar to how you might use [Future].wait.
+/// When any Stream does not emit any values, Stream will complete immediately
+/// without emitting any items and without any calls to the combiner function.
+/// When any Stream emits an error, listening still continues unless
+/// you set cancelOnError to true.
 ///
-/// Be aware that if any of the inner streams supplied to forkJoin error
-/// you will lose the value of any other streams that would or have already
-/// completed if you do not catch the error correctly on the inner stream.
-///
-/// If you are only concerned with all inner streams completing
-/// successfully you can catch the error on the outside.
 /// It's also worth noting that if you have an stream
 /// that emits more than one item, and you are concerned with the previous
 /// emissions forkJoin is not the correct choice.

--- a/test/streams/fork_join_test.dart
+++ b/test/streams/fork_join_test.dart
@@ -338,7 +338,7 @@ void main() {
     streamWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
       expect(e, isException);
-    }));
+    }), cancelOnError: true);
   });
 
   test('Rx.forkJoin.error.shouldThrowB', () async {
@@ -384,7 +384,7 @@ void main() {
     );
     await expectLater(
       stream,
-      emitsInOrder(<dynamic>[emitsDone]),
+      emitsInOrder(<dynamic>[emitsError(isStateError), emitsDone]),
     );
   });
 


### PR DESCRIPTION
Changes:
- When any Stream emits an error, listening still continues unless `cancelOnError: true` on the downstream.
- Pause and resume Streams properly