### PR TITLE
Fix RetryStream example and try-catch DeferStream

### DIFF
--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -791,14 +791,13 @@ abstract class Rx {
   ///
   /// ### Example
   ///
-  ///     Rx.retry(() { Stream.value(1); })
-  ///         .listen((i) => print(i); // Prints 1
+  ///     Rx.retry(() => Stream.value(1))
+  ///         .listen((i) => print(i)); // Prints 1
   ///
-  ///     Rx
-  ///        .retry(() {
-  ///          Stream.value(1).concatWith([Stream.error(Error())]);
-  ///        }, 1)
-  ///        .listen(print, onError: (e, s) => print(e); // Prints 1, 1, RetryError
+  ///     Rx.retry(
+  ///       () => Stream.value(1).concatWith([Stream.error(Error())]),
+  ///       1,
+  ///     ).listen(print, onError: (e, s) => print(e)); // Prints 1, 1, RetryError
   static Stream<T> retry<T>(Stream<T> Function() streamFactory, [int count]) =>
       RetryStream<T>(streamFactory, count);
 

--- a/lib/src/streams/defer.dart
+++ b/lib/src/streams/defer.dart
@@ -33,7 +33,25 @@ class DeferStream<T> extends Stream<T> {
 
   @override
   StreamSubscription<T> listen(void Function(T event) onData,
-          {Function onError, void Function() onDone, bool cancelOnError}) =>
-      _factory().listen(onData,
-          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+      {Function onError, void Function() onDone, bool cancelOnError}) {
+    Stream<T> stream;
+
+    try {
+      stream = _factory();
+    } catch (e, s) {
+      return Stream<T>.error(e, s).listen(
+        onData,
+        onError: onError,
+        onDone: onDone,
+        cancelOnError: cancelOnError,
+      );
+    }
+
+    return stream.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
 }

--- a/lib/src/streams/retry.dart
+++ b/lib/src/streams/retry.dart
@@ -13,14 +13,13 @@ import 'package:rxdart/src/streams/utils.dart';
 ///
 /// ### Example
 ///
-///     RetryStream(() { Stream.fromIterable([1]); })
+///     RetryStream(() => Stream.value(1))
 ///         .listen((i) => print(i)); // Prints 1
 ///
-///     RetryStream(() {
-///          Stream.fromIterable([1])
-///             .concatWith([ErrorStream(Error())]);
-///        }, 1)
-///        .listen(print, onError: (e, s) => print(e)); // Prints 1, 1, RetryError
+///     RetryStream(
+///       () => Stream.value(1).concatWith([Stream.error(Error())]),
+///       1,
+///     ).listen(print, onError: (e, s) => print(e)); // Prints 1, 1, RetryError
 class RetryStream<T> extends Stream<T> {
   /// The factory method used at subscription time
   final Stream<T> Function() streamFactory;

--- a/test/streams/defer_test.dart
+++ b/test/streams/defer_test.dart
@@ -89,13 +89,27 @@ void main() {
     }
   });
 
-  test('Rx.defer.error.shouldThrow', () async {
+  test('Rx.defer.error.shouldThrow.A', () async {
     final streamWithError = Rx.defer(() => _getErroneousStream());
 
     streamWithError.listen(null,
         onError: expectAsync1((Exception e) {
           expect(e, isException);
         }, count: 1));
+  });
+
+  test('Rx.defer.error.shouldThrow.B', () {
+    final deferStream1 = Rx.defer<int>(() => throw Exception());
+    expect(
+      deferStream1,
+      emitsInOrder(<dynamic>[emitsError(isException), emitsDone]),
+    );
+
+    final deferStream2 = Rx.defer<int>(() => throw Exception(), reusable: true);
+    expect(
+      deferStream2,
+      emitsInOrder(<dynamic>[emitsError(isException), emitsDone]),
+    );
   });
 }
 


### PR DESCRIPTION
Closes #501 
-   Fix `RetryStream` example
-   Catch error thrown from `streamFactor`:
```dart
Rx.defer<int>(() => throw Exception())
```