### PR TITLE
ValueStream.requireValue and requireError: throws actual error or StateError

### DIFF
--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -22,9 +22,22 @@ extension ValueStreamExtensions<T> on ValueStream<T> {
   /// Returns last emitted value, or null if there has been no emission yet.
   T? get value => valueWrapper?.value;
 
-  /// Returns last emitted value, or throws `"Null check operator used on a null value"` error
-  /// if there has been no emission yet.
-  T get requireValue => valueWrapper!.value;
+  /// Returns last emitted value, failing if there is no value.
+  /// Throws [error] if [hasError].
+  /// Throws [StateError], if neither [hasData] nor [hasError].
+  T get requireValue {
+    final value = valueWrapper?.value;
+    if (value != null) {
+      return value;
+    }
+
+    final error = errorAndStackTrace?.error;
+    if (error != null) {
+      throw error;
+    }
+
+    throw StateError('Neither data event nor error event has been emitted.');
+  }
 
   /// A flag that turns true as soon as at an error event has been emitted.
   bool get hasError => errorAndStackTrace != null;
@@ -32,6 +45,14 @@ extension ValueStreamExtensions<T> on ValueStream<T> {
   /// Last emitted error, or null if no error added or value exists.
   Object? get error => errorAndStackTrace?.error;
 
-  /// Last emitted error, or throws `"Null check operator used on a null value"` error if no error added or value exists.
-  Object get requireError => errorAndStackTrace!.error;
+  /// Returns last emitted error, failing if there is no error.
+  /// Throws [StateError] if no error added or value exists.
+  Object get requireError {
+    final error = errorAndStackTrace?.error;
+    if (error != null) {
+      return error;
+    }
+
+    throw StateError('Last emitted event is not an error event.');
+  }
 }

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -26,14 +26,14 @@ extension ValueStreamExtensions<T> on ValueStream<T> {
   /// Throws [error] if [hasError].
   /// Throws [StateError], if neither [hasData] nor [hasError].
   T get requireValue {
-    final value = valueWrapper?.value;
-    if (value != null) {
-      return value;
+    final wrapper = valueWrapper;
+    if (wrapper != null) {
+      return wrapper.value;
     }
 
-    final error = errorAndStackTrace?.error;
-    if (error != null) {
-      throw error;
+    final errorAndSt = errorAndStackTrace;
+    if (errorAndSt != null) {
+      throw errorAndSt.error;
     }
 
     throw StateError('Neither data event nor error event has been emitted.');
@@ -48,9 +48,9 @@ extension ValueStreamExtensions<T> on ValueStream<T> {
   /// Returns last emitted error, failing if there is no error.
   /// Throws [StateError] if no error added or value exists.
   Object get requireError {
-    final error = errorAndStackTrace?.error;
-    if (error != null) {
-      return error;
+    final errorAndSt = errorAndStackTrace;
+    if (errorAndSt != null) {
+      return errorAndSt.error;
     }
 
     throw StateError('Last emitted event is not an error event.');

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -53,6 +53,10 @@ extension ValueStreamExtensions<T> on ValueStream<T> {
       return errorAndSt.error;
     }
 
-    throw StateError('Last emitted event is not an error event.');
+    if (hasValue) {
+      throw StateError('Last emitted event is not an error event.');
+    }
+
+    throw StateError('Neither data event nor error event has been emitted.');
   }
 }

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -583,6 +583,8 @@ void main() {
       final subject = BehaviorSubject<int>();
 
       expect(subject.errorAndStackTrace?.error, isNull);
+      expect(subject.error, isNull);
+      expect(() => subject.requireError, throwsStateError);
     });
 
     test('error returns null for a seeded subject with non-null seed', () {
@@ -590,6 +592,8 @@ void main() {
       final subject = BehaviorSubject<int>.seeded(1);
 
       expect(subject.errorAndStackTrace?.error, isNull);
+      expect(subject.error, isNull);
+      expect(() => subject.requireError, throwsStateError);
     });
 
     test('error returns null for a seeded subject with null seed', () {
@@ -597,6 +601,8 @@ void main() {
       final subject = BehaviorSubject<int?>.seeded(null);
 
       expect(subject.errorAndStackTrace?.error, isNull);
+      expect(subject.error, isNull);
+      expect(() => subject.requireError, throwsStateError);
     });
 
     test('can synchronously get the latest error', () async {
@@ -609,15 +615,23 @@ void main() {
       unseeded.add(2);
       unseeded.add(3);
       expect(unseeded.errorAndStackTrace?.error, isNull);
+      expect(unseeded.error, isNull);
+      expect(() => unseeded.requireError, throwsStateError);
       unseeded.addError(Exception('oh noes!'));
       expect(unseeded.errorAndStackTrace?.error, isException);
+      expect(unseeded.error, isException);
+      expect(unseeded.requireError, isException);
 
       seeded.add(1);
       seeded.add(2);
       seeded.add(3);
       expect(seeded.errorAndStackTrace?.error, isNull);
+      expect(seeded.error, isNull);
+      expect(() => seeded.requireError, throwsStateError);
       seeded.addError(Exception('oh noes!'));
       expect(seeded.errorAndStackTrace?.error, isException);
+      expect(seeded.error, isException);
+      expect(seeded.requireError, isException);
     });
 
     test('emits event after error to every subscriber, ensures error is null',
@@ -631,15 +645,23 @@ void main() {
       unseeded.add(2);
       unseeded.addError(Exception('oh noes!'));
       expect(unseeded.errorAndStackTrace?.error, isException);
+      expect(unseeded.error, isException);
+      expect(unseeded.requireError, isException);
       unseeded.add(3);
       expect(unseeded.errorAndStackTrace?.error, isNull);
+      expect(unseeded.error, isNull);
+      expect(() => unseeded.requireError, throwsStateError);
 
       seeded.add(1);
       seeded.add(2);
       seeded.addError(Exception('oh noes!'));
       expect(seeded.errorAndStackTrace?.error, isException);
+      expect(seeded.error, isException);
+      expect(seeded.requireError, isException);
       seeded.add(3);
       expect(seeded.errorAndStackTrace?.error, isNull);
+      expect(seeded.error, isNull);
+      expect(() => seeded.requireError, throwsStateError);
     });
 
     test(

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -155,7 +155,7 @@ void main() {
       await expectLater(seeded.value, isNull);
     });
 
-    test('can synchronously get the latest value', () async {
+    test('can synchronously get the latest value', () {
       // ignore: close_sinks
       final unseeded = BehaviorSubject<int>(),
           // ignore: close_sinks
@@ -169,9 +169,13 @@ void main() {
       seeded.add(2);
       seeded.add(3);
 
-      await expectLater(unseeded.value, 3);
+      expect(unseeded.value, 3);
+      expect(unseeded.valueWrapper, ValueWrapper(3));
+      expect(unseeded.requireValue, 3);
 
-      await expectLater(seeded.value, 3);
+      expect(seeded.value, 3);
+      expect(seeded.valueWrapper, ValueWrapper(3));
+      expect(seeded.requireValue, 3);
     });
 
     test('can synchronously get the latest null value', () async {
@@ -188,9 +192,13 @@ void main() {
       seeded.add(2);
       seeded.add(null);
 
-      await expectLater(unseeded.value, isNull);
+      expect(unseeded.value, isNull);
+      expect(unseeded.valueWrapper, ValueWrapper<int?>(null));
+      expect(unseeded.requireValue, isNull);
 
-      await expectLater(seeded.value, isNull);
+      expect(seeded.value, isNull);
+      expect(seeded.valueWrapper, ValueWrapper<int?>(null));
+      expect(seeded.requireValue, isNull);
     });
 
     test('emits the seed item if no new items have been emitted', () async {
@@ -217,6 +225,8 @@ void main() {
       final subject = BehaviorSubject<int>.seeded(1);
 
       expect(subject.value, 1);
+      expect(subject.valueWrapper, ValueWrapper(1));
+      expect(subject.requireValue, 1);
     });
 
     test('can synchronously get the initial null value', () {
@@ -224,6 +234,8 @@ void main() {
       final subject = BehaviorSubject<int?>.seeded(null);
 
       expect(subject.value, null);
+      expect(subject.valueWrapper, ValueWrapper<int?>(null));
+      expect(subject.requireValue, null);
     });
 
     test('initial value is null when no value has been emitted', () {
@@ -231,6 +243,8 @@ void main() {
       final subject = BehaviorSubject<int>();
 
       expect(subject.value, isNull);
+      expect(subject.valueWrapper, null);
+      expect(() => subject.requireValue, throwsStateError);
     });
 
     test('emits done event to listeners when the subject is closed', () async {


### PR DESCRIPTION
#550 
- Breaking change: NO
- Throws human-readable error instead of throwing "Null check ..."
- Inspirited by Flutter `AsyncSnapshot.requireData` https://github.com/flutter/flutter/blob/021311ed8a2c182d3237330e5d8ae4c4937b3d76/packages/flutter/lib/src/widgets/async.dart#L248
  ```dart
  /// Returns latest data received, failing if there is no data.
  ///
  /// Throws [error], if [hasError]. Throws [StateError], if neither [hasData]
  /// nor [hasError].
  T get requireData {
    if (hasData)
      return data!;
    if (hasError)
      throw error!;
    throw StateError('Snapshot has neither data nor error');
  }
```