### PR TITLE
`Connectable`: remove unnecessary `asBroadcastStream`

### DIFF
--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -49,11 +49,7 @@ class PublishConnectableStream<T> extends ConnectableStream<T> {
     return PublishConnectableStream<T>._(source, PublishSubject<T>(sync: sync));
   }
 
-  PublishConnectableStream._(Stream<T> source, this._subject)
-      : _source = source.isBroadcast
-            ? source
-            : source.asBroadcastStream(onCancel: (s) => s.cancel()),
-        super(_subject);
+  PublishConnectableStream._(this._source, this._subject) : super(_subject);
 
   ConnectableStreamSubscription<T> _connect() =>
       ConnectableStreamSubscription<T>(
@@ -103,11 +99,7 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   final Stream<T> _source;
   final BehaviorSubject<T> _subject;
 
-  ValueConnectableStream._(Stream<T> source, this._subject)
-      : _source = source.isBroadcast
-            ? source
-            : source.asBroadcastStream(onCancel: (s) => s.cancel()),
-        super(_subject);
+  ValueConnectableStream._(this._source, this._subject) : super(_subject);
 
   /// Constructs a [Stream] which only begins emitting events when
   /// the [connect] method is called, this [Stream] acts like a
@@ -208,11 +200,7 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
     );
   }
 
-  ReplayConnectableStream._(Stream<T> source, this._subject)
-      : _source = source.isBroadcast
-            ? source
-            : source.asBroadcastStream(onCancel: (s) => s.cancel()),
-        super(_subject);
+  ReplayConnectableStream._(this._source, this._subject) : super(_subject);
 
   ConnectableStreamSubscription<T> _connect() =>
       ConnectableStreamSubscription<T>(


### PR DESCRIPTION
`source.asBroadcastStream(onCancel: (s) => s.cancel())` is same as `share()`, convert to broadcast stream twice is unnecessary.