### PR TITLE
Corrected typo "observe2" > "observer2"

### DIFF
--- a/lib/src/subjects/publish_subject.dart
+++ b/lib/src/subjects/publish_subject.dart
@@ -21,7 +21,7 @@ import 'package:rxdart/src/subjects/subject.dart';
 ///     subject.add(2);
 ///
 ///     // observer2 will only receive 3 and done event
-///     subject.stream.listen(observe2);
+///     subject.stream.listen(observer2);
 ///     subject.add(3);
 ///     subject.close();
 class PublishSubject<T> extends Subject<T> {


### PR DESCRIPTION
in 18 it is called observer1
in 19 it is called observer1
in 23 it is called observer2
in 24 it is called observe2

clearly the last time the last 'r' was missing