### PR TITLE
Travis: enable asserts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,22 @@ script:
   - dartfmt -n ./lib --set-exit-if-changed
   - dartanalyzer --fatal-infos --fatal-warnings ./
   - pub run test test/rxdart_test.dart
-  - dart --disable-service-auth-codes --enable-vm-service=8111 --pause-isolates-on-exit test/rxdart_test.dart &
-  - nohup pub global run coverage:collect_coverage --port=8111 --out=coverage.json --wait-paused --resume-isolates
-  - pub global run coverage:format_coverage --lcov --in=coverage.json --out=lcov.info --packages=.packages --report-on=lib
+  - dart
+     --disable-service-auth-codes
+     --enable-vm-service=8111
+     --pause-isolates-on-exit
+     --enable-asserts
+     test/rxdart_test.dart
+     nohup pub global run coverage:collect_coverage
+     --port=8111
+     --out=coverage.json
+     --wait-paused
+     --resume-isolates
+  - pub global run coverage:format_coverage
+     --lcov
+     --in=coverage.json
+     --out=lcov.info
+     --packages=.packages
+     --report-on=lib
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ script:
      --enable-vm-service=8111
      --pause-isolates-on-exit
      --enable-asserts
-     test/rxdart_test.dart
-     nohup pub global run coverage:collect_coverage
+     test/rxdart_test.dart &
+  - nohup pub global run coverage:collect_coverage
      --port=8111
      --out=coverage.json
      --wait-paused


### PR DESCRIPTION
When running script: `nohup pub global run coverage:collect_coverage --port=8111 --out=coverage.json --wait-paused --resume-isolates
nohup: ignoring input`,  assertions are disabled
```
00:44 +495 -1: Rx.throttle.error.shouldThrowB [E]
  Expected: throws <Instance of 'AssertionError'>
    Actual: <Closure: () => Stream<int>>
     Which: returned <Instance of '_ControllerStream<int>'>
.
.
.
00:53 +687 ~2 -2: CompositeSubscription Rx.compositeSubscription.addNotNull [E]
  Expected: throws <Instance of 'AssertionError'>
    Actual: <Closure: () => StreamSubscription<void>>
     Which: returned <null>
.
.
.
00:53 +687 ~2 -2: CompositeSubscription Rx.compositeSubscription.pauseAndResume
00:53 +688 ~2 -2: CompositeSubscription Rx.compositeSubscription.resumeWithFuture
00:53 +689 ~2 -2: CompositeSubscription Rx.compositeSubscription.allPaused
00:53 +690 ~2 -2: CompositeSubscription Rx.compositeSubscription.allPaused.indirectly
00:53 +691 ~2 -2: CompositeSubscription Rx.compositeSubscription.size
00:53 +692 ~2 -2: Some tests failed.
```
This PR adds `--enable-asserts` option to that script