### PR TITLE
Change behavior in forward stream

### DIFF
--- a/lib/src/transformers/backpressure/backpressure.dart
+++ b/lib/src/transformers/backpressure/backpressure.dart
@@ -352,7 +352,7 @@ class BackpressureStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
       dispatchOnClose,
       maxLengthQueue,
     );
-    return forwardStream(stream, sink);
+    return ForwardingStream(stream, sink);
   }
 }
 

--- a/lib/src/transformers/delay.dart
+++ b/lib/src/transformers/delay.dart
@@ -80,7 +80,7 @@ class DelayStreamTransformer<S> extends StreamTransformerBase<S, S> {
 
   @override
   Stream<S> bind(Stream<S> stream) =>
-      forwardStream(stream, _DelayStreamSink<S>(duration));
+      ForwardingStream(stream, _DelayStreamSink<S>(duration));
 }
 
 /// Extends the Stream class with the ability to delay events being emitted

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -169,7 +169,7 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
   }
 
   @override
-  Stream<S> bind(Stream<S> stream) => forwardStream<S, S>(
+  Stream<S> bind(Stream<S> stream) => ForwardingStream<S, S>(
         stream,
         _DoStreamSink<S>(
           onCancel,

--- a/lib/src/transformers/exhaust_map.dart
+++ b/lib/src/transformers/exhaust_map.dart
@@ -83,7 +83,7 @@ class ExhaustMapStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
 
   @override
   Stream<T> bind(Stream<S> stream) =>
-      forwardStream(stream, _ExhaustMapStreamSink(mapper));
+      ForwardingStream(stream, _ExhaustMapStreamSink(mapper));
 }
 
 /// Extends the Stream class with the ability to transform the Stream into

--- a/lib/src/transformers/flat_map.dart
+++ b/lib/src/transformers/flat_map.dart
@@ -87,7 +87,7 @@ class FlatMapStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
 
   @override
   Stream<T> bind(Stream<S> stream) =>
-      forwardStream(stream, _FlatMapStreamSink(mapper));
+      ForwardingStream(stream, _FlatMapStreamSink(mapper));
 }
 
 /// Extends the Stream class with the ability to convert the source Stream into

--- a/lib/src/transformers/on_error_resume.dart
+++ b/lib/src/transformers/on_error_resume.dart
@@ -91,7 +91,7 @@ class OnErrorResumeStreamTransformer<S> extends StreamTransformerBase<S, S> {
   OnErrorResumeStreamTransformer(this.recoveryFn);
 
   @override
-  Stream<S> bind(Stream<S> stream) => forwardStream(
+  Stream<S> bind(Stream<S> stream) => ForwardingStream(
         stream,
         _OnErrorResumeStreamSink<S>(recoveryFn),
       );

--- a/lib/src/transformers/skip_last.dart
+++ b/lib/src/transformers/skip_last.dart
@@ -59,7 +59,7 @@ class SkipLastStreamTransformer<T> extends StreamTransformerBase<T, T> {
 
   @override
   Stream<T> bind(Stream<T> stream) =>
-      forwardStream(stream, _SkipLastStreamSink(count));
+      ForwardingStream(stream, _SkipLastStreamSink(count));
 }
 
 /// Extends the Stream class with the ability to skip the last [count] items

--- a/lib/src/transformers/skip_until.dart
+++ b/lib/src/transformers/skip_until.dart
@@ -62,7 +62,7 @@ class SkipUntilStreamTransformer<S, T> extends StreamTransformerBase<S, S> {
 
   @override
   Stream<S> bind(Stream<S> stream) =>
-      forwardStream(stream, _SkipUntilStreamSink(otherStream));
+      ForwardingStream(stream, _SkipUntilStreamSink(otherStream));
 }
 
 /// Extends the Stream class with the ability to skip events until another

--- a/lib/src/transformers/start_with.dart
+++ b/lib/src/transformers/start_with.dart
@@ -73,7 +73,7 @@ class StartWithStreamTransformer<S> extends StreamTransformerBase<S, S> {
 
   @override
   Stream<S> bind(Stream<S> stream) =>
-      forwardStream(stream, _StartWithStreamSink(startValue));
+      ForwardingStream(stream, _StartWithStreamSink(startValue));
 }
 
 /// Extends the [Stream] class with the ability to emit the given value as the

--- a/lib/src/transformers/start_with_error.dart
+++ b/lib/src/transformers/start_with_error.dart
@@ -76,5 +76,5 @@ class StartWithErrorStreamTransformer<S> extends StreamTransformerBase<S, S> {
 
   @override
   Stream<S> bind(Stream<S> stream) =>
-      forwardStream(stream, _StartWithErrorStreamSink(error, stackTrace));
+      ForwardingStream(stream, _StartWithErrorStreamSink(error, stackTrace));
 }

--- a/lib/src/transformers/start_with_many.dart
+++ b/lib/src/transformers/start_with_many.dart
@@ -72,7 +72,7 @@ class StartWithManyStreamTransformer<S> extends StreamTransformerBase<S, S> {
 
   @override
   Stream<S> bind(Stream<S> stream) =>
-      forwardStream(stream, _StartWithManyStreamSink(startValues));
+      ForwardingStream(stream, _StartWithManyStreamSink(startValues));
 }
 
 /// Extends the [Stream] class with the ability to emit the given values as the

--- a/lib/src/transformers/switch_if_empty.dart
+++ b/lib/src/transformers/switch_if_empty.dart
@@ -82,7 +82,7 @@ class SwitchIfEmptyStreamTransformer<S> extends StreamTransformerBase<S, S> {
 
   @override
   Stream<S> bind(Stream<S> stream) {
-    return forwardStream(stream, _SwitchIfEmptyStreamSink(fallbackStream));
+    return ForwardingStream(stream, _SwitchIfEmptyStreamSink(fallbackStream));
   }
 }
 

--- a/lib/src/transformers/switch_map.dart
+++ b/lib/src/transformers/switch_map.dart
@@ -83,7 +83,7 @@ class SwitchMapStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
 
   @override
   Stream<T> bind(Stream<S> stream) =>
-      forwardStream(stream, _SwitchMapStreamSink(mapper));
+      ForwardingStream(stream, _SwitchMapStreamSink(mapper));
 }
 
 /// Extends the Stream with the ability to convert one stream into a new Stream

--- a/lib/src/transformers/take_last.dart
+++ b/lib/src/transformers/take_last.dart
@@ -65,7 +65,7 @@ class TakeLastStreamTransformer<T> extends StreamTransformerBase<T, T> {
 
   @override
   Stream<T> bind(Stream<T> stream) =>
-      forwardStream(stream, _TakeLastStreamSink<T>(count));
+      ForwardingStream(stream, _TakeLastStreamSink<T>(count));
 }
 
 /// Extends the [Stream] class with the ability receive only the final [count]

--- a/lib/src/transformers/take_until.dart
+++ b/lib/src/transformers/take_until.dart
@@ -59,7 +59,7 @@ class TakeUntilStreamTransformer<S, T> extends StreamTransformerBase<S, S> {
 
   @override
   Stream<S> bind(Stream<S> stream) =>
-      forwardStream(stream, _TakeUntilStreamSink(otherStream));
+      ForwardingStream(stream, _TakeUntilStreamSink(otherStream));
 }
 
 /// Extends the Stream class with the ability receive events from the source

--- a/lib/src/transformers/time_interval.dart
+++ b/lib/src/transformers/time_interval.dart
@@ -59,7 +59,7 @@ class TimeIntervalStreamTransformer<S>
 
   @override
   Stream<TimeInterval<S>> bind(Stream<S> stream) =>
-      forwardStream(stream, _TimeIntervalStreamSink());
+      ForwardingStream(stream, _TimeIntervalStreamSink());
 }
 
 /// A class that represents a snapshot of the current value emitted by a

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -367,7 +367,7 @@ class WithLatestFromStreamTransformer<S, T, R>
           );
 
   @override
