### PR TITLE
Add Rx.fromCallable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,23 +86,24 @@ You can construct the Streams provided by RxDart in two ways. The following exam
 
 #### List of Classes / Static Factories
 
+- [CombineLatestStream](https://pub.dev/documentation/rxdart/latest/rx/CombineLatestStream-class.html) (combine2, combine3... combine9) / [Rx.combineLatest2](https://pub.dev/documentation/rxdart/latest/rx/Rx/combineLatest2.html)...[Rx.combineLatest9](https://pub.dev/documentation/rxdart/latest/rx/Rx/combineLatest9.html)
 - [ConcatStream](https://pub.dev/documentation/rxdart/latest/rx/ConcatStream-class.html) / [Rx.concat](https://pub.dev/documentation/rxdart/latest/rx/Rx/concat.html)
 - [ConcatEagerStream](https://pub.dev/documentation/rxdart/latest/rx/ConcatEagerStream-class.html) / [Rx.concatEager](https://pub.dev/documentation/rxdart/latest/rx/Rx/concatEager.html)
 - [DeferStream](https://pub.dev/documentation/rxdart/latest/rx/DeferStream-class.html) / [Rx.defer](https://pub.dev/documentation/rxdart/latest/rx/Rx/defer.html)
+- [ForkJoinStream](https://pub.dev/documentation/rxdart/latest/rx/ForkJoinStream-class.html) (join2, join3... join9) / [Rx.forkJoin2](https://pub.dev/documentation/rxdart/latest/rx/Rx/forkJoin2.html)...[Rx.forkJoin9](https://pub.dev/documentation/rxdart/latest/rx/Rx/forkJoin9.html)
+- [FromCallableStream](https://pub.dev/documentation/rxdart/latest/rx/FromCallableStream-class.html) / [Rx.fromCallable](https://pub.dev/documentation/rxdart/latest/rx/Rx/fromCallable.html)
 - [MergeStream](https://pub.dev/documentation/rxdart/latest/rx/MergeStream-class.html) / [Rx.merge](https://pub.dev/documentation/rxdart/latest/rx/Rx/merge.html)
 - [NeverStream](https://pub.dev/documentation/rxdart/latest/rx/NeverStream-class.html) / [Rx.never](https://pub.dev/documentation/rxdart/latest/rx/Rx/never.html)
 - [RaceStream](https://pub.dev/documentation/rxdart/latest/rx/RaceStream-class.html) / [Rx.race](https://pub.dev/documentation/rxdart/latest/rx/Rx/race.html)
+- [RangeStream](https://pub.dev/documentation/rxdart/latest/rx/RangeStream-class.html) / [Rx.range](https://pub.dev/documentation/rxdart/latest/rx/Rx/range.html)
 - [RepeatStream](https://pub.dev/documentation/rxdart/latest/rx/RepeatStream-class.html) / [Rx.repeat](https://pub.dev/documentation/rxdart/latest/rx/Rx/repeat.html)
 - [RetryStream](https://pub.dev/documentation/rxdart/latest/rx/RetryStream-class.html) / [Rx.retry](https://pub.dev/documentation/rxdart/latest/rx/Rx/retry.html)
 - [RetryWhenStream](https://pub.dev/documentation/rxdart/latest/rx/RetryWhenStream-class.html) / [Rx.retryWhen](https://pub.dev/documentation/rxdart/latest/rx/Rx/retryWhen.html)
 - [SequenceEqualStream](https://pub.dev/documentation/rxdart/latest/rx/SequenceEqualStream-class.html) / [Rx.sequenceEqual](https://pub.dev/documentation/rxdart/latest/rx/Rx/sequenceEqual.html)
 - [SwitchLatestStream](https://pub.dev/documentation/rxdart/latest/rx/SwitchLatestStream-class.html) / [Rx.switchLatest](https://pub.dev/documentation/rxdart/latest/rx/Rx/switchLatest.html)
 - [TimerStream](https://pub.dev/documentation/rxdart/latest/rx/TimerStream-class.html) / [Rx.timer](https://pub.dev/documentation/rxdart/latest/rx/Rx/timer.html)
-- [CombineLatestStream](https://pub.dev/documentation/rxdart/latest/rx/CombineLatestStream-class.html) (combine2, combine3... combine9) / [Rx.combineLatest2](https://pub.dev/documentation/rxdart/latest/rx/Rx/combineLatest2.html)...[Rx.combineLatest9](https://pub.dev/documentation/rxdart/latest/rx/Rx/combineLatest9.html) 
-- [ForkJoinStream](https://pub.dev/documentation/rxdart/latest/rx/ForkJoinStream-class.html) (join2, join3... join9) / [Rx.forkJoin2](https://pub.dev/documentation/rxdart/latest/rx/Rx/forkJoin2.html)...[Rx.forkJoin9](https://pub.dev/documentation/rxdart/latest/rx/Rx/forkJoin9.html)
-- [RangeStream](https://pub.dev/documentation/rxdart/latest/rx/RangeStream-class.html) / [Rx.range](https://pub.dev/documentation/rxdart/latest/rx/Rx/range.html)
-- [ZipStream](https://pub.dev/documentation/rxdart/latest/rx/ZipStream-class.html) (zip2, zip3, zip4, ..., zip9) / [Rx.zip](https://pub.dev/documentation/rxdart/latest/rx/Rx/zip2.html)...[Rx.zip9](https://pub.dev/documentation/rxdart/latest/rx/Rx/zip9.html)
 - [UsingStream](https://pub.dev/documentation/rxdart/latest/rx/UsingStream-class.html) / [Rx.using](https://pub.dev/documentation/rxdart/latest/rx/Rx/using.html)
+- [ZipStream](https://pub.dev/documentation/rxdart/latest/rx/ZipStream-class.html) (zip2, zip3, zip4, ..., zip9) / [Rx.zip](https://pub.dev/documentation/rxdart/latest/rx/Rx/zip2.html)...[Rx.zip9](https://pub.dev/documentation/rxdart/latest/rx/Rx/zip9.html)
 - ** If you're looking for an [Interval](http://reactivex.io/documentation/operators/interval.html) equivalent, check out Dart's [Stream.periodic](https://api.dart.dev/stable/2.7.2/dart-async/Stream/Stream.periodic.html) for similar behavior.
 
 ### Extension Methods

--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -730,8 +730,8 @@ abstract class Rx {
   ///       return 'Value';
   ///     }).listen(print); // prints Value
   static Stream<T> fromCallable<T>(FutureOr<T> Function() callable,
-          {bool isReusable = false}) =>
-      FromCallableStream(callable, isReusable: isReusable);
+          {bool reusable = false}) =>
+      FromCallableStream(callable, reusable: reusable);
 
   /// Flattens the items emitted by the given [streams] into a single Stream
   /// sequence.

--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:rxdart/src/streams/from_callable.dart';
 import 'package:rxdart/streams.dart';
 
 /// A utility class that provides static methods to create the various Streams
@@ -704,6 +705,31 @@ abstract class Rx {
         streamI,
         combiner,
       );
+
+  /// Returns a Stream that, when listening to it, calls a function you specify
+  /// and then emits the value returned from that function.
+  ///
+  /// If result from invoking [callable] function:
+  /// - Is a [Future]: when the future completes, this stream will fire one event, either
+  ///   data or error, and then close with a done-event.
+  /// - Is a [T]: this stream emits a single data event and then completes with a done event.
+  ///
+  /// A [FromCallableStream] is always a single-subscription Stream.
+  /// This Stream is effectively equivalent to one created by
+  /// `(() async* { yield await callable() }())` or `(() async* { yield callable(); }())`.
+  ///
+  /// [ReactiveX doc](http://reactivex.io/documentation/operators/from.html)
+  ///
+  /// ### Example
+  ///
+  ///     Rx.fromCallable(() => 'Value').listen(print); // prints Value
+  ///
+  ///     Rx.fromCallable(() async {
+  ///       await Future<void>.delayed(const Duration(seconds: 1));
+  ///       return 'Value';
+  ///     }).listen(print); // prints Value
+  static Stream<T> fromCallable<T>(FutureOr<T> Function() callable) =>
+      FromCallableStream(callable);
 
   /// Flattens the items emitted by the given [streams] into a single Stream
   /// sequence.

--- a/lib/src/rx.dart
+++ b/lib/src/rx.dart
@@ -714,7 +714,8 @@ abstract class Rx {
   ///   data or error, and then close with a done-event.
   /// - Is a [T]: this stream emits a single data event and then completes with a done event.
   ///
-  /// A [FromCallableStream] is always a single-subscription Stream.
+  /// By default, a [FromCallableStream] is a single-subscription Stream. However, it's possible
+  /// to make them reusable.
   /// This Stream is effectively equivalent to one created by
   /// `(() async* { yield await callable() }())` or `(() async* { yield callable(); }())`.
   ///
@@ -728,8 +729,9 @@ abstract class Rx {
   ///       await Future<void>.delayed(const Duration(seconds: 1));
   ///       return 'Value';
   ///     }).listen(print); // prints Value
-  static Stream<T> fromCallable<T>(FutureOr<T> Function() callable) =>
-      FromCallableStream(callable);
+  static Stream<T> fromCallable<T>(FutureOr<T> Function() callable,
+          {bool isReusable = false}) =>
+      FromCallableStream(callable, isReusable: isReusable);
 
   /// Flattens the items emitted by the given [streams] into a single Stream
   /// sequence.

--- a/lib/src/streams/from_callable.dart
+++ b/lib/src/streams/from_callable.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+/// Returns a Stream that, when listening to it, calls a function you specify
+/// and then emits the value returned from that function.
+///
+/// If result from invoking [callable] function:
+/// - Is a [Future]: when the future completes, this stream will fire one event, either
+///   data or error, and then close with a done-event.
+/// - Is a [T]: this stream emits a single data event and then completes with a done event.
+///
+/// A [FromCallableStream] is always a single-subscription Stream.
+/// This Stream is effectively equivalent to one created by
+/// `(() async* { yield await callable() }())` or `(() async* { yield callable(); }())`.
+///
+/// [ReactiveX doc](http://reactivex.io/documentation/operators/from.html)
+///
+/// ### Example
+///
+///     FromCallableStream(() => 'Value').listen(print); // prints Value
+///
+///     FromCallableStream(() async {
+///       await Future<void>.delayed(const Duration(seconds: 1));
+///       return 'Value';
+///     }).listen(print); // prints Value
+class FromCallableStream<T> extends Stream<T> {
+  Stream<T> _stream;
+
+  /// A function will be called at subscription time.
+  final FutureOr<T> Function() callable;
+
+  /// Construct a Stream that, when listening to it, calls a function you specify
+  /// and then emits the value returned from that function.
+  FromCallableStream(this.callable);
+
+  @override
+  bool get isBroadcast => false;
+
+  @override
+  StreamSubscription<T> listen(
+    void Function(T event) onData, {
+    Function onError,
+    void Function() onDone,
+    bool cancelOnError,
+  }) {
+    if (_stream == null) {
+      try {
+        final value = callable();
+
+        _stream = value is Future<T>
+            ? Stream.fromFuture(value)
+            : Stream.value(value as T);
+      } catch (e, s) {
+        _stream = Stream.error(e, s);
+      }
+    }
+
+    return _stream.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+}

--- a/lib/src/streams/from_callable.dart
+++ b/lib/src/streams/from_callable.dart
@@ -32,9 +32,9 @@ class FromCallableStream<T> extends Stream<T> {
 
   /// Construct a Stream that, when listening to it, calls a function you specify
   /// and then emits the value returned from that function.
-  /// [isReusable] indicates whether this Stream can be listened to multiple times or not.
-  FromCallableStream(this.callable, {bool isReusable = false})
-      : _isReusable = isReusable;
+  /// [reusable] indicates whether this Stream can be listened to multiple times or not.
+  FromCallableStream(this.callable, {bool reusable = false})
+      : _isReusable = reusable;
 
   @override
   bool get isBroadcast => _isReusable;

--- a/lib/streams.dart
+++ b/lib/streams.dart
@@ -6,6 +6,7 @@ export 'src/streams/concat_eager.dart';
 export 'src/streams/connectable_stream.dart';
 export 'src/streams/defer.dart';
 export 'src/streams/fork_join.dart';
+export 'src/streams/from_callable.dart';
 export 'src/streams/merge.dart';
 export 'src/streams/never.dart';
 export 'src/streams/race.dart';

--- a/test/rxdart_test.dart
+++ b/test/rxdart_test.dart
@@ -7,6 +7,7 @@ import 'streams/concat_eager_test.dart' as concat_eager_test;
 import 'streams/concat_test.dart' as concat_test;
 import 'streams/defer_test.dart' as defer_test;
 import 'streams/fork_join_test.dart' as fork_join_test;
+import 'streams/from_callable_test.dart' as from_callable_test;
 import 'streams/merge_test.dart' as merge_test;
 import 'streams/never_test.dart' as never_test;
 import 'streams/publish_connectable_stream_test.dart'
@@ -91,6 +92,7 @@ void main() {
   concat_test.main();
   defer_test.main();
   fork_join_test.main();
+  from_callable_test.main();
   merge_test.main();
   never_test.main();
   range_test.main();

--- a/test/streams/from_callable_test.dart
+++ b/test/streams/from_callable_test.dart
@@ -1,0 +1,118 @@
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Rx.fromCallable.sync', () {
+    var called = false;
+
+    var stream = Rx.fromCallable(() {
+      called = true;
+      return 2;
+    });
+
+    expect(called, false);
+    expectLater(stream, emitsInOrder(<dynamic>[2, emitsDone]));
+    expect(called, true);
+  });
+
+  test('Rx.fromCallable.async', () {
+    var called = false;
+
+    var stream = FromCallableStream(() async {
+      called = true;
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      return 2;
+    });
+
+    expect(called, false);
+    expectLater(stream, emitsInOrder(<dynamic>[2, emitsDone]));
+    expect(called, true);
+  });
+
+  test('Rx.fromCallable.singleSubscription', () {
+    {
+      var stream = Rx.fromCallable(() =>
+          Future.delayed(const Duration(milliseconds: 10), () => 'Value'));
+
+      stream.listen(null);
+      expect(() => stream.listen(null), throwsStateError);
+    }
+
+    {
+      var stream = Rx.fromCallable(() => Future<String>.error(Exception()));
+
+      stream.listen(null, onError: (Object e) {});
+      expect(
+          () => stream.listen(null, onError: (Object e) {}), throwsStateError);
+    }
+  });
+
+  test('Rx.fromCallable.asBroadcastStream', () async {
+    final stream = Rx.fromCallable(() => 2).asBroadcastStream();
+
+    // listen twice on same stream
+    stream.listen(null);
+    stream.listen(null);
+
+    // code should reach here
+    await expectLater(stream.isBroadcast, isTrue);
+  });
+
+  test('Rx.fromCallable.sync.shouldThrow', () {
+    var stream = Rx.fromCallable<String>(() => throw Exception());
+
+    expectLater(
+      stream,
+      emitsInOrder(<dynamic>[emitsError(isException), emitsDone]),
+    );
+  });
+
+  test('Rx.fromCallable.async.shouldThrow', () {
+    {
+      var stream = Rx.fromCallable<String>(() async => throw Exception());
+
+      expectLater(
+        stream,
+        emitsInOrder(<dynamic>[emitsError(isException), emitsDone]),
+      );
+    }
+
+    {
+      var stream = Rx.fromCallable<String>(() => Future.error(Exception()));
+
+      expectLater(
+        stream,
+        emitsInOrder(<dynamic>[emitsError(isException), emitsDone]),
+      );
+    }
+  });
+
+  test('Rx.fromCallable.sync.pause.resume', () {
+    var stream = Rx.fromCallable(() => 'Value');
+
+    stream
+        .listen(
+          expectAsync1(
+            (v) => expect(v, 'Value'),
+            count: 1,
+          ),
+        )
+        .pause(Future<void>.delayed(const Duration(milliseconds: 50)));
+  });
+
+  test('Rx.fromCallable.async.pause.resume', () {
+    var stream = Rx.fromCallable(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      return 'Value';
+    });
+
+    stream
+        .listen(
+          expectAsync1(
+            (v) => expect(v, 'Value'),
+            count: 1,
+          ),
+        )
+        .pause(Future<void>.delayed(const Duration(milliseconds: 50)));
+  });
+}

--- a/test/streams/from_callable_test.dart
+++ b/test/streams/from_callable_test.dart
@@ -30,7 +30,7 @@ void main() {
   });
 
   test('Rx.fromCallable.reusable', () {
-    var stream = Rx.fromCallable(() => 2, isReusable: true);
+    var stream = Rx.fromCallable(() => 2, reusable: true);
     expect(stream.isBroadcast, isTrue);
 
     stream.listen(null);

--- a/test/streams/from_callable_test.dart
+++ b/test/streams/from_callable_test.dart
@@ -29,11 +29,22 @@ void main() {
     expect(called, true);
   });
 
+  test('Rx.fromCallable.reusable', () {
+    var stream = Rx.fromCallable(() => 2, isReusable: true);
+    expect(stream.isBroadcast, isTrue);
+
+    stream.listen(null);
+    stream.listen(null);
+
+    expect(true, true);
+  });
+
   test('Rx.fromCallable.singleSubscription', () {
     {
       var stream = Rx.fromCallable(() =>
           Future.delayed(const Duration(milliseconds: 10), () => 'Value'));
 
+      expect(stream.isBroadcast, isFalse);
       stream.listen(null);
       expect(() => stream.listen(null), throwsStateError);
     }
@@ -41,6 +52,7 @@ void main() {
     {
       var stream = Rx.fromCallable(() => Future<String>.error(Exception()));
 
+      expect(stream.isBroadcast, isFalse);
       stream.listen(null, onError: (Object e) {});
       expect(
           () => stream.listen(null, onError: (Object e) {}), throwsStateError);


### PR DESCRIPTION
- Closes #309 
- Seems #310  discontinued, so I open new PR adding `Rx.fromCallable / FromCallableStream`
- Adding param `reusable: bool` that allows listening to Stream multiple times (like `defer`).