### PR TITLE
fix refCount, update ConnectableStream

### DIFF
--- a/lib/src/streams/concat.dart
+++ b/lib/src/streams/concat.dart
@@ -99,6 +99,8 @@ extension ConcatExtensions<T> on Stream<T> {
   Stream<T> concatWith(Iterable<Stream<T>> other) {
     final concatStream = ConcatStream<T>([this, ...other]);
 
-    return isBroadcast ? concatStream.asBroadcastStream() : concatStream;
+    return isBroadcast
+        ? concatStream.asBroadcastStream(onCancel: (s) => s.cancel())
+        : concatStream;
   }
 }

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -50,8 +50,9 @@ class PublishConnectableStream<T> extends ConnectableStream<T> {
   }
 
   PublishConnectableStream._(Stream<T> source, this._subject)
-      : _source =
-            source.isBroadcast ?? true ? source : source.asBroadcastStream(),
+      : _source = source.isBroadcast ?? true
+            ? source
+            : source.asBroadcastStream(onCancel: (s) => s.cancel()),
         super(_subject);
 
   @override
@@ -65,12 +66,15 @@ class PublishConnectableStream<T> extends ConnectableStream<T> {
         connect();
       }
     };
+    _subject.onCancel = null;
 
     return _subject;
   }
 
   @override
   StreamSubscription<T> connect() {
+    _subject.onListen = _subject.onCancel = null;
+
     return ConnectableStreamSubscription<T>(
       _source.listen(_subject.add, onError: _subject.addError),
       _subject,
@@ -88,9 +92,7 @@ class PublishConnectableStream<T> extends ConnectableStream<T> {
       );
     };
 
-    _subject.onCancel = () {
-      subscription.cancel();
-    };
+    _subject.onCancel = () => subscription.cancel();
 
     return _subject;
   }
@@ -105,8 +107,9 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   final BehaviorSubject<T> _subject;
 
   ValueConnectableStream._(Stream<T> source, this._subject)
-      : _source =
-            source.isBroadcast ?? true ? source : source.asBroadcastStream(),
+      : _source = source.isBroadcast ?? true
+            ? source
+            : source.asBroadcastStream(onCancel: (s) => s.cancel()),
         super(_subject);
 
   /// Constructs a [Stream] which only begins emitting events when
@@ -139,12 +142,15 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
         connect();
       }
     };
+    _subject.onCancel = null;
 
     return _subject;
   }
 
   @override
   StreamSubscription<T> connect() {
+    _subject.onListen = _subject.onCancel = null;
+
     return ConnectableStreamSubscription<T>(
       _source.listen(_subject.add, onError: _subject.addError),
       _subject,
@@ -162,9 +168,7 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
       );
     };
 
-    _subject.onCancel = () {
-      subscription.cancel();
-    };
+    _subject.onCancel = () => subscription.cancel();
 
     return _subject;
   }
@@ -202,8 +206,9 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
   }
 
   ReplayConnectableStream._(Stream<T> source, this._subject)
-      : _source =
-            source.isBroadcast ?? true ? source : source.asBroadcastStream(),
+      : _source = source.isBroadcast ?? true
+            ? source
+            : source.asBroadcastStream(onCancel: (s) => s.cancel()),
         super(_subject);
 
   @override
@@ -217,12 +222,15 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
         connect();
       }
     };
+    _subject.onCancel = null;
 
     return _subject;
   }
 
   @override
   StreamSubscription<T> connect() {
+    _subject.onListen = _subject.onCancel = null;
+
     return ConnectableStreamSubscription<T>(
       _source.listen(_subject.add, onError: _subject.addError),
       _subject,
@@ -240,9 +248,7 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
       );
     };
 
