### PR TITLE
fix(onErrorResume): still adds data when Stream emits an error

### DIFF
--- a/test/transformers/on_error_return_test.dart
+++ b/test/transformers/on_error_return_test.dart
@@ -54,4 +54,19 @@ void main() {
 
     controller.add(1);
   });
+
+  test('Rx.onErrorReturn still adds data when Stream emits an error: issue/616',
+      () {
+    final stream = Rx.concat<int>([
+      Stream.value(1),
+      Stream.error(Exception()),
+      Stream.fromIterable([2, 3]),
+      Stream.error(Exception()),
+      Stream.value(4),
+    ]).onErrorReturn(-1);
+    expect(
+      stream,
+      emitsInOrder(<Object>[1, -1, 2, 3, -1, 4, emitsDone]),
+    );
+  });
 }

--- a/test/transformers/on_error_return_with_test.dart
+++ b/test/transformers/on_error_return_with_test.dart
@@ -55,4 +55,20 @@ void main() {
 
     controller.add(1);
   });
+
+  test(
+      'Rx.onErrorReturnWith still adds data when Stream emits an error: issue/616',
+      () {
+    final stream = Rx.concat<int>([
+      Stream.value(1),
+      Stream.error(Exception()),
+      Stream.fromIterable([2, 3]),
+      Stream.error(Exception()),
+      Stream.value(4),
+    ]).onErrorReturnWith((e, s) => -1);
+    expect(
+      stream,
+      emitsInOrder(<Object>[1, -1, 2, 3, -1, 4, emitsDone]),
+    );
+  });
 }


### PR DESCRIPTION
- Fixes #616
- Same behavior as `flatMap`, but for error instead of data