-  Stream<R> bind(Stream<S> stream) => forwardStream(
+  Stream<R> bind(Stream<S> stream) => ForwardingStream(
         stream,
         _WithLatestFromStreamSink<S, T, R>(latestFromStreams, combiner),
       );

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -78,18 +78,5 @@ Stream<R> forwardStream<T, R>(
     onDone: () => runCatching(() => connectedSink.close(controller)),
   );
 
-  return _ForwardingStream(controller.stream);
-}
-
-class _ForwardingStream<T> extends Stream<T> {
-  final Stream<T> source;
-
-  _ForwardingStream(this.source);
-
-  @override
-  StreamSubscription<T> listen(void Function(T event)? onData,
-      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
-    return source.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
-  }
+  return controller.stream;
 }

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -106,7 +106,8 @@ class _CombinedStreamSubscription<T, R> extends StreamSubscription<R> {
   _CombinedStreamSubscription(this._innerSubscription, this._outerSubscription);
 
   @override
-  Future<E> asFuture<E>([E? futureValue]) => _outerSubscription.asFuture();
+  Future<E> asFuture<E>([E? futureValue]) =>
+      _outerSubscription.asFuture(futureValue);
 
   @override
   Future<void> cancel() {

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -347,8 +347,7 @@ void main() {
       final subject = BehaviorSubject<void>();
 
       unawaited(subject
-          .addStream(Stream<void>.error(Exception()),
-              cancelOnError: true)
+          .addStream(Stream<void>.error(Exception()), cancelOnError: true)
           .whenComplete(() => subject.add(1)));
 
       await expectLater(subject.stream,
@@ -874,8 +873,8 @@ void main() {
         {
           var behaviorSubject = BehaviorSubject.seeded(1);
 
-          var mapped = behaviorSubject
-              .asyncMap((event) => Future.value(event + 1));
+          var mapped =
+              behaviorSubject.asyncMap((event) => Future.value(event + 1));
           expect(mapped, emitsInOrder(<int>[2, 3]));
 
           behaviorSubject.add(2);
@@ -884,8 +883,8 @@ void main() {
         {
           var behaviorSubject = BehaviorSubject<int>();
 
-          var mapped = behaviorSubject
-              .asyncMap((event) => Future.value(event + 1));
+          var mapped =
+              behaviorSubject.asyncMap((event) => Future.value(event + 1));
           expect(mapped, emitsInOrder(<int>[2, 3]));
 
           behaviorSubject.add(1);

--- a/test/transformers/skip_last_test.dart
+++ b/test/transformers/skip_last_test.dart
@@ -24,7 +24,6 @@ void main() {
     expect(count, equals(values.length));
   });
 
-
   test('Rx.skipLast.skipMoreThanLength', () async {
     final stream = Stream.fromIterable([1, 2, 3, 4, 5]).skipLast(100);
 

--- a/test/transformers/switch_map_test.dart
+++ b/test/transformers/switch_map_test.dart
@@ -160,7 +160,7 @@ void main() {
     final controller = StreamController<bool>.broadcast();
     final root =
         OnSubscriptionTriggerableStream(controller.stream, () => count++);
-    final stream = root.map((event) => Stream.value(event));
+    final stream = root.switchMap((event) => Stream.value(event));
 
     stream.listen((event) {});
     stream.listen((event) {});

--- a/test/transformers/switch_map_test.dart
+++ b/test/transformers/switch_map_test.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
+import '../utils/on_subscription_triggerable_stream.dart';
+
 Stream<int> _getStream() {
   final controller = StreamController<int>();
 
@@ -150,5 +152,21 @@ void main() {
     await Future<void>.delayed(Duration.zero);
     await inner.close();
     await outer.close();
+  });
+
+  test('Rx.switchMap every subscription triggers a listen on the root Stream',
+      () async {
+    var count = 0;
+    final controller = StreamController<bool>.broadcast();
+    final root =
+        OnSubscriptionTriggerableStream(controller.stream, () => count++);
+    final stream = root.map((event) => Stream.value(event));
+
+    stream.listen((event) {});
+    stream.listen((event) {});
+
+    expect(count, 2);
+
+    await controller.close();
   });
 }

--- a/test/utils/on_subscription_triggerable_stream.dart
+++ b/test/utils/on_subscription_triggerable_stream.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+
+class OnSubscriptionTriggerableStream<T> extends Stream<T> {
+  final Stream<T> inner;
+  final void Function() onSubscribe;
+
+  OnSubscriptionTriggerableStream(this.inner, this.onSubscribe);
+
+  @override
+  bool get isBroadcast => inner.isBroadcast;
+
+  @override
+  StreamSubscription<T> listen(void Function(T event)? onData,
+      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+    onSubscribe();
+    return inner.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+}


### PR DESCRIPTION
As reported here: https://github.com/ReactiveX/rxdart/issues/587

We currently have an issue that any transformer which uses `forwardStream`, only invokes `listen` once, and afterwards delegates `listen` calls to its inner `controller.stream`.

Best described with a test:
```dart
void main() {
  final controller = StreamController<void>.broadcast();
  final stream = DoOnSubscribeStream(controller.stream, () {
    print('new subscription');
  });

  var switched = stream.switchMap((event) => Stream.value(event));
  switched.listen(null); // prints!
  switched.listen(null); // does not print!

  var mapped = stream.map((event) => event);
  mapped.listen(null); // prints!
  mapped.listen(null); // prints!
}
```
If we run this, then the first use case with `switchMap` only triggers the listen _once_, whereas the `map` version triggers is _twice_

If a user overrides the `listen` method, then this becomes problematic.