### PR TITLE
fix(switchMap): doesn't close after the last inner closed

### DIFF
--- a/lib/src/transformers/switch_map.dart
+++ b/lib/src/transformers/switch_map.dart
@@ -20,9 +20,10 @@ class _SwitchMapStreamSink<S, T> implements ForwardingSink<S, T> {
       sink.add,
       onError: sink.addError,
       onDone: () {
+        _mapperSubscription = null;
+
         if (_inputClosed) {
           sink.close();
-          _mapperSubscription = null;
         }
       },
     );

--- a/test/transformers/switch_map_test.dart
+++ b/test/transformers/switch_map_test.dart
@@ -137,4 +137,18 @@ void main() {
 
     controller.add(1);
   });
+
+  test('Rx.switchMap closes after the last inner Stream closed - issue/511',
+      () async {
+    final outer = StreamController<bool>();
+    final inner = BehaviorSubject.seeded(false);
+    final stream = outer.stream.switchMap((_) => inner.stream);
+
+    expect(stream, emitsThrough(emitsDone));
+
+    outer.add(true);
+    await Future<void>.delayed(Duration.zero);
+    await inner.close();
+    await outer.close();
+  });
 }


### PR DESCRIPTION
:bug: Fixes https://github.com/ReactiveX/rxdart/issues/511.