-    _subject.onCancel = () {
-      subscription.cancel();
-    };
+    _subject.onCancel = () => subscription.cancel();
 
     return _subject;
   }

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -262,10 +262,8 @@ class ConnectableStreamSubscription<T> extends StreamSubscription<T> {
   ConnectableStreamSubscription(this._source, this._subject);
 
   @override
-  Future<dynamic> cancel() async {
-    await _source.cancel();
-    await _subject.close();
-  }
+  Future<dynamic> cancel() =>
+      _source.cancel().then<void>((_) => _subject.close());
 
   @override
   Future<E> asFuture<E>([E futureValue]) => _source.asFuture(futureValue);

--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -88,6 +88,8 @@ extension MergeExtension<T> on Stream<T> {
   Stream<T> mergeWith(Iterable<Stream<T>> streams) {
     final stream = MergeStream<T>([this, ...streams]);
 
-    return isBroadcast ? stream.asBroadcastStream() : stream;
+    return isBroadcast
+        ? stream.asBroadcastStream(onCancel: (s) => s.cancel())
+        : stream;
   }
 }

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -388,6 +388,8 @@ extension ZipWithExtension<T> on Stream<T> {
   Stream<R> zipWith<S, R>(Stream<S> other, R Function(T t, S s) zipper) {
     final stream = ZipStream.zip2(this, other, zipper);
 
-    return isBroadcast ? stream.asBroadcastStream() : stream;
+    return isBroadcast
+        ? stream.asBroadcastStream(onCancel: (s) => s.cancel())
+        : stream;
   }
 }

--- a/test/streams/publish_connectable_stream_test.dart
+++ b/test/streams/publish_connectable_stream_test.dart
@@ -15,11 +15,13 @@ void main() {
       when(stream.listen(any, onError: anyNamed('onError')))
           .thenReturn(Stream<int>.fromIterable(const [1, 2, 3]).listen(null));
 
-      verifyNever(stream.listen(any, onError: anyNamed('onError')));
+      verifyNever(stream.listen(any,
+          onError: anyNamed('onError'), onDone: anyNamed('onDone')));
 
       connectableStream.connect();
 
-      verify(stream.listen(any, onError: anyNamed('onError')));
+      verify(stream.listen(any,
+          onError: anyNamed('onError'), onDone: anyNamed('onDone')));
     });
 
     test('should begin emitting items after connection', () {
@@ -76,7 +78,7 @@ void main() {
       expect(await stream.isEmpty, true);
     });
 
-    test('refcount cancels source subscription when no listeners remain',
+    test('refCount cancels source subscription when no listeners remain',
         () async {
       var isCanceled = false;
 
@@ -89,6 +91,22 @@ void main() {
 
       await subscription.cancel();
       expect(isCanceled, true);
+    });
+
+    test('can close share() stream', () async {
+      final isCanceled = Completer<void>();
+
+      final controller = StreamController<bool>();
+      controller.stream
+          .share()
+          .doOnCancel(() => isCanceled.complete())
+          .listen(null);
+
+      controller.add(true);
+      await Future<void>.delayed(Duration.zero);
+      await controller.close();
+
+      expect(isCanceled.future, completes);
     });
   });
 }

--- a/test/streams/publish_connectable_stream_test.dart
+++ b/test/streams/publish_connectable_stream_test.dart
@@ -75,5 +75,20 @@ void main() {
 
       expect(await stream.isEmpty, true);
     });
+
+    test('refcount cancels source subscription when no listeners remain',
+        () async {
+      var isCanceled = false;
+
+      final controller =
+          StreamController<void>(onCancel: () => isCanceled = true);
+      final stream = controller.stream.share();
+
+      StreamSubscription subscription;
+      subscription = stream.listen(null);
+
+      await subscription.cancel();
+      expect(isCanceled, true);
+    });
   });
 }

--- a/test/streams/replay_connectable_stream_test.dart
+++ b/test/streams/replay_connectable_stream_test.dart
@@ -138,5 +138,20 @@ void main() {
 
       expect(await stream.isEmpty, true);
     });
+
+    test('refcount cancels source subscription when no listeners remain',
+        () async {
+      var isCanceled = false;
+
+      final controller =
+          StreamController<void>(onCancel: () => isCanceled = true);
+      final stream = controller.stream.shareReplay();
+
+      StreamSubscription subscription;
+      subscription = stream.listen(null);
+
+      await subscription.cancel();
+      expect(isCanceled, true);
+    });
   });
 }

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -169,5 +169,36 @@ void main() {
 
       expect(await stream.isEmpty, true);
     });
+
+    test('refcount cancels source subscription when no listeners remain',
+        () async {
+      {
+        var isCanceled = false;
+
+        final controller =
+            StreamController<void>(onCancel: () => isCanceled = true);
+        final stream = controller.stream.shareValue();
+
+        StreamSubscription subscription;
+        subscription = stream.listen(null);
+
+        await subscription.cancel();
+        expect(isCanceled, true);
+      }
+
+      {
+        var isCanceled = false;
+
+        final controller =
+            StreamController<void>(onCancel: () => isCanceled = true);
+        final stream = controller.stream.shareValueSeeded(null);
+
+        StreamSubscription subscription;
+        subscription = stream.listen(null);
+
+        await subscription.cancel();
+        expect(isCanceled, true);
+      }
+    });
   });
 }


### PR DESCRIPTION
Fixes #514 
Related: dart-lang/sdk#26686,  #455
- Cancel source subscription when shared stream, zip, merge, concat stream cancel
- Forward done event, #288 