### PR TITLE
backpressure: max length buffer

### DIFF
--- a/lib/src/transformers/backpressure/backpressure.dart
+++ b/lib/src/transformers/backpressure/backpressure.dart
@@ -31,21 +31,24 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S, T> {
   final bool Function(List<S> queue) _closeWindowWhen;
   final bool _ignoreEmptyWindows;
   final bool _dispatchOnClose;
-  final queue = <S>[];
+  final Queue<S> queue = DoubleLinkedQueue<S>();
+  final int maxLengthQueue;
   var skip = 0;
   var _hasData = false;
   var _mainClosed = false;
   StreamSubscription<dynamic> _windowSubscription;
 
   _BackpressureStreamSink(
-      this._strategy,
-      this._windowStreamFactory,
-      this._onWindowStart,
-      this._onWindowEnd,
-      this._startBufferEvery,
-      this._closeWindowWhen,
-      this._ignoreEmptyWindows,
-      this._dispatchOnClose);
+    this._strategy,
+    this._windowStreamFactory,
+    this._onWindowStart,
+    this._onWindowEnd,
+    this._startBufferEvery,
+    this._closeWindowWhen,
+    this._ignoreEmptyWindows,
+    this._dispatchOnClose,
+    this.maxLengthQueue,
+  );
 
   @override
   void add(EventSink<T> sink, S data) {
@@ -54,6 +57,10 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S, T> {
 
     if (skip == 0) {
       queue.add(data);
+
+      if (maxLengthQueue != null && queue.length > maxLengthQueue) {
+        queue.removeFirstElements(queue.length - maxLengthQueue);
+      }
     }
 
     if (skip > 0) {
@@ -135,8 +142,7 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S, T> {
   }
 
   void maybeCloseWindow(EventSink<T> sink) {
-    if (_closeWindowWhen != null &&
-        _closeWindowWhen(UnmodifiableListView(queue))) {
+    if (_closeWindowWhen != null && _closeWindowWhen(unmodifiableQueue)) {
       resolveWindowEnd(sink);
     }
   }
@@ -173,10 +179,7 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S, T> {
 
   void resolveWindowStart(S event, EventSink<T> sink) {
     if (_onWindowStart != null) {
-      var startEvent = _onWindowStart(event);
-      if (startEvent != null) {
-        sink.add(startEvent);
-      }
+      sink.add(_onWindowStart(event));
     }
   }
 
@@ -184,10 +187,7 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S, T> {
     if (isControllerClosing &&
         _strategy == WindowStrategy.eventAfterLastWindow) {
       if (_hasData && queue.length > 1 && _onWindowEnd != null) {
-        var endEvent = _onWindowEnd(List<S>.unmodifiable(queue));
-        if (endEvent != null) {
-          sink.add(endEvent);
-        }
+        sink.add(_onWindowEnd(unmodifiableQueue));
       }
 
       queue.clear();
@@ -211,12 +211,16 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S, T> {
 
     if (_hasData && (queue.isNotEmpty || !_ignoreEmptyWindows)) {
       if (_onWindowEnd != null) {
-        sink.add(_onWindowEnd(List<S>.unmodifiable(queue)));
+        sink.add(_onWindowEnd(unmodifiableQueue));
       }
 
       // prepare the buffer for the next window.
       // by default, this is just a cleared buffer
       if (!isControllerClosing && _startBufferEvery > 0) {
+        skip = _startBufferEvery > queue.length
+            ? _startBufferEvery - queue.length
+            : 0;
+
         // ...unless startBufferEvery is provided.
         // here we backtrack to the first event of the last buffer
         // and count forward using startBufferEvery until we reach
@@ -246,22 +250,18 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S, T> {
         // skip becomes 1
         // event 2 is skipped, skip becomes 0
         // event 3 is now added to the buffer
-        final startWith = (_startBufferEvery < queue.length)
-            ? queue.sublist(_startBufferEvery)
-            : <S>[];
-
-        skip = _startBufferEvery > queue.length
-            ? _startBufferEvery - queue.length
-            : 0;
-
-        queue
-          ..clear()
-          ..addAll(startWith);
+        if (_startBufferEvery < queue.length) {
+          queue.removeFirstElements(_startBufferEvery);
+        } else {
+          queue.clear();
+        }
       } else {
         queue.clear();
       }
     }
   }
+
+  List<S> get unmodifiableQueue => List<S>.unmodifiable(queue);
 }
 
 /// A highly customizable [StreamTransformer] which can be configured
@@ -300,6 +300,11 @@ class BackpressureStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
   /// Handler which fires when the window closes
   final T Function(List<S> queue) onWindowEnd;
 
+  /// Maximum length of the buffer.
+  /// Specify this value to avoid running out of memory when adding too many events to the buffer.
+  /// If it's `null`, maximum length of the buffer is unlimited.
+  final int maxLengthQueue;
+
   /// Used to skip an amount of events
   final int startBufferEvery;
 
@@ -322,17 +327,21 @@ class BackpressureStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
   ///
   /// For more info on the parameters, see [BackpressureStreamTransformer],
   /// or see the various back pressure [StreamTransformer]s for examples.
-  BackpressureStreamTransformer(this.strategy, this.windowStreamFactory,
-      {this.onWindowStart,
-      this.onWindowEnd,
-      this.startBufferEvery = 0,
-      this.closeWindowWhen,
-      this.ignoreEmptyWindows = true,
-      this.dispatchOnClose = true});
+  BackpressureStreamTransformer(
+    this.strategy,
+    this.windowStreamFactory, {
+    this.onWindowStart,
+    this.onWindowEnd,
+    this.startBufferEvery = 0,
+    this.closeWindowWhen,
+    this.ignoreEmptyWindows = true,
+    this.dispatchOnClose = true,
+    this.maxLengthQueue,
+  });
 
   @override
   Stream<T> bind(Stream<S> stream) {
-    var sink = _BackpressureStreamSink(
+    final sink = _BackpressureStreamSink(
       strategy,
       windowStreamFactory,
       onWindowStart,
@@ -341,7 +350,17 @@ class BackpressureStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
       closeWindowWhen,
       ignoreEmptyWindows,
       dispatchOnClose,
+      maxLengthQueue,
     );
     return forwardStream(stream, sink);
+  }
+}
+
+extension _RemoveFirstNQueueExtension<T> on Queue<T> {
+  /// Removes the first [count] elements of this queue.
+  void removeFirstElements(int count) {
+    for (var i = 0; i < count; i++) {
+      removeFirst();
+    }
   }
 }

--- a/lib/src/transformers/backpressure/debounce.dart
+++ b/lib/src/transformers/backpressure/debounce.dart
@@ -30,10 +30,13 @@ class DebounceStreamTransformer<T> extends BackpressureStreamTransformer<T, T> {
   /// The [window] is reset whenever the [Stream] that is being transformed
   /// emits an event.
   DebounceStreamTransformer(Stream Function(T event) window)
-      : super(WindowStrategy.everyEvent, window,
-            onWindowEnd: (Iterable<T> queue) => queue.last) {
-    assert(window != null, 'window stream factory cannot be null');
-  }
+      : assert(window != null, 'window stream factory cannot be null'),
+        super(
+          WindowStrategy.everyEvent,
+          window,
+          onWindowEnd: (Iterable<T> queue) => queue.last,
+          maxLengthQueue: 1,
+        );
 }
 
 /// Extends the Stream class with the ability to debounce events in various ways
@@ -78,5 +81,5 @@ extension DebounceExtensions<T> on Stream<T> {
   ///       .debounceTime(Duration(seconds: 1))
   ///       .listen(print); // prints 4
   Stream<T> debounceTime(Duration duration) => transform(
-      DebounceStreamTransformer<T>((_) => TimerStream<bool>(true, duration)));
+      DebounceStreamTransformer<T>((_) => TimerStream<void>(null, duration)));
 }

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -286,7 +286,7 @@ void main() {
 
       // a cancel() call may occur after the controller is already closed
       // in that case, the error is forwarded to the current [Zone]
-      runZoned(
+      runZonedGuarded(
         () {
           Stream.value(1)
               .doOnCancel(() =>
@@ -299,9 +299,10 @@ void main() {
               .listen(null)
                 ..cancel();
         },
-        onError: expectAsync2(
-            (Exception e, [StackTrace s]) => expect(e, isException),
-            count: 2),
+        expectAsync2(
+          (Object e, StackTrace s) => expect(e, isException),
+          count: 2,
+        ),
       );
 
       Stream.value(1)


### PR DESCRIPTION
- Fix #526 .
- Fix travis Dart 2.12.0-13.0.dev lint: • 'onError' is deprecated and shouldn't be used. Use runZonedGuarded instead. • test/transformers/do_test.dart:302:9 • deprecated_member_use