### PR TITLE
OnErrorResume: add StackTrace param to recoveryFn

### DIFF
--- a/test/transformers/on_error_resume_test.dart
+++ b/test/transformers/on_error_resume_test.dart
@@ -22,7 +22,7 @@ void main() {
     var count = 0;
 
     Stream<int>.error(Exception())
-        .onErrorResume((dynamic e) => _getStream())
+        .onErrorResume((e, st) => _getStream())
         .listen(expectAsync1((result) {
           expect(result, expected[count++]);
         }, count: expected.length));
@@ -32,8 +32,7 @@ void main() {
     final exception = Exception();
 
     expect(
-      Stream<Object>.error(exception)
-          .onErrorResume((Object e) => Stream.value(e)),
+      Stream<Object>.error(exception).onErrorResume((e, st) => Stream.value(e)),
       emits(exception),
     );
   });
@@ -66,7 +65,7 @@ void main() {
 
   test('Rx.onErrorResumeNext.pause.resume', () async {
     final transformer =
-        OnErrorResumeStreamTransformer<int>((Object _) => _getStream());
+        OnErrorResumeStreamTransformer<int>((_, __) => _getStream());
     final exp = const [50] + expected;
     late StreamSubscription<num> subscription;
     var count = 0;
@@ -108,7 +107,7 @@ void main() {
 
   test('OnErrorResumeStreamTransformer.reusable', () async {
     final transformer = OnErrorResumeStreamTransformer<int>(
-        (Object _) => _getStream().asBroadcastStream());
+        (_, __) => _getStream().asBroadcastStream());
     var countA = 0, countB = 0;
 
     Stream<int>.error(Exception())
@@ -128,7 +127,7 @@ void main() {
     final controller = StreamController<int>();
 
     final stream =
-        controller.stream.onErrorResume((Object _) => Stream<int>.empty());
+        controller.stream.onErrorResume((_, __) => Stream<int>.empty());
 
     stream.listen(null);
     expect(() => stream.listen(null), throwsStateError);

--- a/test/transformers/on_error_return_with_test.dart
+++ b/test/transformers/on_error_return_with_test.dart
@@ -8,7 +8,7 @@ void main() {
 
   test('Rx.onErrorReturnWith', () async {
     Stream<num>.error(Exception())
-        .onErrorReturnWith((dynamic e) => e is StateError ? 1 : 0)
+        .onErrorReturnWith((e, _) => e is StateError ? 1 : 0)
         .listen(expectAsync1((num result) {
       expect(result, expected);
     }));
@@ -16,7 +16,7 @@ void main() {
 
   test('Rx.onErrorReturnWith.asBroadcastStream', () async {
     final stream = Stream<num>.error(Exception())
-        .onErrorReturnWith((dynamic e) => 0)
+        .onErrorReturnWith((_, __) => 0)
         .asBroadcastStream();
 
     await expectLater(stream.isBroadcast, isTrue);
@@ -34,7 +34,7 @@ void main() {
     late StreamSubscription<num> subscription;
 
     subscription = Stream<num>.error(Exception())
-        .onErrorReturnWith((dynamic e) => 0)
+        .onErrorReturnWith((_, __) => 0)
         .listen(expectAsync1((num result) {
       expect(result, expected);
 
@@ -48,7 +48,7 @@ void main() {
   test('Rx.onErrorReturnWith accidental broadcast', () async {
     final controller = StreamController<int>();
 
-    final stream = controller.stream.onErrorReturnWith((Object _) => 1);
+    final stream = controller.stream.onErrorReturnWith((_, __) => 1);
 
     stream.listen(null);
     expect(() => stream.listen(null), throwsStateError);


### PR DESCRIPTION
- Sometimes, we need to access `StackTrace` when using `onErrorResume`.
- This PR adds `StackTrace` param to `OnErrorResumeStreamTransformer`, `onErrorResume`, `onErrorReturnWith` :
```diff
- Stream<T> onErrorResume(Stream<T> Function(Object error) recoveryFn)
+ Stream<T> onErrorResume(Stream<T> Function(Object error, StackTrace stackTrace) recoveryFn)
```
- **Breaking change**:
  - `onErrorResume`
  - `onErrorReturnWith`
  - `OnErrorResumeStreamTransformer`

_Sent from my Redmi  7A using [FastHub](https://play.google.com/store/apps/details?id=com.fastaccess.github)_