### PR TITLE
`ValueStream` contains only value, error and stackTrace

### DIFF
--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -158,22 +158,10 @@ class ValueConnectableStream<T> extends ConnectableStream<T>
   }
 
   @override
-  bool get hasValue => _subject.hasValue;
-
-  @override
   T get value => _subject.value;
 
   @override
-  T? get valueOrNull => _subject.valueOrNull;
-
-  @override
   Object get error => _subject.error;
-
-  @override
-  Object? get errorOrNull => _subject.errorOrNull;
-
-  @override
-  bool get hasError => _subject.hasError;
 
   @override
   StackTrace? get stackTrace => _subject.stackTrace;

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -6,26 +6,55 @@ abstract class ValueStream<T> implements Stream<T> {
   /// Throws [ValueStreamError] if this Stream has no value.
   T get value;
 
-  /// Returns either [value], or `null`, should [value] not yet have been set.
-  T? get valueOrNull;
-
-  /// Returns `true` when [value] is available.
-  bool get hasValue;
-
   /// Returns last emitted error, failing if there is no error.
   ///
   /// Throws [ValueStreamError] if this Stream has no error.
   Object get error;
 
-  /// Last emitted error, or `null` if no error added.
-  Object? get errorOrNull;
-
-  /// Returns `true` when [error] is available.
-  bool get hasError;
-
   /// Returns [StackTrace] of the last emitted error,
   /// or `null` if no error added or the added error has no [StackTrace].
   StackTrace? get stackTrace;
+}
+
+/// Extensions to easily access value and error.
+extension ValueStreamExtensions<T> on ValueStream<T> {
+  /// Returns either [value], or `null`, should [value] not yet have been set.
+  T? get valueOrNull {
+    try {
+      return value;
+    } on ValueStreamError {
+      return null;
+    }
+  }
+
+  /// Returns `true` when [value] is available.
+  bool get hasValue {
+    try {
+      value;
+      return true;
+    } on ValueStreamError {
+      return false;
+    }
+  }
+
+  /// Last emitted error, or `null` if no error added.
+  Object? get errorOrNull {
+    try {
+      return error;
+    } on ValueStreamError {
+      return null;
+    }
+  }
+
+  /// Returns `true` when [error] is available.
+  bool get hasError {
+    try {
+      error;
+      return true;
+    } on ValueStreamError {
+      return false;
+    }
+  }
 }
 
 enum _MissingCase {

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -136,9 +136,6 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   ValueStream<T> get stream => this;
 
   @override
-  bool get hasValue => _wrapper.value != null;
-
-  @override
   T get value {
     final wrapper = _wrapper.value;
     if (wrapper != null) {
@@ -147,17 +144,8 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
     throw ValueStreamError.hasNoValue();
   }
 
-  @override
-  T? get valueOrNull => _wrapper.value?.value;
-
   /// Set and emit the new value.
   set value(T newValue) => add(newValue);
-
-  @override
-  bool get hasError => _wrapper.errorAndStackTrace != null;
-
-  @override
-  Object? get errorOrNull => _wrapper.errorAndStackTrace?.error;
 
   @override
   Object get error {


### PR DESCRIPTION
#556 
```dart
/// An [Stream] that provides synchronous access to the last emitted item
abstract class ValueStream<T> implements Stream<T> {
  /// Returns the last emitted value, failing if there is no value.
  /// See [hasValue] to determine whether [value] has already been set.
  ///
  /// Throws [ValueStreamError] if this Stream has no value.
  T get value;

  /// Returns last emitted error, failing if there is no error.
  ///
  /// Throws [ValueStreamError] if this Stream has no error.
  Object get error;

  /// Returns [StackTrace] of the last emitted error,
  /// or `null` if no error added or the added error has no [StackTrace].
  StackTrace? get stackTrace;
}
```