### PR TITLE
docs: Updated a Bad URL

### DIFF
--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -27,7 +27,7 @@ import 'package:rxdart/streams.dart';
 /// RxDart is built.
 ///
 ///   - [Asynchronous Programming: Streams](https://www.dartlang.org/tutorials/language/streams)
-///   - [Single-Subscription vs. Broadcast Streams](https://www.dartcn.com/articles/libraries/broadcast-streams)
+///   - [Single-Subscription vs. Broadcast Streams](https://dart.dev/tutorials/language/streams#two-kinds-of-streams)
 ///   - [Creating Streams in Dart](https://www.dartlang.org/articles/libraries/creating-streams)
 ///   - [Testing Streams: Stream Matchers](https://pub.dartlang.org/packages/test#stream-matchers)
 ///

--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -27,7 +27,7 @@ import 'package:rxdart/streams.dart';
 /// RxDart is built.
 ///
 ///   - [Asynchronous Programming: Streams](https://www.dartlang.org/tutorials/language/streams)
-///   - [Single-Subscription vs. Broadcast Streams](https://www.dartcn.com/articles/libraries/broadcast-streams#:~:text=Single%2Dsubscription%20streams%20are%20designed,can%20be%20lost%20or%20ignored.)
+///   - [Single-Subscription vs. Broadcast Streams](https://www.dartcn.com/articles/libraries/broadcast-streams)
 ///   - [Creating Streams in Dart](https://www.dartlang.org/articles/libraries/creating-streams)
 ///   - [Testing Streams: Stream Matchers](https://pub.dartlang.org/packages/test#stream-matchers)
 ///

--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -27,7 +27,7 @@ import 'package:rxdart/streams.dart';
 /// RxDart is built.
 ///
 ///   - [Asynchronous Programming: Streams](https://www.dartlang.org/tutorials/language/streams)
-///   - [Single-Subscription vs. Broadcast Streams](https://www.dartlang.org/articles/libraries/broadcast-streams)
+///   - [Single-Subscription vs. Broadcast Streams](https://www.dartcn.com/articles/libraries/broadcast-streams#:~:text=Single%2Dsubscription%20streams%20are%20designed,can%20be%20lost%20or%20ignored.)
 ///   - [Creating Streams in Dart](https://www.dartlang.org/articles/libraries/creating-streams)
 ///   - [Testing Streams: Stream Matchers](https://pub.dartlang.org/packages/test#stream-matchers)
 ///


### PR DESCRIPTION
The link "Single-Subscription vs. Broadcast Streams" on https://pub.dev/documentation/rxdart/latest/rx/Rx-class.html is not working.
* Fixes: #504 