### PR TITLE
Error and stack trace

### DIFF
--- a/lib/rxdart.dart
+++ b/lib/rxdart.dart
@@ -3,6 +3,8 @@ library rx;
 export 'src/rx.dart';
 export 'src/streams/connectable_stream.dart';
 export 'src/utils/composite_subscription.dart';
+export 'src/utils/error_and_stacktrace.dart';
+export 'src/utils/notification.dart';
 export 'streams.dart';
 export 'subjects.dart';
 export 'transformers.dart';

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 
-import 'package:rxdart/rxdart.dart';
 import 'package:rxdart/src/streams/replay_stream.dart';
 import 'package:rxdart/src/streams/value_stream.dart';
+import 'package:rxdart/src/utils/error_and_stacktrace.dart';
+import 'package:rxdart/subjects.dart';
 
 /// A ConnectableStream resembles an ordinary Stream, except that it
 /// can be listened to multiple times and does not begin emitting items when
@@ -174,7 +175,7 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   bool get hasValue => _subject.hasValue;
 
   @override
-  Object get error => _subject.error;
+  ErrorAndStackTrace get errorAndStackTrace => _subject.errorAndStackTrace;
 
   @override
   bool get hasError => _subject.hasError;
@@ -248,7 +249,8 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
   List<T> get values => _subject.values;
 
   @override
-  List<Object> get errors => _subject.errors;
+  List<ErrorAndStackTrace> get errorAndStackTraces =>
+      _subject.errorAndStackTraces;
 }
 
 /// A special [StreamSubscription] that not only cancels the connection to

--- a/lib/src/streams/replay_stream.dart
+++ b/lib/src/streams/replay_stream.dart
@@ -1,8 +1,10 @@
+import 'package:rxdart/src/utils/error_and_stacktrace.dart';
+
 /// An [Stream] that provides synchronous access to the emitted values
 abstract class ReplayStream<T> implements Stream<T> {
   /// Synchronously get the values stored in Subject. May be empty.
   List<T> get values;
 
-  /// Synchronously get the errors stored in Subject. May be empty.
-  List<Object> get errors;
+  /// Synchronously get the errors and stack traces stored in Subject. May be empty.
+  List<ErrorAndStackTrace> get errorAndStackTraces;
 }

--- a/lib/src/streams/retry.dart
+++ b/lib/src/streams/retry.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:rxdart/src/streams/utils.dart';
+import 'package:rxdart/src/utils/error_and_stacktrace.dart';
 
 /// Creates a [Stream] that will recreate and re-listen to the source
 /// [Stream] the specified number of times until the [Stream] terminates
