### PR TITLE
ForwardingSink: StackTrace? to StackTrace

### DIFF
--- a/lib/src/subjects/subject.dart
+++ b/lib/src/subjects/subject.dart
@@ -112,7 +112,7 @@ abstract class Subject<T> extends StreamView<T> implements StreamController<T> {
 
     source.listen((T event) {
       _add(event);
-    }, onError: (Object e, StackTrace? s) {
+    }, onError: (Object e, StackTrace s) {
       _addError(e, s);
 
       if (identical(cancelOnError, true)) {

--- a/lib/src/transformers/backpressure/backpressure.dart
+++ b/lib/src/transformers/backpressure/backpressure.dart
@@ -71,7 +71,7 @@ class _BackpressureStreamSink<S, T> implements ForwardingSink<S, T> {
   }
 
   @override
-  void addError(EventSink<T> sink, Object e, [StackTrace? st]) =>
+  void addError(EventSink<T> sink, Object e, StackTrace st) =>
       sink.addError(e, st);
 
   @override

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -9,7 +9,7 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
   final void Function(S event)? _onData;
   final void Function()? _onDone;
   final void Function(Notification<S> notification)? _onEach;
-  final void Function(Object, StackTrace?)? _onError;
+  final void Function(Object, StackTrace)? _onError;
   final void Function()? _onListen;
   final void Function()? _onPause;
   final void Function()? _onResume;
@@ -41,7 +41,7 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  void addError(EventSink<S> sink, Object e, [StackTrace? st]) {
+  void addError(EventSink<S> sink, Object e, StackTrace st) {
     try {
       _onError?.call(e, st);
     } catch (e, s) {
@@ -134,7 +134,7 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
   final void Function(Notification<S> notification)? onEach;
 
   /// fires on errors
-  final void Function(Object, StackTrace?)? onError;
+  final void Function(Object, StackTrace)? onError;
 
   /// fires when a subscription first starts
   final void Function()? onListen;
@@ -245,7 +245,7 @@ extension DoExtensions<T> on Stream<T> {
   ///     Stream.error(Exception())
   ///       .doOnError((error, stacktrace) => print('oh no'))
   ///       .listen(null); // prints 'Oh no'
-  Stream<T> doOnError(void Function(Object, StackTrace?) onError) =>
+  Stream<T> doOnError(void Function(Object, StackTrace) onError) =>
       transform(DoStreamTransformer<T>(onError: onError));
 
   /// Invokes the given callback function when the stream is first listened to.

--- a/lib/src/transformers/exhaust_map.dart
+++ b/lib/src/transformers/exhaust_map.dart
@@ -32,7 +32,7 @@ class _ExhaustMapStreamSink<S, T> implements ForwardingSink<S, T> {
   }
 
   @override
-  void addError(EventSink<T> sink, Object e, [StackTrace? st]) =>
+  void addError(EventSink<T> sink, Object e, StackTrace st) =>
       sink.addError(e, st);
 
   @override

--- a/lib/src/transformers/flat_map.dart
+++ b/lib/src/transformers/flat_map.dart
@@ -36,7 +36,7 @@ class _FlatMapStreamSink<S, T> implements ForwardingSink<S, T> {
   }
 
   @override
-  void addError(EventSink<T> sink, Object e, [StackTrace? st]) =>
+  void addError(EventSink<T> sink, Object e, StackTrace st) =>
       sink.addError(e, st);
 
   @override

--- a/lib/src/transformers/on_error_resume.dart
+++ b/lib/src/transformers/on_error_resume.dart
@@ -18,7 +18,7 @@ class _OnErrorResumeStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  void addError(EventSink<S> sink, Object e, [StackTrace? st]) {
+  void addError(EventSink<S> sink, Object e, StackTrace st) {
     _inRecovery = true;
 
     final recoveryStream = _recoveryFn(e);

--- a/lib/src/transformers/skip_until.dart
+++ b/lib/src/transformers/skip_until.dart
@@ -18,7 +18,7 @@ class _SkipUntilStreamSink<S, T> implements ForwardingSink<S, S> {
   }
 
   @override
-  void addError(EventSink<S> sink, Object e, [StackTrace? st]) =>
+  void addError(EventSink<S> sink, Object e, StackTrace st) =>
       sink.addError(e, st);
 
   @override

--- a/lib/src/transformers/start_with.dart
+++ b/lib/src/transformers/start_with.dart
@@ -16,7 +16,7 @@ class _StartWithStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  void addError(EventSink<S> sink, Object e, [StackTrace? st]) {
+  void addError(EventSink<S> sink, Object e, StackTrace st) {
     _safeAddFirstEvent(sink);
     sink.addError(e, st);
   }

--- a/lib/src/transformers/start_with_error.dart
+++ b/lib/src/transformers/start_with_error.dart
@@ -17,7 +17,7 @@ class _StartWithErrorStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  void addError(EventSink<S> sink, Object e, [StackTrace? st]) {
+  void addError(EventSink<S> sink, Object e, StackTrace st) {
     _safeAddFirstEvent(sink);
     sink.addError(e, st);
   }

--- a/lib/src/transformers/start_with_many.dart
+++ b/lib/src/transformers/start_with_many.dart
@@ -16,7 +16,7 @@ class _StartWithManyStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  void addError(EventSink<S> sink, Object e, [StackTrace? st]) {
+  void addError(EventSink<S> sink, Object e, StackTrace st) {
     _safeAddFirstEvent(sink);
     sink.addError(e, st);
   }

--- a/lib/src/transformers/switch_if_empty.dart
+++ b/lib/src/transformers/switch_if_empty.dart
@@ -18,7 +18,7 @@ class _SwitchIfEmptyStreamSink<S> implements ForwardingSink<S, S> {
   }
 
   @override
-  void addError(EventSink<S> sink, Object error, [StackTrace? st]) {
+  void addError(EventSink<S> sink, Object error, StackTrace st) {
     sink.addError(error, st);
   }
 

--- a/lib/src/transformers/switch_map.dart
+++ b/lib/src/transformers/switch_map.dart
@@ -30,7 +30,7 @@ class _SwitchMapStreamSink<S, T> implements ForwardingSink<S, T> {
   }
 
   @override
-  void addError(EventSink<T> sink, Object e, [StackTrace? st]) =>
+  void addError(EventSink<T> sink, Object e, StackTrace st) =>
       sink.addError(e, st);
 
   @override

--- a/lib/src/transformers/take_last.dart
+++ b/lib/src/transformers/take_last.dart
@@ -22,7 +22,8 @@ class _TakeLastStreamSink<T> implements ForwardingSink<T, T> {
   }
 
   @override
-  void addError(EventSink<T> sink, Object e, [st]) => sink.addError(e, st);
+  void addError(EventSink<T> sink, Object e, StackTrace st) =>
+      sink.addError(e, st);
 
   @override
   void close(EventSink<T> sink) {

--- a/lib/src/transformers/take_until.dart
+++ b/lib/src/transformers/take_until.dart
@@ -13,7 +13,7 @@ class _TakeUntilStreamSink<S, T> implements ForwardingSink<S, S> {
   void add(EventSink<S> sink, S data) => sink.add(data);
 
   @override
-  void addError(EventSink<S> sink, Object e, [StackTrace? st]) =>
+  void addError(EventSink<S> sink, Object e, StackTrace st) =>
       sink.addError(e, st);
 
   @override

--- a/lib/src/transformers/time_interval.dart
+++ b/lib/src/transformers/time_interval.dart
@@ -23,7 +23,7 @@ class _TimeIntervalStreamSink<S> implements ForwardingSink<S, TimeInterval<S>> {
   }
 
   @override
-  void addError(EventSink<TimeInterval<S>> sink, Object e, [StackTrace? st]) =>
+  void addError(EventSink<TimeInterval<S>> sink, Object e, StackTrace st) =>
       sink.addError(e, st);
 
   @override

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -22,7 +22,7 @@ class _WithLatestFromStreamSink<S, T, R> implements ForwardingSink<S, R> {
   }
 
   @override
-  void addError(EventSink<R> sink, Object e, [StackTrace? st]) =>
+  void addError(EventSink<R> sink, Object e, StackTrace st) =>
       sink.addError(e, st);
 
   @override

--- a/lib/src/utils/forwarding_sink.dart
+++ b/lib/src/utils/forwarding_sink.dart
@@ -13,7 +13,7 @@ abstract class ForwardingSink<T, R> {
   void add(EventSink<R> sink, T data);
 
   /// Handle error event
-  void addError(EventSink<R> sink, Object error, [StackTrace? st]);
+  void addError(EventSink<R> sink, Object error, StackTrace st);
 
   /// Handle close event
   void close(EventSink<R> sink);

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -16,6 +16,8 @@ Stream<R> forwardStream<T, R>(
   late StreamController<R> controller;
   late StreamSubscription<T> subscription;
 
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:tryInline')
   void runCatching(void Function() block) {
     try {
       block();
@@ -29,7 +31,7 @@ Stream<R> forwardStream<T, R>(
 
     subscription = stream.listen(
       (data) => runCatching(() => connectedSink.add(controller, data)),
-      onError: (Object e, StackTrace? st) =>
+      onError: (Object e, StackTrace st) =>
           runCatching(() => connectedSink.addError(controller, e, st)),
       onDone: () => runCatching(() => connectedSink.close(controller)),
     );

--- a/lib/src/utils/min_max.dart
+++ b/lib/src/utils/min_max.dart
@@ -19,7 +19,7 @@ Future<T> minMax<T>(Stream<T> stream, bool findMin, Comparator<T>? comparator) {
   late T accumulator;
   late Comparator<T> comparatorNotNull;
 
-  final cancelAndCompleteError = (Object e, StackTrace? st) async {
+  final cancelAndCompleteError = (Object e, StackTrace st) async {
     await subscription.cancel();
 
     completer.completeError(e, st);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,4 +13,4 @@ dev_dependencies:
   build_web_compilers: ^2.7.0
   pedantic: ^1.10.0
   stack_trace: ^1.10.0
-  test: ^1.16.0
+  test: ^1.16.5

--- a/test/streams/retry_when_test.dart
+++ b/test/streams/retry_when_test.dart
@@ -166,10 +166,10 @@ Stream<int> Function() _sourceStream(int i, [int? throwAt]) {
           Stream.fromIterable(range(i)).map((i) => i == throwAt ? throw i : i);
 }
 
-Stream<void> _alwaysThrow(dynamic e, StackTrace? s) =>
+Stream<void> _alwaysThrow(dynamic e, StackTrace s) =>
     Stream<void>.error(Error(), StackTrace.fromString('S'));
 
-Stream<void> _neverThrow(dynamic e, StackTrace? s) => Stream.value('');
+Stream<void> _neverThrow(dynamic e, StackTrace s) => Stream.value('');
 
 Stream<int> Function() _getStreamWithExtras(int failCount) {
   var count = 0;

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -260,7 +260,7 @@ void main() {
           .listen(
             null,
             onError: expectAsync2(
-              (Exception e, [StackTrace? s]) => expect(e, isException),
+              (Exception e, StackTrace s) => expect(e, isException),
             ),
           );
 
@@ -269,7 +269,7 @@ void main() {
           .listen(
             null,
             onError: expectAsync2(
-              (Exception e, [StackTrace? s]) => expect(e, isException),
+              (Exception e, StackTrace s) => expect(e, isException),
             ),
           );
 
@@ -279,7 +279,7 @@ void main() {
           .listen(
             null,
             onError: expectAsync2(
-              (Exception e, [StackTrace? s]) => expect(e, isException),
+              (Exception e, StackTrace s) => expect(e, isException),
               count: 2,
             ),
           );
@@ -297,7 +297,7 @@ void main() {
               .doOnCancel(
                   () => throw Exception('catch me if you can! doOnCancel'))
               .listen(null)
-                .cancel();
+              .cancel();
         },
         expectAsync2(
           (Object e, StackTrace s) => expect(e, isException),
@@ -310,7 +310,7 @@ void main() {
           .listen(
             null,
             onError: expectAsync2(
-              (Exception e, [StackTrace? s]) => expect(e, isException),
+              (Exception e, StackTrace s) => expect(e, isException),
             ),
           );
 
@@ -319,7 +319,7 @@ void main() {
           .listen(
             null,
             onError: expectAsync2(
-              (Exception e, [StackTrace? s]) => expect(e, isException),
+              (Exception e, StackTrace s) => expect(e, isException),
               count: 2,
             ),
           );
@@ -328,7 +328,7 @@ void main() {
           .doOnPause(() => throw Exception('catch me if you can! doOnPause'))
           .listen(null,
               onError: expectAsync2(
-                (Exception e, [StackTrace? s]) => expect(e, isException),
+                (Exception e, StackTrace s) => expect(e, isException),
               ))
             ..pause()
             ..resume();
@@ -337,7 +337,7 @@ void main() {
           .doOnResume(() => throw Exception('catch me if you can! doOnResume'))
           .listen(null,
               onError: expectAsync2(
-                  (Exception e, [StackTrace? s]) => expect(e, isException)))
+                  (Exception e, StackTrace s) => expect(e, isException)))
             ..pause()
             ..resume();
     });

--- a/test/transformers/start_with_error_test.dart
+++ b/test/transformers/start_with_error_test.dart
@@ -64,7 +64,7 @@ void main() {
             subscription.cancel();
           }
         }, count: expectedOutput.length),
-        onError: (Object e, [StackTrace? s]) => expect(e, isException));
+        onError: (Object e, StackTrace s) => expect(e, isException));
 
     subscription.pause();
     subscription.resume();
@@ -77,8 +77,8 @@ void main() {
 
     final stream = controller.stream.transform(transformer);
 
-    stream.listen(null, onError: (Object e, [StackTrace? s]) {});
-    expect(() => stream.listen(null, onError: (Object e, [StackTrace? s]) {}),
+    stream.listen(null, onError: (Object e, StackTrace s) {});
+    expect(() => stream.listen(null, onError: (Object e, StackTrace s) {}),
         throwsStateError);
 
     controller.add(1);


### PR DESCRIPTION
- Breaking change: NO
- `ForwardingSink`: `StackTrace?` to `StackTrace `, because it is always not null,

https://github.com/dart-lang/sdk/blob/53f5179b45911fd1f937239f91e55ec8badd7975/sdk/lib/async/stream.dart#L461-L462
```dart
  /// Adds a subscription to this stream.
  /// ...
  /// The [onError] callback must be of type `void Function(Object error)` or
  /// `void Function(Object error, StackTrace)`.
  /// The function type determines whether [onError] is invoked with a stack
  /// trace argument.
  /// The stack trace argument may be [StackTrace.empty] if this stream received
  /// an error without a stack trace.
  /// ...
  StreamSubscription<T> listen(void onData(T event)?,
      {Function? onError, void onDone()?, bool? cancelOnError});
```