### PR TITLE
doOnError: update signature

### DIFF
--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -9,7 +9,7 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
   final void Function(S event) _onData;
   final void Function() _onDone;
   final void Function(Notification<S> notification) _onEach;
-  final Function _onError;
+  final void Function(Object, StackTrace) _onError;
   final void Function() _onListen;
   final void Function(Future<dynamic> resumeSignal) _onPause;
   final void Function() _onResume;
@@ -135,7 +135,7 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
   final void Function(Notification<S> notification) onEach;
 
   /// fires on errors
-  final Function onError;
+  final void Function(Object, StackTrace) onError;
 
   /// fires when a subscription first starts
   final void Function() onListen;
@@ -246,7 +246,7 @@ extension DoExtensions<T> on Stream<T> {
   ///     Stream.error(Exception())
   ///       .doOnError((error, stacktrace) => print('oh no'))
   ///       .listen(null); // prints 'Oh no'
-  Stream<T> doOnError(Function onError) =>
+  Stream<T> doOnError(void Function(Object, StackTrace) onError) =>
       transform(DoStreamTransformer<T>(onError: onError));
 
   /// Invokes the given callback function when the stream is first listened to.

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -16,7 +16,7 @@ void main() {
     test('calls onError when an error is emitted', () async {
       var onErrorCalled = false;
       final stream = Stream<void>.error(Exception())
-          .doOnError((dynamic e, dynamic s) => onErrorCalled = true);
+          .doOnError((e, s) => onErrorCalled = true);
 
       await expectLater(stream, emitsError(isException));
       await expectLater(onErrorCalled, isTrue);
@@ -27,9 +27,7 @@ void main() {
         () async {
       var count = 0;
       final subject = BehaviorSubject<int>(sync: true);
-      final stream = subject.stream.doOnError(
-        (dynamic e, dynamic s) => count++,
-      );
+      final stream = subject.stream.doOnError((e, s) => count++);
 
       stream.listen(null, onError: (dynamic e, dynamic s) {});
       stream.listen(null, onError: (dynamic e, dynamic s) {});
@@ -276,8 +274,8 @@ void main() {
           );
 
       Stream<void>.error(Exception('oh noes!'))
-          .doOnError((dynamic _, dynamic __) =>
-              throw Exception('catch me if you can! doOnError'))
+          .doOnError(
+              (_, __) => throw Exception('catch me if you can! doOnError'))
           .listen(
             null,
             onError: expectAsync2(


### PR DESCRIPTION
Fix #492 
- Change:
```dart
Stream<T> doOnError(Function onError)
``` 
to
```dart
Stream<T> doOnError(void Function(Object, StackTrace) onError)
```
- Because we alway call `_onError` with two arguments:
https://github.com/ReactiveX/rxdart/blob/4dcefadf6f72cc5061f7b9346e93179cfd2515d6/lib/src/transformers/do.dart#L46