### PR TITLE
Refactor ValueStream: remove ValueWrapper

### DIFF
--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:rxdart/src/streams/replay_stream.dart';
 import 'package:rxdart/src/streams/value_stream.dart';
-import 'package:rxdart/src/utils/error_and_stacktrace.dart';
 import 'package:rxdart/subjects.dart';
 
 /// A ConnectableStream resembles an ordinary Stream, except that it
@@ -169,9 +168,6 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   }
 
   @override
-  ErrorAndStackTrace? get errorAndStackTrace => _subject.errorAndStackTrace;
-
-  @override
   bool get hasValue => _subject.hasValue;
 
   @override
@@ -179,6 +175,18 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
 
   @override
   T? get valueOrNull => _subject.valueOrNull;
+
+  @override
+  Object get error => _subject.error;
+
+  @override
+  Object? get errorOrNull => _subject.errorOrNull;
+
+  @override
+  bool get hasError => _subject.hasError;
+
+  @override
+  StackTrace? get stackTraceOrNull => _subject.stackTraceOrNull;
 }
 
 /// A [ConnectableStream] that converts a single-subscription Stream into
@@ -249,8 +257,10 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
   List<T> get values => _subject.values;
 
   @override
-  List<ErrorAndStackTrace> get errorAndStackTraces =>
-      _subject.errorAndStackTraces;
+  List<Object> get errors => _subject.errors;
+
+  @override
+  List<StackTrace?> get stackTraces => _subject.stackTraces;
 }
 
 /// A special [StreamSubscription] that not only cancels the connection to

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:rxdart/src/streams/replay_stream.dart';
 import 'package:rxdart/src/streams/value_stream.dart';
 import 'package:rxdart/src/utils/error_and_stacktrace.dart';
-import 'package:rxdart/src/utils/value_wrapper.dart';
 import 'package:rxdart/subjects.dart';
 
 /// A ConnectableStream resembles an ordinary Stream, except that it
@@ -173,7 +172,13 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   ErrorAndStackTrace? get errorAndStackTrace => _subject.errorAndStackTrace;
 
   @override
-  ValueWrapper<T>? get valueWrapper => _subject.valueWrapper;
+  bool get hasValue => _subject.hasValue;
+
+  @override
+  T get value => _subject.value;
+
+  @override
+  T? get valueOrNull => _subject.valueOrNull;
 }
 
 /// A [ConnectableStream] that converts a single-subscription Stream into

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -171,13 +171,13 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   bool get hasValue => _subject.hasValue;
 
   @override
-  T get value => _subject.value;
+  T get requireValue => _subject.requireValue;
 
   @override
   T? get valueOrNull => _subject.valueOrNull;
 
   @override
-  Object get error => _subject.error;
+  Object get requireError => _subject.requireError;
 
   @override
   Object? get errorOrNull => _subject.errorOrNull;