@@ -30,7 +31,7 @@ class RetryStream<T> extends Stream<T> {
   int _retryStep = 0;
   StreamController<T> _controller;
   StreamSubscription<T> _subscription;
-  final _errors = <ErrorAndStacktrace>[];
+  final _errors = <ErrorAndStackTrace>[];
 
   /// Constructs a [Stream] that will recreate and re-listen to the source
   /// [Stream] (created by the provided factory method) the specified number
@@ -57,7 +58,7 @@ class RetryStream<T> extends Stream<T> {
           onError: (dynamic e, StackTrace s) {
         _subscription.cancel();
 
-        _errors.add(ErrorAndStacktrace(e, s));
+        _errors.add(ErrorAndStackTrace(e, s));
 
         if (count == _retryStep) {
           _controller

--- a/lib/src/streams/retry_when.dart
+++ b/lib/src/streams/retry_when.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:rxdart/src/streams/utils.dart';
+import 'package:rxdart/src/utils/error_and_stacktrace.dart';
 
 /// Creates a Stream that will recreate and re-listen to the source
 /// Stream when the notifier emits a new value. If the source Stream
@@ -67,7 +68,7 @@ class RetryWhenStream<T> extends Stream<T> {
   final RetryWhenStreamFactory retryWhenFactory;
   StreamController<T> _controller;
   StreamSubscription<T> _subscription;
-  final _errors = <ErrorAndStacktrace>[];
+  final _errors = <ErrorAndStackTrace>[];
 
   /// Constructs a [Stream] that will recreate and re-listen to the source
   /// [Stream] (created by the provided factory method).
@@ -108,14 +109,14 @@ class RetryWhenStream<T> extends Stream<T> {
         sub = retryWhenFactory(e, s).listen(
           (event) {
             sub.cancel();
-            _errors.add(ErrorAndStacktrace(e, s));
+            _errors.add(ErrorAndStackTrace(e, s));
             _retry();
           },
           onError: (Object e, [StackTrace s]) {
             sub.cancel();
             _controller
               ..addError(RetryError.onReviveFailed(
-                _errors..add(ErrorAndStacktrace(e, s)),
+                _errors..add(ErrorAndStackTrace(e, s)),
               ))
               ..close();
           },

--- a/lib/src/streams/sequence_equal.dart
+++ b/lib/src/streams/sequence_equal.dart
@@ -59,7 +59,8 @@ class SequenceEqualStream<S, T> extends Stream<bool> {
                   other.transform(MaterializeStreamTransformer()),
                   (Notification<S> s, Notification<T> t) =>
                       s.kind == t.kind &&
-                      s.error?.toString() == t.error?.toString() &&
+                      s.errorAndStackTrace?.error?.toString() ==
+                          t.errorAndStackTrace?.error?.toString() &&
                       doCompare(s.value, t.value))
               .where((isEqual) => !isEqual)
               .listen(emitAndClose,

--- a/lib/src/streams/utils.dart
+++ b/lib/src/streams/utils.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/error_and_stacktrace.dart';
+
 /// The function used to create the [Stream] which triggers a re-listen.
 typedef RetryWhenStreamFactory = Stream<void> Function(
     dynamic error, StackTrace stack);
@@ -10,50 +12,20 @@ class RetryError extends Error {
   final String message;
 
   /// A [List] of errors that where thrown while attempting to retry.
-  final List<ErrorAndStacktrace> errors;
+  final List<ErrorAndStackTrace> errors;
 
   RetryError._(this.message, this.errors);
 
   /// Constructs a [RetryError], including the [errors] that were encountered
   /// during the [count] retry stages.
-  factory RetryError.withCount(int count, List<ErrorAndStacktrace> errors) =>
+  factory RetryError.withCount(int count, List<ErrorAndStackTrace> errors) =>
       RetryError._('Received an error after attempting $count retries', errors);
 
   /// Constructs a [RetryError], including the [errors] that were encountered
   /// during the retry stage.
-  factory RetryError.onReviveFailed(List<ErrorAndStacktrace> errors) =>
+  factory RetryError.onReviveFailed(List<ErrorAndStackTrace> errors) =>
       RetryError._('Received an error after attempting to retry.', errors);
 
   @override
   String toString() => message;
-}
-
-/// An Object which acts as a tuple containing both an error and the
-/// corresponding stack trace.
-class ErrorAndStacktrace {
-  /// A reference to the wrapped error object.
-  final dynamic error;
-
-  /// A reference to the wrapped [StackTrace]
-  final StackTrace stackTrace;
-
-  /// Constructs an object containing both an [error] and the
-  /// corresponding [stackTrace].
-  ErrorAndStacktrace(this.error, this.stackTrace);
-
-  @override
-  String toString() {
-    return 'ErrorAndStacktrace{error: $error, stacktrace: $stackTrace}';
-  }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ErrorAndStacktrace &&
-          runtimeType == other.runtimeType &&
-          error == other.error &&
-          stackTrace == other.stackTrace;
-
-  @override
-  int get hashCode => error.hashCode ^ stackTrace.hashCode;
 }

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -1,3 +1,5 @@
+import 'package:rxdart/src/utils/error_and_stacktrace.dart';
+
 /// An [Stream] that provides synchronous access to the last emitted item
 abstract class ValueStream<T> implements Stream<T> {
   /// Last emitted value, or null if there has been no emission yet
@@ -7,9 +9,10 @@ abstract class ValueStream<T> implements Stream<T> {
   /// A flag that turns true as soon as at least one event has been emitted.
   bool get hasValue;
 
-  /// Last emitted error, or null if no error added or value exists.
+  /// Last emitted error and the corresponding stack trace,
+  /// or null if no error added or value exists.
   /// See [hasError]
-  Object get error;
+  ErrorAndStackTrace get errorAndStackTrace;
 
   /// A flag that turns true as soon as at an error event has been emitted.
   bool get hasError;

--- a/lib/src/subjects/replay_subject.dart
+++ b/lib/src/subjects/replay_subject.dart
@@ -74,11 +74,16 @@ class ReplaySubject<T> extends Subject<T> implements ReplayStream<T> {
         () => queue.toList(growable: false).reversed.fold(controller.stream,
             (stream, event) {
           if (event.isError) {
-            return stream.transform(StartWithErrorStreamTransformer(
-                event.errorAndStackTrace.error,
-                event.errorAndStackTrace.stackTrace));
+            final errorAndStackTrace = event.errorAndStackTrace;
+
+            return stream.transform(
+              StartWithErrorStreamTransformer(
+                errorAndStackTrace.error,
+                errorAndStackTrace.stackTrace,
+              ),
+            );
           } else {
-            return stream.transform(StartWithStreamTransformer(event.event));
+            return stream.transform(StartWithStreamTransformer(event.data));
           }
         }),
         reusable: true,
@@ -101,7 +106,7 @@ class ReplaySubject<T> extends Subject<T> implements ReplayStream<T> {
       _queue.removeFirst();
     }
 
-    _queue.add(_Event(false, event: event));
+    _queue.add(_Event.data(event));
   }
 
   @override
@@ -110,20 +115,19 @@ class ReplaySubject<T> extends Subject<T> implements ReplayStream<T> {
       _queue.removeFirst();
     }
 
-    _queue.add(_Event<T>(true,
-        errorAndStackTrace: _ErrorAndStackTrace(error, stackTrace)));
+    _queue.add(_Event<T>.error(ErrorAndStackTrace(error, stackTrace)));
   }
 
   @override
   List<T> get values => _queue
       .where((event) => !event.isError)
-      .map((event) => event.event)
+      .map((event) => event.data)
       .toList(growable: false);
 
   @override
-  List<Object> get errors => _queue
+  List<ErrorAndStackTrace> get errorAndStackTraces => _queue
       .where((event) => event.isError)
-      .map((event) => event.errorAndStackTrace.error)
+      .map((event) => event.errorAndStackTrace)
       .toList(growable: false);
 
   @override
@@ -142,15 +146,13 @@ class ReplaySubject<T> extends Subject<T> implements ReplayStream<T> {
 
 class _Event<T> {
   final bool isError;
-  final T event;
-  final _ErrorAndStackTrace errorAndStackTrace;
+  final T data;
+  final ErrorAndStackTrace errorAndStackTrace;
 
-  _Event(this.isError, {this.event, this.errorAndStackTrace});
-}
+  _Event._({this.isError, this.data, this.errorAndStackTrace});
 
-class _ErrorAndStackTrace {
-  final Object error;
-  final StackTrace stackTrace;
+  factory _Event.data(T data) => _Event._(isError: false, data: data);
 
-  _ErrorAndStackTrace(this.error, this.stackTrace);
+  factory _Event.error(ErrorAndStackTrace e) =>
+      _Event._(isError: true, errorAndStackTrace: e);
 }

--- a/lib/src/transformers/dematerialize.dart
+++ b/lib/src/transformers/dematerialize.dart
@@ -14,7 +14,10 @@ class _DematerializeStreamSink<S> implements EventSink<Notification<S>> {
     } else if (data.isOnDone) {
       _outputSink.close();
     } else if (data.isOnError) {
-      _outputSink.addError(data.error, data.stackTrace);
+      _outputSink.addError(
+        data.errorAndStackTrace.error,
+        data.errorAndStackTrace.stackTrace,
+      );
     }
   }
 

--- a/lib/src/utils/error_and_stacktrace.dart
+++ b/lib/src/utils/error_and_stacktrace.dart
@@ -1,0 +1,28 @@
+/// An Object which acts as a tuple containing both an error and the
+/// corresponding stack trace.
+class ErrorAndStackTrace {
+  /// A reference to the wrapped error object.
+  final Object error;
+
+  /// A reference to the wrapped [StackTrace]
+  final StackTrace stackTrace;
+
+  /// Constructs an object containing both an [error] and the
+  /// corresponding [stackTrace].
+  ErrorAndStackTrace(this.error, this.stackTrace);
+
+  @override
+  String toString() =>
+      'ErrorAndStackTrace{error: $error, stackTrace: $stackTrace}';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ErrorAndStackTrace &&
+          runtimeType == other.runtimeType &&
+          error == other.error &&
+          stackTrace == other.stackTrace;
+
+  @override
+  int get hashCode => error.hashCode ^ stackTrace.hashCode;
+}

--- a/lib/src/utils/notification.dart
+++ b/lib/src/utils/notification.dart
@@ -1,3 +1,5 @@
+import 'package:rxdart/rxdart.dart';
+
 /// The type of event used in [Notification]
 enum Kind {
   /// Specifies an onData event
@@ -23,53 +25,46 @@ class Notification<T> {
   /// The wrapped value, if applicable
   final T value;
 
-  /// The wrapped error, if applicable
-  final dynamic error;
-
-  /// The wrapped stackTrace, if applicable
-  final StackTrace stackTrace;
+  /// The wrapped error and stack trace, if applicable
+  final ErrorAndStackTrace errorAndStackTrace;
 
   /// Constructs a [Notification] which, depending on the [kind], wraps either
   /// [value], or [error] and [stackTrace], or neither if it is just a
   /// [Kind.OnData] event.
-  const Notification(this.kind, this.value, this.error, this.stackTrace);
+  const Notification._(this.kind, this.value, this.errorAndStackTrace);
 
   /// Constructs a [Notification] with [Kind.OnData] and wraps a [value]
   factory Notification.onData(T value) =>
-      Notification<T>(Kind.OnData, value, null, null);
+      Notification<T>._(Kind.OnData, value, null);
 
   /// Constructs a [Notification] with [Kind.OnDone]
   factory Notification.onDone() =>
-      const Notification(Kind.OnDone, null, null, null);
+      const Notification._(Kind.OnDone, null, null);
 
   /// Constructs a [Notification] with [Kind.OnError] and wraps an [error] and [stackTrace]
-  factory Notification.onError(dynamic error, StackTrace stackTrace) =>
-      Notification<T>(Kind.OnError, null, error, stackTrace);
+  factory Notification.onError(Object error, StackTrace stackTrace) =>
+      Notification<T>._(
+        Kind.OnError,
+        null,
+        ErrorAndStackTrace(error, stackTrace),
+      );
 
   @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    return other is Notification &&
-        kind == other.kind &&
-        error == other.error &&
-        stackTrace == other.stackTrace &&
-        value == other.value;
-  }
+  String toString() =>
+      'Notification{kind: $kind, value: $value, errorAndStackTrace: $errorAndStackTrace}';
 
   @override
-  int get hashCode {
-    return kind.hashCode ^
-        error.hashCode ^
-        stackTrace.hashCode ^
-        value.hashCode;
-  }
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Notification &&
+          runtimeType == other.runtimeType &&
+          kind == other.kind &&
+          value == other.value &&
+          errorAndStackTrace == other.errorAndStackTrace;
 
   @override
-  String toString() {
-    return 'Notification{kind: $kind, value: $value, error: $error, stackTrace: $stackTrace}';
-  }
+  int get hashCode =>
+      kind.hashCode ^ value.hashCode ^ errorAndStackTrace.hashCode;
 
   /// A test to determine if this [Notification] wraps an onData event
   bool get isOnData => kind == Kind.OnData;

--- a/lib/transformers.dart
+++ b/lib/transformers.dart
@@ -35,4 +35,3 @@ export 'src/transformers/time_interval.dart';
 export 'src/transformers/timestamp.dart';
 export 'src/transformers/where_type.dart';
 export 'src/transformers/with_latest_from.dart';
-export 'src/utils/notification.dart';

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -158,7 +158,7 @@ void main() {
         onError: (Object error) {
           expect(stream.value, isNull);
           expect(stream.hasValue, isFalse);
-          expect(stream.error, error);
+          expect(stream.errorAndStackTrace.error, error);
           expect(stream.hasError, isTrue);
         },
       );

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -582,21 +582,21 @@ void main() {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>();
 
-      expect(subject.error, isNull);
+      expect(subject.errorAndStackTrace?.error, isNull);
     });
 
     test('error returns null for a seeded subject with non-null seed', () {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>.seeded(1);
 
-      expect(subject.error, isNull);
+      expect(subject.errorAndStackTrace?.error, isNull);
     });
 
     test('error returns null for a seeded subject with null seed', () {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>.seeded(null);
 
-      expect(subject.error, isNull);
+      expect(subject.errorAndStackTrace?.error, isNull);
     });
 
     test('can synchronously get the latest error', () async {
@@ -608,16 +608,16 @@ void main() {
       unseeded.add(1);
       unseeded.add(2);
       unseeded.add(3);
-      expect(unseeded.error, isNull);
+      expect(unseeded.errorAndStackTrace?.error, isNull);
       unseeded.addError(Exception('oh noes!'));
-      expect(unseeded.error, isException);
+      expect(unseeded.errorAndStackTrace.error, isException);
 
       seeded.add(1);
       seeded.add(2);
       seeded.add(3);
-      expect(seeded.error, isNull);
+      expect(seeded.errorAndStackTrace?.error, isNull);
       seeded.addError(Exception('oh noes!'));
-      expect(seeded.error, isException);
+      expect(seeded.errorAndStackTrace.error, isException);
     });
 
     test('emits event after error to every subscriber, ensures error is null',
@@ -630,16 +630,16 @@ void main() {
       unseeded.add(1);
       unseeded.add(2);
       unseeded.addError(Exception('oh noes!'));
-      expect(unseeded.error, isException);
+      expect(unseeded.errorAndStackTrace.error, isException);
       unseeded.add(3);
-      expect(unseeded.error, isNull);
+      expect(unseeded.errorAndStackTrace?.error, isNull);
 
       seeded.add(1);
       seeded.add(2);
       seeded.addError(Exception('oh noes!'));
-      expect(seeded.error, isException);
+      expect(seeded.errorAndStackTrace.error, isException);
       seeded.add(3);
-      expect(seeded.error, isNull);
+      expect(seeded.errorAndStackTrace?.error, isNull);
     });
 
     test(

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -125,7 +125,9 @@ void main() {
       subject.addError(e3);
 
       await expectLater(
-          subject.errors, containsAllInOrder(<Exception>[e1, e2, e3]));
+        subject.errorAndStackTraces.map((es) => es.error),
+        containsAllInOrder(<Exception>[e1, e2, e3]),
+      );
     });
 
     test('replays the most recently emitted items up to a max size', () async {

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -146,7 +146,7 @@ void main() {
         actual.add(notification);
 
         if (notification.isOnError) {
-          stacktrace = notification.stackTrace;
+          stacktrace = notification.errorAndStackTrace?.stackTrace;
         }
       });
 
@@ -155,8 +155,8 @@ void main() {
 
       await expectLater(actual, [
         Notification.onData(1),
-        Notification<void>.onError(exception, stacktrace),
-        Notification<void>.onDone()
+        Notification<int>.onError(exception, stacktrace),
+        Notification<int>.onDone(),
       ]);
     });
 


### PR DESCRIPTION
### ISSUE
Fixes #517 
### BREAKING CHANGE:
- Change `ValueStream.error` to `ValueStream.errorAndStackTrace`:
   using  `stream.errorAndStackTrace?.error` instead of `stream.error`
- Change `ReplayStream.errors` to `ReplayStream.errorAndStackTraces`:
   using  `stream.errorAndStackTraces.map((es) => es.error).toList()` instead of `stream.errors`
- `Notification`: merge 2 fields `error` and `stackTrace` to `errorAndStackTrace`