### PR TITLE
`forwardStream`: remove try-catch

### DIFF
--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -75,14 +75,30 @@ class _DoStreamSink<S> implements ForwardingSink<S, S> {
 
   @override
   void onListen(EventSink<S> sink) {
-    _onListen?.call();
+    try {
+      _onListen?.call();
+    } catch (e, s) {
+      sink.addError(e, s);
+    }
   }
 
   @override
-  void onPause(EventSink<S> sink) => _onPause?.call();
+  void onPause(EventSink<S> sink) {
+    try {
+      _onPause?.call();
+    } catch (e, s) {
+      sink.addError(e, s);
+    }
+  }
 
   @override
-  void onResume(EventSink<S> sink) => _onResume?.call();
+  void onResume(EventSink<S> sink) {
+    try {
+      _onResume?.call();
+    } catch (e, s) {
+      sink.addError(e, s);
+    }
+  }
 }
 
 /// Invokes the given callback at the corresponding point the the stream

--- a/lib/src/transformers/exhaust_map.dart
+++ b/lib/src/transformers/exhaust_map.dart
@@ -16,7 +16,13 @@ class _ExhaustMapStreamSink<S, T> implements ForwardingSink<S, T> {
       return;
     }
 
-    final mappedStream = _mapper(data);
+    final Stream<T> mappedStream;
+    try {
+      mappedStream = _mapper(data);
+    } catch (e, s) {
+      sink.addError(e, s);
+      return;
+    }
 
     _mapperSubscription = mappedStream.listen(
       sink.add,

--- a/lib/src/transformers/flat_map.dart
+++ b/lib/src/transformers/flat_map.dart
@@ -13,7 +13,13 @@ class _FlatMapStreamSink<S, T> implements ForwardingSink<S, T> {
 
   @override
   void add(EventSink<T> sink, S data) {
-    final mappedStream = _mapper(data);
+    final Stream<T> mappedStream;
+    try {
+      mappedStream = _mapper(data);
+    } catch (e, s) {
+      sink.addError(e, s);
+      return;
+    }
 
     _openSubscriptions++;
 

--- a/lib/src/transformers/skip_last.dart
+++ b/lib/src/transformers/skip_last.dart
@@ -20,8 +20,10 @@ class _SkipLastStreamSink<T> implements ForwardingSink<T, T> {
 
   @override
   void close(EventSink<T> sink) {
-    final takeNum = queue.length - count >= 0 ? queue.length - count : 0;
-    queue.take(takeNum).forEach(sink.add);
+    final limit = queue.length - count;
+    if (limit > 0) {
+      queue.sublist(0, limit).forEach(sink.add);
+    }
     sink.close();
   }
 

--- a/lib/src/transformers/switch_map.dart
+++ b/lib/src/transformers/switch_map.dart
@@ -12,7 +12,13 @@ class _SwitchMapStreamSink<S, T> implements ForwardingSink<S, T> {
 
   @override
   void add(EventSink<T> sink, S data) {
-    final mappedStream = _mapper(data);
+    final Stream<T> mappedStream;
+    try {
+      mappedStream = _mapper(data);
+    } catch (e, s) {
+      sink.addError(e, s);
+      return;
+    }
 
     _mapperSubscription?.cancel();
 

--- a/lib/src/utils/forwarding_sink.dart
+++ b/lib/src/utils/forwarding_sink.dart
@@ -19,7 +19,8 @@ abstract class ForwardingSink<T, R> {
   void close(EventSink<R> sink);
 
   /// Fires when a listener subscribes on the underlying [Stream].
-  void onListen(EventSink<R> sink);
+  /// Returns a [Future] to delay listening to source [Stream].
+  FutureOr<void> onListen(EventSink<R> sink);
 
   /// Fires when a subscriber pauses.
   void onPause(EventSink<R> sink);

--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -55,8 +55,6 @@ Stream<R> forwardStream<T, R>(
     return Future.wait(futures);
   }
 
-  ;
-
   final onPause = () {
     subscription!.pause();
     connectedSink.onPause(controller);


### PR DESCRIPTION
- Remove try catch to increase performance.
- Implementation classes must handle error.