--- a/lib/src/streams/replay_stream.dart
+++ b/lib/src/streams/replay_stream.dart
@@ -1,10 +1,11 @@
-import 'package:rxdart/src/utils/error_and_stacktrace.dart';
-
 /// An [Stream] that provides synchronous access to the emitted values
 abstract class ReplayStream<T> implements Stream<T> {
   /// Synchronously get the values stored in Subject. May be empty.
   List<T> get values;
 
   /// Synchronously get the errors and stack traces stored in Subject. May be empty.
-  List<ErrorAndStackTrace> get errorAndStackTraces;
+  List<Object> get errors;
+
+  /// Synchronously get the stack traces of errors stored in Subject. May be empty.
+  List<StackTrace?> get stackTraces;
 }

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -1,12 +1,9 @@
-import 'package:rxdart/src/utils/error_and_stacktrace.dart';
-
 /// An [Stream] that provides synchronous access to the last emitted item
 abstract class ValueStream<T> implements Stream<T> {
   /// Returns the last emitted value, failing if there is no value.
   /// See [hasValue] to determine whether [value] has already been set.
   ///
-  /// Throws [error] if [hasError].
-  /// Throws [StateError], if neither [hasValue] nor [hasError].
+  /// Throws [ValueIsMissingError] if has no value or has error.
   T get value;
 
   /// Returns either [value], or `null`, should [value] not yet have been set.
@@ -15,32 +12,45 @@ abstract class ValueStream<T> implements Stream<T> {
   /// Returns `true` when [value] is available.
   bool get hasValue;
 
-  /// Last emitted error and the corresponding stack trace,
-  /// or null if no error added or value exists.
-  /// See [hasError]
-  ErrorAndStackTrace? get errorAndStackTrace;
-}
-
-/// Extensions to easily access value and error.
-extension ValueStreamExtensions<T> on ValueStream<T> {
-  /// A flag that turns true as soon as at an error event has been emitted.
-  bool get hasError => errorAndStackTrace != null;
-
-  /// Last emitted error, or `null` if no error added or value exists.
-  Object? get errorOrNull => errorAndStackTrace?.error;
-
   /// Returns last emitted error, failing if there is no error.
   /// Throws [StateError] if no error added or value exists.
-  Object get error {
-    final errorAndSt = errorAndStackTrace;
-    if (errorAndSt != null) {
-      return errorAndSt.error;
-    }
+  Object get error;
 
-    if (hasValue) {
-      throw StateError('Last emitted event is not an error event.');
-    }
+  /// Last emitted error, or `null` if no error added or value exists.
+  Object? get errorOrNull;
 
-    throw StateError('Neither data event nor error event has been emitted.');
+  /// A flag that turns true as soon as at an error event has been emitted.
+  bool get hasError;
+
+  /// Returns [StackTrace] of the last emitted error,
+  /// or `null` if no error added or value exists or error has without [StackTrace].
+  StackTrace? get stackTraceOrNull;
+}
+
+class ValueIsMissingError extends Error {
+  final bool _hasError;
+
+  ValueIsMissingError(this._hasError);
+
+  @override
+  String toString() {
+    final message = _hasError
+        ? 'Last emitted event is an error event'
+        : 'Neither data event nor error event has been emitted';
+    return 'MissingValueError: $message. You should check ValueStream.hasValue before accessing ValueStream.value, or use ValueStream.valueOrNull instead.';
+  }
+}
+
+class MissingErrorError extends Error {
+  final bool _hasValue;
+
+  MissingErrorError(this._hasValue);
+
+  @override
+  String toString() {
+    final message = _hasValue
+        ? 'Last emitted event is a data event'
+        : 'Neither data event nor error event has been emitted';
+    return 'MissingErrorError: $message. You should check ValueStream.hasError before accessing ValueStream.error, or use ValueStream.errorOrNull instead.';
   }
 }

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -3,7 +3,7 @@ abstract class ValueStream<T> implements Stream<T> {
   /// Returns the last emitted value, failing if there is no value.
   /// See [hasValue] to determine whether [value] has already been set.
   ///
-  /// Throws [ValueIsMissingError] if has no value or has error.
+  /// Throws [ValueStreamError] if this Stream has no value.
   T get value;
 
   /// Returns either [value], or `null`, should [value] not yet have been set.
@@ -13,44 +13,47 @@ abstract class ValueStream<T> implements Stream<T> {
   bool get hasValue;
 
   /// Returns last emitted error, failing if there is no error.
-  /// Throws [StateError] if no error added or value exists.
+  ///
+  /// Throws [ValueStreamError] if this Stream has no error.
   Object get error;
 
-  /// Last emitted error, or `null` if no error added or value exists.
+  /// Last emitted error, or `null` if no error added.
   Object? get errorOrNull;
 
-  /// A flag that turns true as soon as at an error event has been emitted.
+  /// Returns `true` when [error] is available.
   bool get hasError;
 
   /// Returns [StackTrace] of the last emitted error,
-  /// or `null` if no error added or value exists or error has without [StackTrace].
+  /// or `null` if no error added or the added error has no [StackTrace].
   StackTrace? get stackTraceOrNull;
 }
 
-class ValueIsMissingError extends Error {
-  final bool _hasError;
-
-  ValueIsMissingError(this._hasError);
-
-  @override
-  String toString() {
-    final message = _hasError
-        ? 'Last emitted event is an error event'
-        : 'Neither data event nor error event has been emitted';
-    return 'MissingValueError: $message. You should check ValueStream.hasValue before accessing ValueStream.value, or use ValueStream.valueOrNull instead.';
-  }
+enum _MissingCase {
+  value,
+  error,
 }
 
-class MissingErrorError extends Error {
-  final bool _hasValue;
+/// The error throw by [ValueStream.value] or [ValueStream.error].
+class ValueStreamError extends Error {
+  final _MissingCase _missingCase;
 
-  MissingErrorError(this._hasValue);
+  ValueStreamError._(this._missingCase);
+
+  /// Construct an [ValueStreamError] thrown by [ValueStream.value] when there is no value.
+  factory ValueStreamError.hasNoValue() =>
+      ValueStreamError._(_MissingCase.value);
+
+  /// Construct an [ValueStreamError] thrown by [ValueStream.error] when there is no error.
+  factory ValueStreamError.hasNoError() =>
+      ValueStreamError._(_MissingCase.error);
 
   @override
   String toString() {
-    final message = _hasValue
-        ? 'Last emitted event is a data event'
-        : 'Neither data event nor error event has been emitted';
-    return 'MissingErrorError: $message. You should check ValueStream.hasError before accessing ValueStream.error, or use ValueStream.errorOrNull instead.';
+    switch (_missingCase) {
+      case _MissingCase.value:
+        return 'ValueStream has no value. You should check ValueStream.hasValue before accessing ValueStream.value, or use ValueStream.valueOrNull instead.';
+      case _MissingCase.error:
+        return 'ValueStream has no error. You should check ValueStream.hasError before accessing ValueStream.error, or use ValueStream.errorOrNull instead.';
+    }
   }
 }

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -9,10 +9,10 @@ abstract class ValueStream<T> implements Stream<T> {
   /// Throws [StateError], if neither [hasValue] nor [hasError].
   T get value;
 
-  /// Returns either [value], or 'null', should [value] not yet have been set.
+  /// Returns either [value], or `null`, should [value] not yet have been set.
   T? get valueOrNull;
 
-  /// Returns 'true' when [value] is available.
+  /// Returns `true` when [value] is available.
   bool get hasValue;
 
   /// Last emitted error and the corresponding stack trace,

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -1,12 +1,19 @@
 import 'package:rxdart/src/utils/error_and_stacktrace.dart';
-import 'package:rxdart/src/utils/value_wrapper.dart';
 
 /// An [Stream] that provides synchronous access to the last emitted item
 abstract class ValueStream<T> implements Stream<T> {
-  /// Last emitted value wrapped in [ValueWrapper], or null if there has been no emission yet.
-  /// To indicate that the latest value is null, return `ValueWrapper(null)`.
-  /// See [hasValue]
-  ValueWrapper<T>? get valueWrapper;
+  /// Returns the last emitted value, failing if there is no value.
+  /// See [hasValue] to determine whether [value] has already been set.
+  ///
+  /// Throws [error] if [hasError].
+  /// Throws [StateError], if neither [hasValue] nor [hasError].
+  T get value;
+
+  /// Returns either [value], or 'null', should [value] not yet have been set.
+  T? get valueOrNull;
+
+  /// Returns 'true' when [value] is available.
+  bool get hasValue;
 
   /// Last emitted error and the corresponding stack trace,
   /// or null if no error added or value exists.
@@ -16,38 +23,15 @@ abstract class ValueStream<T> implements Stream<T> {
 
 /// Extensions to easily access value and error.
 extension ValueStreamExtensions<T> on ValueStream<T> {
-  /// A flag that turns true as soon as at least one event has been emitted.
-  bool get hasValue => valueWrapper != null;
-
-  /// Returns last emitted value, or null if there has been no emission yet.
-  T? get value => valueWrapper?.value;
-
-  /// Returns last emitted value, failing if there is no value.
-  /// Throws [error] if [hasError].
-  /// Throws [StateError], if neither [hasData] nor [hasError].
-  T get requireValue {
-    final wrapper = valueWrapper;
-    if (wrapper != null) {
-      return wrapper.value;
-    }
-
-    final errorAndSt = errorAndStackTrace;
-    if (errorAndSt != null) {
-      throw errorAndSt.error;
-    }
-
-    throw StateError('Neither data event nor error event has been emitted.');
-  }
-
   /// A flag that turns true as soon as at an error event has been emitted.
   bool get hasError => errorAndStackTrace != null;
 
-  /// Last emitted error, or null if no error added or value exists.
-  Object? get error => errorAndStackTrace?.error;
+  /// Last emitted error, or `null` if no error added or value exists.
+  Object? get errorOrNull => errorAndStackTrace?.error;
 
   /// Returns last emitted error, failing if there is no error.
   /// Throws [StateError] if no error added or value exists.
-  Object get requireError {
+  Object get error {
     final errorAndSt = errorAndStackTrace;
     if (errorAndSt != null) {
       return errorAndSt.error;

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -4,7 +4,7 @@ abstract class ValueStream<T> implements Stream<T> {
   /// See [hasValue] to determine whether [value] has already been set.
   ///
   /// Throws [ValueStreamError] if this Stream has no value.
-  T get value;
+  T get requireValue;
 
   /// Returns either [value], or `null`, should [value] not yet have been set.
   T? get valueOrNull;
@@ -15,7 +15,7 @@ abstract class ValueStream<T> implements Stream<T> {
   /// Returns last emitted error, failing if there is no error.
   ///
   /// Throws [ValueStreamError] if this Stream has no error.
-  Object get error;
+  Object get requireError;
 
   /// Last emitted error, or `null` if no error added.
   Object? get errorOrNull;
@@ -33,13 +33,13 @@ enum _MissingCase {
   error,
 }
 
-/// The error throw by [ValueStream.value] or [ValueStream.error].
+/// The error throw by [ValueStream.requireValue] or [ValueStream.error].
 class ValueStreamError extends Error {
   final _MissingCase _missingCase;
 
   ValueStreamError._(this._missingCase);
 
-  /// Construct an [ValueStreamError] thrown by [ValueStream.value] when there is no value.
+  /// Construct an [ValueStreamError] thrown by [ValueStream.requireValue] when there is no value.
   factory ValueStreamError.hasNoValue() =>
       ValueStreamError._(_MissingCase.value);
 
@@ -51,7 +51,7 @@ class ValueStreamError extends Error {
   String toString() {
     switch (_missingCase) {
       case _MissingCase.value:
-        return 'ValueStream has no value. You should check ValueStream.hasValue before accessing ValueStream.value, or use ValueStream.valueOrNull instead.';
+        return 'ValueStream has no value. You should check ValueStream.hasValue before accessing ValueStream.requireValue, or use ValueStream.requireValueOrNull instead.';
       case _MissingCase.error:
         return 'ValueStream has no error. You should check ValueStream.hasError before accessing ValueStream.error, or use ValueStream.errorOrNull instead.';
     }

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -144,13 +144,7 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
     if (wrapper != null) {
       return wrapper.value;
     }
-
-    final errorAndSt = _wrapper.latestErrorAndStackTrace;
-    if (errorAndSt != null) {
-      throw errorAndSt.error;
-    }
-
-    throw StateError('Neither data event nor error event has been emitted.');
+    throw ValueIsMissingError(hasError);
   }
 
   @override
@@ -160,8 +154,23 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   set value(T newValue) => add(newValue);
 
   @override
-  ErrorAndStackTrace? get errorAndStackTrace =>
-      _wrapper.latestErrorAndStackTrace;
+  bool get hasError => _wrapper.latestErrorAndStackTrace != null;
+
+  @override
+  Object? get errorOrNull => _wrapper.latestErrorAndStackTrace?.error;
+
+  @override
+  Object get error {
+    final errorAndSt = _wrapper.latestErrorAndStackTrace;
+    if (errorAndSt != null) {
+      return errorAndSt.error;
+    }
+    throw MissingErrorError(hasValue);
+  }
+
+  @override
+  StackTrace? get stackTraceOrNull =>
+      _wrapper.latestErrorAndStackTrace?.stackTrace;
 
   @override
   BehaviorSubject<R> createForwardingSubject<R>({

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -136,9 +136,6 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   ValueStream<T> get stream => this;
 
   @override
-  ValueWrapper<T>? get valueWrapper => _wrapper.latestValue;
-
-  @override
   ErrorAndStackTrace? get errorAndStackTrace =>
       _wrapper.latestErrorAndStackTrace;
 
@@ -233,6 +230,27 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
       sync: true,
     );
   }
+
+  @override
+  bool get hasValue => _wrapper.latestValue != null;
+
+  @override
+  T get value {
+    final wrapper = _wrapper.latestValue;
+    if (wrapper != null) {
+      return wrapper.value;
+    }
+
+    final errorAndSt = _wrapper.latestErrorAndStackTrace;
+    if (errorAndSt != null) {
+      throw errorAndSt.error;
+    }
+
+    throw StateError('Neither data event nor error event has been emitted.');
+  }
+
+  @override
+  T? get valueOrNull => _wrapper.latestValue?.value;
 }
 
 class _Wrapper<T> {

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -139,7 +139,7 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   bool get hasValue => _wrapper.value != null;
 
   @override
-  T get value {
+  T get requireValue {
     final wrapper = _wrapper.value;
     if (wrapper != null) {
       return wrapper.value;
@@ -160,7 +160,7 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   Object? get errorOrNull => _wrapper.errorAndStackTrace?.error;
 
   @override
-  Object get error {
+  Object get requireError {
     final errorAndSt = _wrapper.errorAndStackTrace;
     if (errorAndSt != null) {
       return errorAndSt.error;

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -106,9 +106,8 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   static Stream<T> Function() _deferStream<T>(
           _Wrapper<T> wrapper, StreamController<T> controller, bool sync) =>
       () {
-        if (wrapper.latestErrorAndStackTrace != null) {
-          final errorAndStackTrace = wrapper.latestErrorAndStackTrace!;
-
+        final errorAndStackTrace = wrapper.errorAndStackTrace;
+        if (errorAndStackTrace != null && !wrapper.isValue) {
           return controller.stream.transform(
             StartWithErrorStreamTransformer(
               errorAndStackTrace.error,
@@ -117,9 +116,10 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
           );
         }
 
-        if (wrapper.latestValue != null) {
-          return controller.stream.transform(
-              StartWithStreamTransformer(wrapper.latestValue!.value));
+        final value = wrapper.value;
+        if (value != null && wrapper.isValue) {
+          return controller.stream
+              .transform(StartWithStreamTransformer(value.value));
         }
 
         return controller.stream;
@@ -136,41 +136,40 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   ValueStream<T> get stream => this;
 
   @override
-  bool get hasValue => _wrapper.latestValue != null;
+  bool get hasValue => _wrapper.value != null;
 
   @override
   T get value {
-    final wrapper = _wrapper.latestValue;
+    final wrapper = _wrapper.value;
     if (wrapper != null) {
       return wrapper.value;
     }
-    throw ValueIsMissingError(hasError);
+    throw ValueStreamError.hasNoValue();
   }
 
   @override
-  T? get valueOrNull => _wrapper.latestValue?.value;
+  T? get valueOrNull => _wrapper.value?.value;
 
   /// Set and emit the new value.
   set value(T newValue) => add(newValue);
 
   @override
-  bool get hasError => _wrapper.latestErrorAndStackTrace != null;
+  bool get hasError => _wrapper.errorAndStackTrace != null;
 
   @override
-  Object? get errorOrNull => _wrapper.latestErrorAndStackTrace?.error;
+  Object? get errorOrNull => _wrapper.errorAndStackTrace?.error;
 
   @override
   Object get error {
-    final errorAndSt = _wrapper.latestErrorAndStackTrace;
+    final errorAndSt = _wrapper.errorAndStackTrace;
     if (errorAndSt != null) {
       return errorAndSt.error;
     }
-    throw MissingErrorError(hasValue);
+    throw ValueStreamError.hasNoError();
   }
 
   @override
-  StackTrace? get stackTraceOrNull =>
-      _wrapper.latestErrorAndStackTrace?.stackTrace;
+  StackTrace? get stackTraceOrNull => _wrapper.errorAndStackTrace?.stackTrace;
 
   @override
   BehaviorSubject<R> createForwardingSubject<R>({
@@ -266,21 +265,24 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
 }
 
 class _Wrapper<T> {
-  ValueWrapper<T>? latestValue;
-  ErrorAndStackTrace? latestErrorAndStackTrace;
+  bool isValue;
+  ValueWrapper<T>? value;
+  ErrorAndStackTrace? errorAndStackTrace;
 
   /// Non-seeded constructor
-  _Wrapper();
+  _Wrapper() : isValue = false;
 
-  _Wrapper.seeded(T value) : latestValue = ValueWrapper(value);
+  _Wrapper.seeded(T value)
+      : value = ValueWrapper(value),
+        isValue = true;
 
   void setValue(T event) {
-    latestValue = ValueWrapper(event);
-    latestErrorAndStackTrace = null;
+    value = ValueWrapper(event);
+    isValue = true;
   }
 
-  void setError(Object error, [StackTrace? stackTrace]) {
-    latestValue = null;
-    latestErrorAndStackTrace = ErrorAndStackTrace(error, stackTrace);
+  void setError(Object error, StackTrace? stackTrace) {
+    errorAndStackTrace = ErrorAndStackTrace(error, stackTrace);
+    isValue = false;
   }
 }

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -156,6 +156,9 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   @override
   T? get valueOrNull => _wrapper.latestValue?.value;
 
+  /// Set and emit the new value.
+  set value(T newValue) => add(newValue);
+
   @override
   ErrorAndStackTrace? get errorAndStackTrace =>
       _wrapper.latestErrorAndStackTrace;

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -136,6 +136,27 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   ValueStream<T> get stream => this;
 
   @override
+  bool get hasValue => _wrapper.latestValue != null;
+
+  @override
+  T get value {
+    final wrapper = _wrapper.latestValue;
+    if (wrapper != null) {
+      return wrapper.value;
+    }
+
+    final errorAndSt = _wrapper.latestErrorAndStackTrace;
+    if (errorAndSt != null) {
+      throw errorAndSt.error;
+    }
+
+    throw StateError('Neither data event nor error event has been emitted.');
+  }
+
+  @override
+  T? get valueOrNull => _wrapper.latestValue?.value;
+
+  @override
   ErrorAndStackTrace? get errorAndStackTrace =>
       _wrapper.latestErrorAndStackTrace;
 
@@ -230,27 +251,6 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
       sync: true,
     );
   }
-
-  @override
-  bool get hasValue => _wrapper.latestValue != null;
-
-  @override
-  T get value {
-    final wrapper = _wrapper.latestValue;
-    if (wrapper != null) {
-      return wrapper.value;
-    }
-
-    final errorAndSt = _wrapper.latestErrorAndStackTrace;
-    if (errorAndSt != null) {
-      throw errorAndSt.error;
-    }
-
-    throw StateError('Neither data event nor error event has been emitted.');
-  }
-
-  @override
-  T? get valueOrNull => _wrapper.latestValue?.value;
 }
 
 class _Wrapper<T> {

--- a/lib/src/subjects/replay_subject.dart
+++ b/lib/src/subjects/replay_subject.dart
@@ -128,9 +128,15 @@ class ReplaySubject<T> extends Subject<T> implements ReplayStream<T> {
       .toList(growable: false);
 
   @override
-  List<ErrorAndStackTrace> get errorAndStackTraces => _queue
+  List<Object> get errors => _queue
       .where((event) => event.isError)
-      .map((event) => event.errorAndStackTrace!)
+      .map((event) => event.errorAndStackTrace!.error)
+      .toList(growable: false);
+
+  @override
+  List<StackTrace?> get stackTraces => _queue
+      .where((event) => event.isError)
+      .map((event) => event.errorAndStackTrace!.stackTrace)
       .toList(growable: false);
 
   @override

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -165,9 +165,11 @@ void main() {
       stream.listen(
         null,
         onError: expectAsync1((Object error) {
-          expect(stream.valueOrNull, isNull);
-          expect(stream.hasValue, isFalse);
+          expect(stream.valueOrNull, 3);
+          expect(stream.value, 3);
+          expect(stream.hasValue, isTrue);
 
+          expect(stream.errorOrNull, error);
           expect(stream.error, error);
           expect(stream.hasError, isTrue);
         }),

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -165,8 +165,9 @@ void main() {
       stream.listen(
         null,
         onError: expectAsync1((Object error) {
-          expect(stream.value, isNull);
+          expect(stream.valueOrNull, isNull);
           expect(stream.hasValue, isFalse);
+
           expect(stream.errorAndStackTrace?.error, error);
           expect(stream.hasError, isTrue);
         }),

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -164,12 +164,12 @@ void main() {
 
       stream.listen(
         null,
-        onError: (Object error) {
+        onError: expectAsync1((Object error) {
           expect(stream.value, isNull);
           expect(stream.hasValue, isFalse);
           expect(stream.errorAndStackTrace?.error, error);
           expect(stream.hasError, isTrue);
-        },
+        }),
       );
     });
 

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -226,7 +226,7 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await controller.close();
 
-        expect(isCanceled.future, completes);
+        await expectLater(isCanceled.future, completes);
       }
 
       {
@@ -242,7 +242,7 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await controller.close();
 
-        expect(isCanceled.future, completes);
+        await expectLater(isCanceled.future, completes);
       }
     });
   });

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -42,7 +42,7 @@ void main() {
 
       expect(stream, emitsInOrder(items));
       stream.listen(expectAsync1((i) {
-        expect(stream.value, items[count]);
+        expect(stream.requireValue, items[count]);
         count++;
       }, count: items.length));
     });
@@ -135,7 +135,7 @@ void main() {
     test('transform Stream with initial value', () async {
       final stream = Stream.fromIterable(const [1, 2, 3]).shareValueSeeded(0);
 
-      expect(stream.value, 0);
+      expect(stream.requireValue, 0);
       expect(stream, emitsInOrder(const <int>[0, 1, 2, 3]));
     });
 
@@ -148,7 +148,7 @@ void main() {
         expect(data, items[count]);
         count++;
         if (count == items.length) {
-          expect(stream.value, 3);
+          expect(stream.requireValue, 3);
         }
       }, count: items.length));
     });
@@ -166,11 +166,11 @@ void main() {
         null,
         onError: expectAsync1((Object error) {
           expect(stream.valueOrNull, 3);
-          expect(stream.value, 3);
+          expect(stream.requireValue, 3);
           expect(stream.hasValue, isTrue);
 
           expect(stream.errorOrNull, error);
-          expect(stream.error, error);
+          expect(stream.requireError, error);
           expect(stream.hasError, isTrue);
         }),
       );

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -168,7 +168,7 @@ void main() {
           expect(stream.valueOrNull, isNull);
           expect(stream.hasValue, isFalse);
 
-          expect(stream.errorAndStackTrace?.error, error);
+          expect(stream.error, error);
           expect(stream.hasError, isTrue);
         }),
       );

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -147,11 +147,11 @@ void main() {
       seeded.add(3);
       seeded.addError(exception);
 
-      expect(unseeded.value, 3);
+      expect(unseeded.requireValue, 3);
       expect(unseeded.valueOrNull, 3);
       expect(unseeded.hasValue, true);
 
-      expect(unseeded.error, exception);
+      expect(unseeded.requireError, exception);
       expect(unseeded.errorOrNull, exception);
       expect(unseeded.hasError, true);
 
@@ -159,11 +159,11 @@ void main() {
       await expectLater(unseeded, emitsError(exception));
       await expectLater(unseeded, emitsError(exception));
 
-      expect(seeded.value, 3);
+      expect(seeded.requireValue, 3);
       expect(seeded.valueOrNull, 3);
       expect(seeded.hasValue, true);
 
-      expect(seeded.error, exception);
+      expect(seeded.requireError, exception);
       expect(seeded.errorOrNull, exception);
       expect(seeded.hasError, true);
 
@@ -186,11 +186,11 @@ void main() {
       seeded.add(2);
       seeded.add(3);
 
-      expect(unseeded.value, 3);
+      expect(unseeded.requireValue, 3);
       expect(unseeded.valueOrNull, 3);
       expect(unseeded.hasValue, true);
 
-      expect(seeded.value, 3);
+      expect(seeded.requireValue, 3);
       expect(seeded.valueOrNull, 3);
       expect(seeded.hasValue, true);
     });
@@ -209,11 +209,11 @@ void main() {
       seeded.add(2);
       seeded.add(null);
 
-      expect(unseeded.value, isNull);
+      expect(unseeded.requireValue, isNull);
       expect(unseeded.valueOrNull, isNull);
       expect(unseeded.hasValue, true);
 
-      expect(seeded.value, isNull);
+      expect(seeded.requireValue, isNull);
       expect(seeded.valueOrNull, isNull);
       expect(seeded.hasValue, true);
     });
@@ -241,7 +241,7 @@ void main() {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>.seeded(1);
 
-      expect(subject.value, 1);
+      expect(subject.requireValue, 1);
       expect(subject.valueOrNull, 1);
       expect(subject.hasValue, true);
     });
@@ -250,7 +250,7 @@ void main() {
       // ignore: close_sinks
       final subject = BehaviorSubject<int?>.seeded(null);
 
-      expect(subject.value, null);
+      expect(subject.requireValue, null);
       expect(subject.valueOrNull, null);
       expect(subject.hasValue, true);
     });
@@ -259,7 +259,7 @@ void main() {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>();
 
-      expect(() => subject.value, throwsValueStreamError);
+      expect(() => subject.requireValue, throwsValueStreamError);
       expect(subject.valueOrNull, null);
       expect(subject.hasValue, false);
     });
@@ -347,7 +347,8 @@ void main() {
       final subject = BehaviorSubject<void>();
 
       unawaited(subject
-          .addStream(Stream<void>.error(Exception()), cancelOnError: true)
+          .addStream(Stream<void>.error(Exception()),
+              cancelOnError: true)
           .whenComplete(() => subject.add(1)));
 
       await expectLater(subject.stream,
@@ -510,7 +511,7 @@ void main() {
 
       subject.sink.add(1);
 
-      expect(subject.value, 1);
+      expect(subject.requireValue, 1);
 
       subject.sink.add(2);
       subject.sink.add(3);
@@ -526,7 +527,7 @@ void main() {
 
       subject.value = 1;
 
-      expect(subject.value, 1);
+      expect(subject.requireValue, 1);
 
       subject.value = 2;
       subject.value = 3;
@@ -631,7 +632,7 @@ void main() {
 
       expect(subject.hasError, isFalse);
       expect(subject.errorOrNull, isNull);
-      expect(() => subject.error, throwsValueStreamError);
+      expect(() => subject.requireError, throwsValueStreamError);
     });
 
     test('error returns null for a seeded subject with non-null seed', () {
@@ -640,7 +641,7 @@ void main() {
 
       expect(subject.hasError, isFalse);
       expect(subject.errorOrNull, isNull);
-      expect(() => subject.error, throwsValueStreamError);
+      expect(() => subject.requireError, throwsValueStreamError);
     });
 
     test('error returns null for a seeded subject with null seed', () {
@@ -649,7 +650,7 @@ void main() {
 
       expect(subject.hasError, isFalse);
       expect(subject.errorOrNull, isNull);
-      expect(() => subject.error, throwsValueStreamError);
+      expect(() => subject.requireError, throwsValueStreamError);
     });
 
     test('can synchronously get the latest error', () async {
@@ -663,24 +664,24 @@ void main() {
       unseeded.add(3);
       expect(unseeded.hasError, isFalse);
       expect(unseeded.errorOrNull, isNull);
-      expect(() => unseeded.error, throwsValueStreamError);
+      expect(() => unseeded.requireError, throwsValueStreamError);
 
       unseeded.addError(Exception('oh noes!'));
       expect(unseeded.hasError, isTrue);
       expect(unseeded.errorOrNull, isException);
-      expect(unseeded.error, isException);
+      expect(unseeded.requireError, isException);
 
       seeded.add(1);
       seeded.add(2);
       seeded.add(3);
       expect(seeded.hasError, isFalse);
       expect(seeded.errorOrNull, isNull);
-      expect(() => seeded.error, throwsValueStreamError);
+      expect(() => seeded.requireError, throwsValueStreamError);
 
       seeded.addError(Exception('oh noes!'));
       expect(seeded.hasError, isTrue);
       expect(seeded.errorOrNull, isException);
-      expect(seeded.error, isException);
+      expect(seeded.requireError, isException);
     });
 
     test('emits event after error to every subscriber', () async {
@@ -694,22 +695,22 @@ void main() {
       unseeded.addError(Exception('oh noes!'));
       expect(unseeded.hasError, isTrue);
       expect(unseeded.errorOrNull, isException);
-      expect(unseeded.error, isException);
+      expect(unseeded.requireError, isException);
       unseeded.add(3);
       expect(unseeded.hasError, isTrue);
       expect(unseeded.errorOrNull, isException);
-      expect(unseeded.error, isException);
+      expect(unseeded.requireError, isException);
 
       seeded.add(1);
       seeded.add(2);
       seeded.addError(Exception('oh noes!'));
       expect(seeded.hasError, isTrue);
       expect(seeded.errorOrNull, isException);
-      expect(seeded.error, isException);
+      expect(seeded.requireError, isException);
       seeded.add(3);
       expect(seeded.hasError, isTrue);
       expect(seeded.errorOrNull, isException);
-      expect(seeded.error, isException);
+      expect(seeded.requireError, isException);
     });
 
     test(
@@ -735,7 +736,7 @@ void main() {
 
       mappedStream.listen(null);
 
-      expect(mappedStream.value, equals(1));
+      expect(mappedStream.requireValue, equals(1));
 
       await subject.close();
     }, skip: true);
@@ -748,7 +749,7 @@ void main() {
 
       subject.add(2);
 
-      expect(mappedStream.value, equals(2));
+      expect(mappedStream.requireValue, equals(2));
 
       await subject.close();
     });
@@ -758,9 +759,9 @@ void main() {
       final mappedStream = subject.map((event) => event).shareValue();
 
       mappedStream.listen(null,
-          onDone: () => expect(mappedStream.value, equals(1)));
+          onDone: () => expect(mappedStream.requireValue, equals(1)));
 
-      expect(() => mappedStream.value, throwsValueStreamError);
+      expect(() => mappedStream.requireValue, throwsValueStreamError);
       expect(mappedStream.valueOrNull, isNull);
       expect(mappedStream.hasValue, false);
 
@@ -772,11 +773,11 @@ void main() {
       final mappedStream = subject.map((event) => event).shareValue();
 
       mappedStream.listen(null,
-          onDone: () => expect(mappedStream.value, equals(2)));
+          onDone: () => expect(mappedStream.requireValue, equals(2)));
 
       subject.add(2);
 
-      expect(() => mappedStream.value, throwsValueStreamError);
+      expect(() => mappedStream.requireValue, throwsValueStreamError);
       expect(mappedStream.valueOrNull, isNull);
       expect(mappedStream.hasValue, false);
 
@@ -873,8 +874,8 @@ void main() {
         {
           var behaviorSubject = BehaviorSubject.seeded(1);
 
-          var mapped =
-              behaviorSubject.asyncMap((event) => Future.value(event + 1));
+          var mapped = behaviorSubject
+              .asyncMap((event) => Future.value(event + 1));
           expect(mapped, emitsInOrder(<int>[2, 3]));
 
           behaviorSubject.add(2);
@@ -883,8 +884,8 @@ void main() {
         {
           var behaviorSubject = BehaviorSubject<int>();
 
-          var mapped =
-              behaviorSubject.asyncMap((event) => Future.value(event + 1));
+          var mapped = behaviorSubject
+              .asyncMap((event) => Future.value(event + 1));
           expect(mapped, emitsInOrder(<int>[2, 3]));
 
           behaviorSubject.add(1);

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -518,7 +518,7 @@ void main() {
       await expectLater(subject.stream, emits(3));
     });
 
-    test('setter has same behavior as adding to Subject', () async {
+    test('setter `value=` has same behavior as adding to Subject', () async {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>();
 

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -5,6 +5,8 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final throwsValueStreamError = throwsA(isA<ValueStreamError>());
+
   group('BehaviorSubject', () {
     test('emits the most recently emitted item to every subscriber', () async {
       // ignore: close_sinks
@@ -128,7 +130,7 @@ void main() {
       await expectLater(seeded.stream, emits(3));
     });
 
-    test('emits errors to every subscriber, ensures value is null', () async {
+    test('emits errors to every subscriber', () async {
       // ignore: close_sinks
       final unseeded = BehaviorSubject<int?>(),
           // ignore: close_sinks
@@ -145,9 +147,9 @@ void main() {
       seeded.add(3);
       seeded.addError(exception);
 
-      expect(() => unseeded.value, throwsA(exception));
-      expect(unseeded.valueOrNull, isNull);
-      expect(unseeded.hasValue, false);
+      expect(unseeded.value, 3);
+      expect(unseeded.valueOrNull, 3);
+      expect(unseeded.hasValue, true);
 
       expect(unseeded.error, exception);
       expect(unseeded.errorOrNull, exception);
@@ -157,9 +159,9 @@ void main() {
       await expectLater(unseeded, emitsError(exception));
       await expectLater(unseeded, emitsError(exception));
 
-      expect(() => seeded.value, throwsA(exception));
-      expect(seeded.valueOrNull, isNull);
-      expect(seeded.hasValue, false);
+      expect(seeded.value, 3);
+      expect(seeded.valueOrNull, 3);
+      expect(seeded.hasValue, true);
 
       expect(seeded.error, exception);
       expect(seeded.errorOrNull, exception);
@@ -257,7 +259,7 @@ void main() {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>();
 
-      expect(() => subject.value, throwsStateError);
+      expect(() => subject.value, throwsValueStreamError);
       expect(subject.valueOrNull, null);
       expect(subject.hasValue, false);
     });
@@ -627,27 +629,27 @@ void main() {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>();
 
-      expect(subject.errorAndStackTrace?.error, isNull);
+      expect(subject.hasError, isFalse);
       expect(subject.errorOrNull, isNull);
-      expect(() => subject.error, throwsStateError);
+      expect(() => subject.error, throwsValueStreamError);
     });
 
     test('error returns null for a seeded subject with non-null seed', () {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>.seeded(1);
 
-      expect(subject.errorAndStackTrace?.error, isNull);
+      expect(subject.hasError, isFalse);
       expect(subject.errorOrNull, isNull);
-      expect(() => subject.error, throwsStateError);
+      expect(() => subject.error, throwsValueStreamError);
     });
 
     test('error returns null for a seeded subject with null seed', () {
       // ignore: close_sinks
       final subject = BehaviorSubject<int?>.seeded(null);
 
-      expect(subject.errorAndStackTrace?.error, isNull);
+      expect(subject.hasError, isFalse);
       expect(subject.errorOrNull, isNull);
-      expect(() => subject.error, throwsStateError);
+      expect(() => subject.error, throwsValueStreamError);
     });
 
     test('can synchronously get the latest error', () async {
@@ -659,28 +661,29 @@ void main() {
       unseeded.add(1);
       unseeded.add(2);
       unseeded.add(3);
-      expect(unseeded.errorAndStackTrace?.error, isNull);
+      expect(unseeded.hasError, isFalse);
       expect(unseeded.errorOrNull, isNull);
-      expect(() => unseeded.error, throwsStateError);
+      expect(() => unseeded.error, throwsValueStreamError);
+
       unseeded.addError(Exception('oh noes!'));
-      expect(unseeded.errorAndStackTrace?.error, isException);
+      expect(unseeded.hasError, isTrue);
       expect(unseeded.errorOrNull, isException);
       expect(unseeded.error, isException);
 
       seeded.add(1);
       seeded.add(2);
       seeded.add(3);
-      expect(seeded.errorAndStackTrace?.error, isNull);
+      expect(seeded.hasError, isFalse);
       expect(seeded.errorOrNull, isNull);
-      expect(() => seeded.error, throwsStateError);
+      expect(() => seeded.error, throwsValueStreamError);
+
       seeded.addError(Exception('oh noes!'));
-      expect(seeded.errorAndStackTrace?.error, isException);
+      expect(seeded.hasError, isTrue);
       expect(seeded.errorOrNull, isException);
       expect(seeded.error, isException);
     });
 
-    test('emits event after error to every subscriber, ensures error is null',
-        () async {
+    test('emits event after error to every subscriber', () async {
       // ignore: close_sinks
       final unseeded = BehaviorSubject<int>(),
           // ignore: close_sinks
@@ -689,24 +692,24 @@ void main() {
       unseeded.add(1);
       unseeded.add(2);
       unseeded.addError(Exception('oh noes!'));
-      expect(unseeded.errorAndStackTrace?.error, isException);
+      expect(unseeded.hasError, isTrue);
       expect(unseeded.errorOrNull, isException);
       expect(unseeded.error, isException);
       unseeded.add(3);
-      expect(unseeded.errorAndStackTrace?.error, isNull);
-      expect(unseeded.errorOrNull, isNull);
-      expect(() => unseeded.error, throwsStateError);
+      expect(unseeded.hasError, isTrue);
+      expect(unseeded.errorOrNull, isException);
+      expect(unseeded.error, isException);
 
       seeded.add(1);
       seeded.add(2);
       seeded.addError(Exception('oh noes!'));
-      expect(seeded.errorAndStackTrace?.error, isException);
+      expect(seeded.hasError, isTrue);
       expect(seeded.errorOrNull, isException);
       expect(seeded.error, isException);
       seeded.add(3);
-      expect(seeded.errorAndStackTrace?.error, isNull);
-      expect(seeded.errorOrNull, isNull);
-      expect(() => seeded.error, throwsStateError);
+      expect(seeded.hasError, isTrue);
+      expect(seeded.errorOrNull, isException);
+      expect(seeded.error, isException);
     });
 
     test(
@@ -757,7 +760,7 @@ void main() {
       mappedStream.listen(null,
           onDone: () => expect(mappedStream.value, equals(1)));
 
-      expect(() => mappedStream.value, throwsStateError);
+      expect(() => mappedStream.value, throwsValueStreamError);
       expect(mappedStream.valueOrNull, isNull);
       expect(mappedStream.hasValue, false);
 
@@ -773,7 +776,7 @@ void main() {
 
       subject.add(2);
 
-      expect(() => mappedStream.value, throwsStateError);
+      expect(() => mappedStream.value, throwsValueStreamError);
       expect(mappedStream.valueOrNull, isNull);
       expect(mappedStream.hasValue, false);
 

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -518,6 +518,22 @@ void main() {
       await expectLater(subject.stream, emits(3));
     });
 
+    test('setter has same behavior as adding to Subject', () async {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>();
+
+      subject.value = 1;
+
+      expect(subject.value, 1);
+
+      subject.value = 2;
+      subject.value = 3;
+
+      await expectLater(subject.stream, emits(3));
+      await expectLater(subject.stream, emits(3));
+      await expectLater(subject.stream, emits(3));
+    });
+
     test('is always treated as a broadcast Stream', () async {
       // ignore: close_sinks
       final subject = BehaviorSubject<int>();

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -156,6 +156,18 @@ void main() {
       await expectLater(unseeded, emitsError(exception));
       await expectLater(unseeded, emitsError(exception));
       await expectLater(unseeded, emitsError(exception));
+
+      expect(() => seeded.value, throwsA(exception));
+      expect(seeded.valueOrNull, isNull);
+      expect(seeded.hasValue, false);
+
+      expect(seeded.error, exception);
+      expect(seeded.errorOrNull, exception);
+      expect(seeded.hasError, true);
+
+      await expectLater(seeded, emitsError(exception));
+      await expectLater(seeded, emitsError(exception));
+      await expectLater(seeded, emitsError(exception));
     });
 
     test('can synchronously get the latest value', () {

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -386,7 +386,7 @@ void main() {
 
       mappedStream.listen(null);
 
-      expect(mappedStream.value, equals(1));
+      expect(mappedStream.requireValue, equals(1));
 
       await subject.close();
     }, skip: true);
@@ -399,7 +399,7 @@ void main() {
 
       subject.add(2);
 
-      expect(mappedStream.value, equals(2));
+      expect(mappedStream.requireValue, equals(2));
 
       await subject.close();
     });
@@ -409,7 +409,7 @@ void main() {
       final mappedStream = subject.map((event) => event).shareValue();
 
       mappedStream.listen(null,
-          onDone: () => expect(mappedStream.value, equals(1)));
+          onDone: () => expect(mappedStream.requireValue, equals(1)));
 
       expect(mappedStream.valueOrNull, isNull);
 
@@ -421,7 +421,7 @@ void main() {
       final mappedStream = subject.map((event) => event).shareValue();
 
       mappedStream.listen(null,
-          onDone: () => expect(mappedStream.value, equals(2)));
+          onDone: () => expect(mappedStream.requireValue, equals(2)));
 
       subject.add(2);
 

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -406,7 +406,7 @@ void main() {
       mappedStream.listen(null,
           onDone: () => expect(mappedStream.value, equals(1)));
 
-      expect(mappedStream.value, equals(isNull));
+      expect(mappedStream.valueOrNull, isNull);
 
       await subject.close();
     });
@@ -420,7 +420,7 @@ void main() {
 
       subject.add(2);
 
-      expect(mappedStream.value, equals(isNull));
+      expect(mappedStream.valueOrNull, isNull);
 
       await subject.close();
     });

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -135,17 +135,22 @@ void main() {
       await expectLater(subject.values, const <int>[1, 2, 3]);
     });
 
-    test('synchronously get the previous errors', () async {
+    test('synchronously get the previous errors', () {
       final subject = ReplaySubject<int>();
       final e1 = Exception(), e2 = Exception(), e3 = Exception();
+      final stackTrace = StackTrace.fromString('#');
 
       subject.addError(e1);
-      subject.addError(e2);
+      subject.addError(e2, stackTrace);
       subject.addError(e3);
 
-      await expectLater(
-        subject.errorAndStackTraces.map((es) => es.error),
+      expect(
+        subject.errors,
         containsAllInOrder(<Exception>[e1, e2, e3]),
+      );
+      expect(
+        subject.stackTraces,
+        containsAllInOrder(<StackTrace?>[null, stackTrace, null]),
       );
     });
 


### PR DESCRIPTION
Fixes #556 
- #559 ValueStream
  - `ValueWrapper` -> `[requireValue, valueOrNull, hasValue]`.
  - `errorAndStackTraces` -> [`requireError`, `errorOrNull`, `stackTraceOrNull`].
- ReplayStream: `errorAndStackTraces` -> [`errors`, `stackTraces`].
- Keep `ValueWrapper` as internal implementation (to able to keep `null` as the latest value when `T` is nullable type).