### PR TITLE
scan: change `seed` to required param.

### DIFF
--- a/lib/src/transformers/scan.dart
+++ b/lib/src/transformers/scan.dart
@@ -20,7 +20,7 @@ class _ScanStreamSink<S, T> implements EventSink<S> {
 }
 
 /// Applies an accumulator function over an stream sequence and returns
-/// each intermediate result. The optional seed value is used as the initial
+/// each intermediate result. The seed value is used as the initial
 /// accumulator value.
 ///
 /// ### Example
@@ -37,7 +37,7 @@ class ScanStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
 
   /// Constructs a [ScanStreamTransformer] which applies an accumulator Function
   /// over the source [Stream] and returns each intermediate result.
-  /// The optional seed value is used as the initial accumulator value.
+  /// The seed value is used as the initial accumulator value.
   ScanStreamTransformer(this.accumulator, this.seed);
 
   @override
@@ -48,7 +48,7 @@ class ScanStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
 /// Extends
 extension ScanExtension<T> on Stream<T> {
   /// Applies an accumulator function over a Stream sequence and returns each
-  /// intermediate result. The optional seed value is used as the initial
+  /// intermediate result. The seed value is used as the initial
   /// accumulator value.
   ///
   /// ### Example

--- a/lib/src/transformers/scan.dart
+++ b/lib/src/transformers/scan.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
 class _ScanStreamSink<S, T> implements EventSink<S> {
-  final T Function(T? accumulated, S value, int index) _accumulator;
+  final T Function(T accumulated, S value, int index) _accumulator;
   final EventSink<T> _outputSink;
-  T? _acc;
+  T _acc;
   var _index = 0;
 
-  _ScanStreamSink(this._outputSink, this._accumulator, [T? seed]) : _acc = seed;
+  _ScanStreamSink(this._outputSink, this._accumulator, this._acc);
 
   @override
   void add(S data) =>
@@ -30,15 +30,15 @@ class _ScanStreamSink<S, T> implements EventSink<S> {
 ///        .listen(print); // prints 1, 3, 6
 class ScanStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
   /// Method which accumulates incoming event into a single, accumulated object
-  final T Function(T? accumulated, S value, int index) accumulator;
+  final T Function(T accumulated, S value, int index) accumulator;
 
   /// The initial value for the accumulated value in the [accumulator]
-  final T? seed;
+  final T seed;
 
   /// Constructs a [ScanStreamTransformer] which applies an accumulator Function
   /// over the source [Stream] and returns each intermediate result.
   /// The optional seed value is used as the initial accumulator value.
-  ScanStreamTransformer(this.accumulator, [this.seed]);
+  ScanStreamTransformer(this.accumulator, this.seed);
 
   @override
   Stream<T> bind(Stream<S> stream) => Stream.eventTransformed(
@@ -57,8 +57,6 @@ extension ScanExtension<T> on Stream<T> {
   ///        .scan((acc, curr, i) => acc + curr, 0)
   ///        .listen(print); // prints 1, 3, 6
   Stream<S> scan<S>(
-    S Function(S? accumulated, T value, int index) accumulator, [
-    S? seed,
-  ]) =>
+          S Function(S accumulated, T value, int index) accumulator, S seed) =>
       transform(ScanStreamTransformer<T, S>(accumulator, seed));
 }

--- a/test/transformers/scan_test.dart
+++ b/test/transformers/scan_test.dart
@@ -9,15 +9,24 @@ void main() {
     var count = 0;
 
     Stream.fromIterable(const [1, 2, 3, 4])
-        .scan((int? acc, int value, int index) => (acc ?? 0) + value)
+        .scan<int>((acc, value, index) => acc + value, 0)
         .listen(expectAsync1((result) {
           expect(expectedOutput[count++], result);
         }, count: expectedOutput.length));
   });
 
+  test('Rx.scan.nullable', () {
+    expect(
+      Stream.fromIterable(const [1, 2, 3, 4])
+          .scan<int?>((acc, value, index) => (acc ?? 0) + value, null)
+          .cast<int>(),
+      emitsInOrder(<int>[1, 3, 6, 10]),
+    );
+  });
+
   test('Rx.scan.reusable', () async {
-    final transformer = ScanStreamTransformer<int, int>(
-        (int? acc, int value, int index) => (acc ?? 0) + value);
+    final transformer =
+        ScanStreamTransformer<int, int>((acc, value, index) => acc + value, 0);
     const expectedOutput = [1, 3, 6, 10];
     var countA = 0, countB = 0;
 
@@ -37,7 +46,7 @@ void main() {
   test('Rx.scan.asBroadcastStream', () async {
     final stream = Stream.fromIterable(const [1, 2, 3, 4])
         .asBroadcastStream()
-        .scan((int? acc, int value, int index) => (acc ?? 0) + value, 0);
+        .scan<int>((acc, value, index) => acc + value, 0);
 
     // listen twice on same stream
     stream.listen(null);
@@ -48,9 +57,7 @@ void main() {
 
   test('Rx.scan.error.shouldThrow', () async {
     final streamWithError = Stream.fromIterable(const [1, 2, 3, 4])
-        .scan((num? acc, num value, int index) {
-      throw StateError('oh noes!');
-    });
+        .scan((acc, value, index) => throw StateError('oh noes!'), 0);
 
     streamWithError.listen(null,
         onError: expectAsync2((StateError e, StackTrace s) {
@@ -61,8 +68,8 @@ void main() {
   test('Rx.scan accidental broadcast', () async {
     final controller = StreamController<int>();
 
-    final stream = controller.stream
-        .scan((int? acc, int value, int index) => (acc ?? 0) + value);
+    final stream =
+        controller.stream.scan<int>((acc, value, index) => acc + value, 0);
 
     stream.listen(null);
     expect(() => stream.listen(null), throwsStateError);


### PR DESCRIPTION
- Make it clearer in null-safety mode.
```dart
Stream.fromIterable(1, 2, 3).scan<int>((acc, e, i) => acc! + e, 0); // <- unnecessary null assertion `! '.
```
- To achieve old behavior, uses `scan<T?>().cast<T>()`
```dart
Stream.fromIterable(const [1, 2, 3, 4])
          .scan<int?>((acc, value, index) => (acc ?? 0) + value, null)
          .cast<int>()
```