### PR TITLE
`groupBy`: add duration selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Add optional parameter `maxConcurrent` to `flatMap`.
 * Update to docs ([@AlexanderJohr](https://github.com/AlexanderJohr)).
 * Bugfix: `onErrorReturnWith` drops remaining data event after the first error.
+* Update `groupBy`
+  * Rename `GroupByStream` to `GroupedStream`.
+  * Add optional parameter `durationSelector`, which used to determine how long each group should exist.
 
 ## 0.27.1
 

--- a/lib/src/transformers/group_by.dart
+++ b/lib/src/transformers/group_by.dart
@@ -3,9 +3,9 @@ import 'dart:async';
 import 'package:rxdart/src/utils/forwarding_sink.dart';
 import 'package:rxdart/src/utils/forwarding_stream.dart';
 
-class _GroupByStreamSink<T, K> extends ForwardingSink<T, GroupByStream<T, K>> {
+class _GroupByStreamSink<T, K> extends ForwardingSink<T, GroupedStream<T, K>> {
   final K Function(T event) grouper;
-  final Stream<void> Function(GroupByStream<T, K>)? duration;
+  final Stream<void> Function(GroupedStream<T, K>)? duration;
 
   final groups = <K, StreamController<T>>{};
   Map<K, StreamSubscription<void>>? subscriptions;
@@ -19,7 +19,7 @@ class _GroupByStreamSink<T, K> extends ForwardingSink<T, GroupByStream<T, K>> {
 
   StreamController<T> _controllerBuilder(K key) {
     final groupedController = StreamController<T>.broadcast(sync: true);
-    final groupByStream = GroupByStream<T, K>(key, groupedController.stream);
+    final groupByStream = GroupedStream<T, K>(key, groupedController.stream);
 
     if (duration != null) {
       subscriptions?.remove(key)?.cancel();
@@ -84,65 +84,68 @@ class _GroupByStreamSink<T, K> extends ForwardingSink<T, GroupByStream<T, K>> {
 }
 
 /// The GroupBy operator divides a [Stream] that emits items into
-/// a [Stream] that emits [GroupByStream],
+/// a [Stream] that emits [GroupedStream],
 /// each one of which emits some subset of the items
 /// from the original source [Stream].
 ///
-/// [GroupByStream] acts like a regular [Stream], yet
+/// [GroupedStream] acts like a regular [Stream], yet
 /// adding a 'key' property, which receives its [Type] and value from
 /// the [_grouper] Function.
 ///
-/// All items with the same key are emitted by the same [GroupByStream].
+/// All items with the same key are emitted by the same [GroupedStream].
 class GroupByStreamTransformer<T, K>
-    extends StreamTransformerBase<T, GroupByStream<T, K>> {
-  /// Method which converts incoming events into a new [GroupByStream]
+    extends StreamTransformerBase<T, GroupedStream<T, K>> {
+  /// Method which converts incoming events into a new [GroupedStream]
   final K Function(T event) grouper;
 
   /// A function that returns an [Stream] to determine how long each group should exist.
   /// When the returned [Stream] emits its first data or done event,
   /// the group will be closed and removed.
-  final Stream<void> Function(GroupByStream<T, K> grouped)? duration;
+  final Stream<void> Function(GroupedStream<T, K> grouped)? durationSelector;
 
   /// Constructs a [StreamTransformer] which groups events from the source
-  /// [Stream] and emits them as [GroupByStream].
-  GroupByStreamTransformer(this.grouper, [this.duration]);
+  /// [Stream] and emits them as [GroupedStream].
+  GroupByStreamTransformer(this.grouper, {this.durationSelector});
 
   @override
-  Stream<GroupByStream<T, K>> bind(Stream<T> stream) =>
-      forwardStream(stream, () => _GroupByStreamSink<T, K>(grouper, duration));
+  Stream<GroupedStream<T, K>> bind(Stream<T> stream) => forwardStream(
+      stream, () => _GroupByStreamSink<T, K>(grouper, durationSelector));
 }
 
 /// The [Stream] used by [GroupByStreamTransformer], it contains events
 /// that are grouped by a key value.
-class GroupByStream<T, K> extends StreamView<T> {
+class GroupedStream<T, K> extends StreamView<T> {
   /// The key is the category to which all events in this group belong to.
   final K key;
 
   /// Constructs a [Stream] which only emits events that can be
   /// categorized under [key].
-  GroupByStream(this.key, Stream<T> stream) : super(stream);
+  GroupedStream(this.key, Stream<T> stream) : super(stream);
 
   @override
-  String toString() => 'GroupByStream{key: $key}';
+  String toString() => 'GroupedStream{key: $key}';
 }
 
 /// Extends the Stream class with the ability to convert events into Streams
 /// of events that are united by a key.
 extension GroupByExtension<T> on Stream<T> {
   /// The GroupBy operator divides a [Stream] that emits items into a [Stream]
-  /// that emits [GroupByStream], each one of which emits some subset of the
+  /// that emits [GroupedStream], each one of which emits some subset of the
   /// items from the original source [Stream].
   ///
-  /// [GroupByStream] acts like a regular [Stream], yet adding a 'key' property,
+  /// [GroupedStream] acts like a regular [Stream], yet adding a 'key' property,
   /// which receives its [Type] and value from the [grouper] Function.
   ///
-  /// All items with the same key are emitted by the same [GroupByStream].
+  /// All items with the same key are emitted by the same [GroupedStream].
   ///
-  /// Optionally, `groupBy` takes a second argument [duration].
-  /// [duration] is a function that returns an [Stream] to determine how long
+  /// Optionally, `groupBy` takes a second argument [durationSelector].
+  /// [durationSelector] is a function that returns an [Stream] to determine how long
   /// each group should exist. When the returned [Stream] emits its first data or done event,
   /// the group will be closed and removed.
-  Stream<GroupByStream<T, K>> groupBy<K>(K Function(T value) grouper,
-          [Stream<void> Function(GroupByStream<T, K> grouped)? duration]) =>
-      transform(GroupByStreamTransformer<T, K>(grouper, duration));
+  Stream<GroupedStream<T, K>> groupBy<K>(
+    K Function(T value) grouper, {
+    Stream<void> Function(GroupedStream<T, K> grouped)? durationSelector,
+  }) =>
+      transform(GroupByStreamTransformer<T, K>(grouper,
+          durationSelector: durationSelector));
 }

--- a/lib/src/transformers/group_by.dart
+++ b/lib/src/transformers/group_by.dart
@@ -39,7 +39,7 @@ class _GroupByStreamSink<T, K> extends ForwardingSink<T, GroupByStream<T, K>> {
 
   @override
   void onData(T data) {
-    K key;
+    final K key;
     try {
       key = grouper(data);
     } catch (e, s) {

--- a/lib/src/transformers/group_by.dart
+++ b/lib/src/transformers/group_by.dart
@@ -93,7 +93,9 @@ class GroupByStreamTransformer<T, K>
   /// Method which converts incoming events into a new [GroupByStream]
   final K Function(T event) grouper;
 
-  /// TODO
+  /// A function that returns an [Stream] to determine how long each group should exist.
+  /// When the returned [Stream] emits its first data or done event,
+  /// the group will be closed and removed.
   final Stream<void> Function(GroupByStream<T, K>)? duration;
 
   /// Constructs a [StreamTransformer] which groups events from the source
@@ -131,7 +133,10 @@ extension GroupByExtension<T> on Stream<T> {
   ///
   /// All items with the same key are emitted by the same [GroupByStream].
   ///
-  /// TODO
+  /// Optionally, `groupBy` takes a second argument [duration].
+  /// [duration] is a function that returns an [Stream] to determine how long
+  /// each group should exist. When the returned [Stream] emits its first data or done event,
+  /// the group will be closed and removed.
   Stream<GroupByStream<T, K>> groupBy<K>(K Function(T value) grouper,
           [Stream<void> Function(GroupByStream<T, K>)? duration]) =>
       transform(GroupByStreamTransformer<T, K>(grouper, duration));

--- a/test/transformers/group_by_test.dart
+++ b/test/transformers/group_by_test.dart
@@ -124,4 +124,34 @@ void main() {
 
     controller.add(1);
   });
+
+  test('Rx.groupBy.durationSelector', () {
+    final g = [
+      '0 -> 1',
+      '1 -> 1',
+      '2 -> 1',
+      '0 -> 2',
+      '1 -> 2',
+      '2 -> 2',
+    ];
+    final take = 30;
+
+    final stream = Stream.periodic(const Duration(milliseconds: 100), (i) => i)
+        .groupBy(
+          (i) => i % 3,
+          (i) => Rx.timer(null, const Duration(milliseconds: 400)),
+        )
+        .flatMap((g) => g
+            .scan<int>((acc, value, index) => acc + 1, 0)
+            .map((event) => '${g.key} -> $event'))
+        .take(take);
+
+    expect(
+      stream,
+      emitsInOrder(<Object>[
+        ...List.filled(take ~/ g.length, g).expand<String>((e) => e),
+        emitsDone,
+      ]),
+    );
+  });
 }

--- a/test/transformers/group_by_test.dart
+++ b/test/transformers/group_by_test.dart
@@ -20,12 +20,40 @@ void main() {
               .having((stream) => stream.key, 'key', 4),
           emitsDone
         ]));
+
+    await expectLater(
+        Stream.fromIterable([1, 2, 3, 4])
+            .groupBy((value) => value, (_) => Rx.never()),
+        emitsInOrder(<Matcher>[
+          TypeMatcher<GroupByStream<int, int>>()
+              .having((stream) => stream.key, 'key', 1),
+          TypeMatcher<GroupByStream<int, int>>()
+              .having((stream) => stream.key, 'key', 2),
+          TypeMatcher<GroupByStream<int, int>>()
+              .having((stream) => stream.key, 'key', 3),
+          TypeMatcher<GroupByStream<int, int>>()
+              .having((stream) => stream.key, 'key', 4),
+          emitsDone
+        ]));
   });
 
   test('Rx.groupBy.correctlyEmitsGroupEvents', () async {
     await expectLater(
         Stream.fromIterable([1, 2, 3, 4])
             .groupBy((value) => _toEventOdd(value % 2))
+            .flatMap((stream) => stream.map((event) => {stream.key: event})),
+        emitsInOrder(<dynamic>[
+          {'odd': 1},
+          {'even': 2},
+          {'odd': 3},
+          {'even': 4},
+          emitsDone
+        ]));
+
+    await expectLater(
+        Stream.fromIterable([1, 2, 3, 4])
+            .groupBy((value) => _toEventOdd(value % 2),
+                (_) => Stream.periodic(const Duration(seconds: 1)))
             .flatMap((stream) => stream.map((event) => {stream.key: event})),
         emitsInOrder(<dynamic>[
           {'odd': 1},
@@ -54,6 +82,25 @@ void main() {
           },
           emitsDone
         ]));
+
+    await expectLater(
+        Stream.fromIterable([1, 2, 3, 4])
+            .groupBy((value) => _toEventOdd(value % 2),
+                (_) => Stream.periodic(const Duration(seconds: 1)))
+            // fold is called when onDone triggers on the Stream
+            .map((stream) async => await stream.fold(
+                {stream.key: <int>[]},
+                (Map<String, List<int>> previous, element) =>
+                    previous..[stream.key]?.add(element))),
+        emitsInOrder(<dynamic>[
+          {
+            'odd': [1, 3]
+          },
+          {
+            'even': [2, 4]
+          },
+          emitsDone
+        ]));
   });
 
   test('Rx.groupBy.emittedStreamCallOnDone', () async {
@@ -63,66 +110,155 @@ void main() {
             // drain will emit 'done' onDone
             .map((stream) async => await stream.drain('done')),
         emitsInOrder(<dynamic>['done', 'done', 'done', 'done', emitsDone]));
+
+    await expectLater(
+        Stream.fromIterable([1, 2, 3, 4])
+            .groupBy((value) => value, (_) => Rx.never())
+            // drain will emit 'done' onDone
+            .map((stream) async => await stream.drain('done')),
+        emitsInOrder(<dynamic>['done', 'done', 'done', 'done', emitsDone]));
   });
 
   test('Rx.groupBy.asBroadcastStream', () async {
-    final stream = Stream.fromIterable([1, 2, 3, 4])
-        .asBroadcastStream()
-        .groupBy((value) => value);
+    {
+      final stream = Stream.fromIterable([1, 2, 3, 4])
+          .asBroadcastStream()
+          .groupBy((value) => value);
 
-    // listen twice on same stream
-    stream.listen(null);
-    stream.listen(null);
-    // code should reach here
-    await expectLater(true, true);
+      // listen twice on same stream
+      stream.listen(null);
+      stream.listen(null);
+      // code should reach here
+      await expectLater(true, true);
+    }
+
+    {
+      final stream = Stream.fromIterable([1, 2, 3, 4])
+          .asBroadcastStream()
+          .groupBy((value) => value,
+              (_) => Stream.periodic(const Duration(seconds: 2)));
+
+      // listen twice on same stream
+      stream.listen(null);
+      stream.listen(null);
+      // code should reach here
+      await expectLater(true, true);
+    }
   });
 
   test('Rx.groupBy.pause.resume', () async {
-    var count = 0;
-    late StreamSubscription subscription;
+    {
+      var count = 0;
+      late StreamSubscription subscription;
 
-    subscription = Stream.fromIterable([1, 2, 3, 4])
-        .groupBy((value) => value)
-        .listen(expectAsync1((result) {
-          count++;
+      subscription = Stream.fromIterable([1, 2, 3, 4])
+          .groupBy((value) => value)
+          .listen(expectAsync1((result) {
+            count++;
 
-          if (count == 4) {
-            subscription.cancel();
-          }
-        }, count: 4));
+            if (count == 4) {
+              subscription.cancel();
+            }
+          }, count: 4));
 
-    subscription.pause(Future<void>.delayed(const Duration(milliseconds: 100)));
+      subscription
+          .pause(Future<void>.delayed(const Duration(milliseconds: 100)));
+    }
+
+    {
+      var count = 0;
+      late StreamSubscription subscription;
+
+      subscription = Stream.fromIterable([1, 2, 3, 4])
+          .groupBy((value) => value,
+              (_) => Rx.timer(null, const Duration(seconds: 1)))
+          .listen(expectAsync1((result) {
+            count++;
+
+            if (count == 4) {
+              subscription.cancel();
+            }
+          }, count: 4));
+
+      subscription
+          .pause(Future<void>.delayed(const Duration(milliseconds: 100)));
+    }
   });
 
   test('Rx.groupBy.error.shouldThrow.onError', () async {
-    final streamWithError =
-        Stream<void>.error(Exception()).groupBy((value) => value);
+    {
+      final streamWithError =
+          Stream<void>.error(Exception()).groupBy((value) => value);
 
-    streamWithError.listen(null,
-        onError: expectAsync2((Exception e, StackTrace s) {
-      expect(e, isException);
-    }));
+      streamWithError.listen(null,
+          onError: expectAsync2((Exception e, StackTrace s) {
+        expect(e, isException);
+      }));
+    }
+
+    {
+      final streamWithError = Stream<void>.error(Exception()).groupBy(
+        (value) => value,
+        (_) => Rx.timer(null, const Duration(seconds: 1)),
+      );
+
+      streamWithError.listen(null,
+          onError: expectAsync2((Exception e, StackTrace s) {
+        expect(e, isException);
+      }));
+    }
   });
 
   test('Rx.groupBy.error.shouldThrow.onGrouper', () async {
-    final streamWithError = Stream.fromIterable([1, 2, 3, 4]).groupBy((value) {
-      throw Exception();
-    });
+    {
+      final streamWithError =
+          Stream.fromIterable([1, 2, 3, 4]).groupBy((value) {
+        throw Exception();
+      });
 
-    streamWithError.listen(null,
-        onError: expectAsync2((Exception e, StackTrace s) {
-          expect(e, isException);
-        }, count: 4));
+      streamWithError.listen(null,
+          onError: expectAsync2((Exception e, StackTrace s) {
+            expect(e, isException);
+          }, count: 4));
+    }
+
+    {
+      final streamWithError = Stream.fromIterable([1, 2, 3, 4]).groupBy(
+        (value) => throw Exception(),
+        (_) => Rx.timer(null, const Duration(seconds: 1)),
+      );
+
+      streamWithError.listen(null,
+          onError: expectAsync2((Exception e, StackTrace s) {
+            expect(e, isException);
+          }, count: 4));
+    }
   });
   test('Rx.groupBy accidental broadcast', () async {
-    final controller = StreamController<int>();
+    {
+      final controller = StreamController<int>();
 
-    final stream = controller.stream.groupBy((_) => _);
+      final stream = controller.stream.groupBy((_) => _);
 
-    stream.listen(null);
-    expect(() => stream.listen(null), throwsStateError);
+      stream.listen(null);
+      expect(() => stream.listen(null), throwsStateError);
 
-    controller.add(1);
+      controller.add(1);
+    }
+
+    {
+      final controller = StreamController<int>();
+
+      final stream = controller.stream.groupBy(
+        (_) => _,
+        (_) => Rx.timer(null, const Duration(seconds: 1)),
+      );
+
+      stream.listen(null);
+      expect(() => stream.listen(null), throwsStateError);
+
+      controller.add(1);
+    }
   });
 
   test('Rx.groupBy.durationSelector', () {


### PR DESCRIPTION
Fixes #606 
Add `duration` param: A function that returns an Stream to determine how long each group should exist.
Ref rxjs: https://github.com/ReactiveX/rxjs/blob/3a6d1643f6ef9cc28cce0051a805b9ce55ceb7a3/src/internal/operators/groupBy.ts#L153