### PR TITLE
`Connectable`: remove unnecessary `asBroadcastStream`

### DIFF
--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -51,22 +51,21 @@ class PublishConnectableStream<T> extends ConnectableStream<T> {
 
   PublishConnectableStream._(this._source, this._subject) : super(_subject);
 
-  ConnectableStreamSubscription<T> _connect() =>
-      ConnectableStreamSubscription<T>(
-        _source.listen(
-          _subject.add,
-          onError: _subject.addError,
-          onDone: _subject.close,
-        ),
-        _subject,
-      );
+  late final _connection = ConnectableStreamSubscription<T>(
+    _source.listen(
+      _subject.add,
+      onError: _subject.addError,
+      onDone: _subject.close,
+    ),
+    _subject,
+  );
 
   @override
   Stream<T> autoConnect({
     void Function(StreamSubscription<T> subscription)? connection,
   }) {
     _subject.onListen = () {
-      final subscription = _connect();
+      final subscription = _connection;
       connection?.call(subscription);
     };
     _subject.onCancel = null;
@@ -77,15 +76,15 @@ class PublishConnectableStream<T> extends ConnectableStream<T> {
   @override
   StreamSubscription<T> connect() {
     _subject.onListen = _subject.onCancel = null;
-    return _connect();
+    return _connection;
   }
 
   @override
   Stream<T> refCount() {
-    late ConnectableStreamSubscription<T> subscription;
+    ConnectableStreamSubscription<T>? subscription;
 
-    _subject.onListen = () => subscription = _connect();
-    _subject.onCancel = () => subscription.cancel();
+    _subject.onListen = () => subscription = _connection;
+    _subject.onCancel = () => subscription?.cancel();
 
     return _subject;
   }
@@ -120,22 +119,21 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
         BehaviorSubject<T>.seeded(seedValue, sync: sync),
       );
 
-  ConnectableStreamSubscription<T> _connect() =>
-      ConnectableStreamSubscription<T>(
-        _source.listen(
-          _subject.add,
-          onError: _subject.addError,
-          onDone: _subject.close,
-        ),
-        _subject,
-      );
+  late final _connection = ConnectableStreamSubscription<T>(
+    _source.listen(
+      _subject.add,
+      onError: _subject.addError,
+      onDone: _subject.close,
+    ),
+    _subject,
+  );
 
   @override
   ValueStream<T> autoConnect({
     void Function(StreamSubscription<T> subscription)? connection,
   }) {
     _subject.onListen = () {
-      final subscription = _connect();
+      final subscription = _connection;
       connection?.call(subscription);
     };
     _subject.onCancel = null;
@@ -146,15 +144,15 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   @override
   StreamSubscription<T> connect() {
     _subject.onListen = _subject.onCancel = null;
-    return _connect();
+    return _connection;
   }
 
   @override
   ValueStream<T> refCount() {
-    late ConnectableStreamSubscription<T> subscription;
+    StreamSubscription<T>? subscription;
 
-    _subject.onListen = () => subscription = _connect();
-    _subject.onCancel = () => subscription.cancel();
+    _subject.onListen = () => subscription = _connection;
+    _subject.onCancel = () => subscription?.cancel();
 
     return _subject;
   }
@@ -202,22 +200,21 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
 
   ReplayConnectableStream._(this._source, this._subject) : super(_subject);
 
-  ConnectableStreamSubscription<T> _connect() =>
-      ConnectableStreamSubscription<T>(
-        _source.listen(
-          _subject.add,
-          onError: _subject.addError,
-          onDone: _subject.close,
-        ),
-        _subject,
-      );
+  late final _connection = ConnectableStreamSubscription<T>(
+    _source.listen(
+      _subject.add,
+      onError: _subject.addError,
+      onDone: _subject.close,
+    ),
+    _subject,
+  );
 
   @override
   ReplayStream<T> autoConnect({
     void Function(StreamSubscription<T> subscription)? connection,
   }) {
     _subject.onListen = () {
-      final subscription = _connect();
+      final subscription = _connection;
       connection?.call(subscription);
     };
     _subject.onCancel = null;
@@ -228,15 +225,15 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
   @override
   StreamSubscription<T> connect() {
     _subject.onListen = _subject.onCancel = null;
-    return _connect();
+    return _connection;
   }
 
   @override
   ReplayStream<T> refCount() {
-    late ConnectableStreamSubscription<T> subscription;
+    ConnectableStreamSubscription<T>? subscription;
 
-    _subject.onListen = () => subscription = _connect();
-    _subject.onCancel = () => subscription.cancel();
+    _subject.onListen = () => subscription = _connection;
+    _subject.onCancel = () => subscription?.cancel();
 
     return _subject;
   }

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -49,11 +49,7 @@ class PublishConnectableStream<T> extends ConnectableStream<T> {
     return PublishConnectableStream<T>._(source, PublishSubject<T>(sync: sync));
   }
 
-  PublishConnectableStream._(Stream<T> source, this._subject)
-      : _source = source.isBroadcast
-            ? source
-            : source.asBroadcastStream(onCancel: (s) => s.cancel()),
-        super(_subject);
+  PublishConnectableStream._(this._source, this._subject) : super(_subject);
 
   ConnectableStreamSubscription<T> _connect() =>
       ConnectableStreamSubscription<T>(
@@ -103,11 +99,7 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   final Stream<T> _source;
   final BehaviorSubject<T> _subject;
 
-  ValueConnectableStream._(Stream<T> source, this._subject)
-      : _source = source.isBroadcast
-            ? source
-            : source.asBroadcastStream(onCancel: (s) => s.cancel()),
-        super(_subject);
+  ValueConnectableStream._(this._source, this._subject) : super(_subject);
 
   /// Constructs a [Stream] which only begins emitting events when
   /// the [connect] method is called, this [Stream] acts like a
@@ -208,11 +200,7 @@ class ReplayConnectableStream<T> extends ConnectableStream<T>
     );
   }
 
-  ReplayConnectableStream._(Stream<T> source, this._subject)
-      : _source = source.isBroadcast
-            ? source
-            : source.asBroadcastStream(onCancel: (s) => s.cancel()),
-        super(_subject);
+  ReplayConnectableStream._(this._source, this._subject) : super(_subject);
 
   ConnectableStreamSubscription<T> _connect() =>
       ConnectableStreamSubscription<T>(

--- a/lib/src/subjects/subject.dart
+++ b/lib/src/subjects/subject.dart
@@ -55,7 +55,7 @@ abstract class Subject<T> extends StreamView<T> implements StreamController<T> {
   ControllerCancelCallback? get onCancel => _controller.onCancel;
 
   @override
-  set onCancel(void Function()? onCancelHandler) {
+  set onCancel(ControllerCancelCallback? onCancelHandler) {
     _controller.onCancel = onCancelHandler;
   }
 


### PR DESCRIPTION
Just cache `ConnectableStreamSubscription`, `source` will only be listened once