### PR TITLE
Migrate from pedantic to lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.11.0.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   strong-mode:
@@ -10,3 +10,7 @@ analyzer:
 linter:
   rules:
     - public_member_api_docs
+    - always_declare_return_types # https://github.com/dart-lang/lints#migrating-from-packagepedantic
+    - prefer_single_quotes # https://github.com/dart-lang/lints#migrating-from-packagepedantic
+    - unawaited_futures # https://github.com/dart-lang/lints#migrating-from-packagepedantic
+    - unsafe_html # https://github.com/dart-lang/lints#migrating-from-packagepedantic

--- a/example/flutter/github_search/.gitignore
+++ b/example/flutter/github_search/.gitignore
@@ -30,6 +30,7 @@
 .pub-cache/
 .pub/
 /build/
+*.mocks.dart
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/example/flutter/github_search/analysis_options.yaml
+++ b/example/flutter/github_search/analysis_options.yaml
@@ -1,5 +1,9 @@
-include: package:pedantic/analysis_options.1.9.0.yaml
+include: package:flutter_lints/flutter.yaml
 linter:
   rules:
     - prefer_final_locals
     - prefer_relative_imports
+    - always_declare_return_types # https://github.com/dart-lang/lints#migrating-from-packagepedantic
+    - prefer_single_quotes # https://github.com/dart-lang/lints#migrating-from-packagepedantic
+    - unawaited_futures # https://github.com/dart-lang/lints#migrating-from-packagepedantic
+    - unsafe_html # https://github.com/dart-lang/lints#migrating-from-packagepedantic

--- a/example/flutter/github_search/lib/empty_result_widget.dart
+++ b/example/flutter/github_search/lib/empty_result_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class EmptyWidget extends StatelessWidget {
-  const EmptyWidget({Key key}) : super(key: key);
+  const EmptyWidget({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -16,7 +16,7 @@ class EmptyWidget extends StatelessWidget {
             size: 80.0,
           ),
           Container(
-            padding: EdgeInsets.only(top: 16.0),
+            padding: const EdgeInsets.only(top: 16.0),
             child: Text(
               'No results',
               style: TextStyle(color: Colors.yellow[100]),

--- a/example/flutter/github_search/lib/github_api.dart
+++ b/example/flutter/github_search/lib/github_api.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:http/http.dart' as http;
 
@@ -10,16 +9,17 @@ class GithubApi {
   final http.Client client;
 
   GithubApi({
-    HttpClient client,
-    Map<String, SearchResult> cache,
+    http.Client? client,
+    Map<String, SearchResult>? cache,
     this.baseUrl = 'https://api.github.com/search/repositories?q=',
   })  : client = client ?? http.Client(),
         cache = cache ?? <String, SearchResult>{};
 
   /// Search Github for repositories using the given term
   Future<SearchResult> search(String term) async {
-    if (cache.containsKey(term)) {
-      return cache[term];
+    final cached = cache[term];
+    if (cached != null) {
+      return cached;
     } else {
       final result = await _fetchResults(term);
 
@@ -44,10 +44,8 @@ class SearchResult {
 
   factory SearchResult.fromJson(dynamic json) {
     final items = (json as List)
-        .cast<Map<String, Object>>()
-        .map((Map<String, Object> item) {
-      return SearchResultItem.fromJson(item);
-    }).toList();
+        .map((item) => SearchResultItem.fromJson(item))
+        .toList(growable: false);
 
     return SearchResult(items);
   }

--- a/example/flutter/github_search/lib/main.dart
+++ b/example/flutter/github_search/lib/main.dart
@@ -10,7 +10,7 @@ void main() {
 class SearchApp extends StatefulWidget {
   final GithubApi api;
 
-  SearchApp({Key key, this.api}) : super(key: key);
+  const SearchApp({Key? key, required this.api}) : super(key: key);
 
   @override
   _RxDartGithubSearchAppState createState() => _RxDartGithubSearchAppState();

--- a/example/flutter/github_search/lib/main.dart
+++ b/example/flutter/github_search/lib/main.dart
@@ -3,20 +3,13 @@ import 'package:flutter/material.dart';
 import 'github_api.dart';
 import 'search_widget.dart';
 
-void main() {
-  runApp(SearchApp(api: GithubApi()));
-}
+void main() => runApp(SearchApp(api: GithubApi()));
 
-class SearchApp extends StatefulWidget {
+class SearchApp extends StatelessWidget {
   final GithubApi api;
 
   const SearchApp({Key? key, required this.api}) : super(key: key);
 
-  @override
-  _RxDartGithubSearchAppState createState() => _RxDartGithubSearchAppState();
-}
-
-class _RxDartGithubSearchAppState extends State<SearchApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -25,7 +18,7 @@ class _RxDartGithubSearchAppState extends State<SearchApp> {
         brightness: Brightness.dark,
         primarySwatch: Colors.grey,
       ),
-      home: SearchScreen(api: widget.api),
+      home: SearchScreen(api: api),
     );
   }
 }

--- a/example/flutter/github_search/lib/search_bloc.dart
+++ b/example/flutter/github_search/lib/search_bloc.dart
@@ -18,7 +18,7 @@ class SearchBloc {
         // Wait for the user to stop typing for 250ms before running a search
         .debounceTime(const Duration(milliseconds: 250))
         // Call the Github api with the given search term and convert it to a
-        // State. If another search term is entered, flatMapLatest will ensure
+        // State. If another search term is entered, switchMap will ensure
         // the previous search is discarded so we don't deliver stale results
         // to the View.
         .switchMap<SearchState>((String term) => _search(term, api))

--- a/example/flutter/github_search/lib/search_error_widget.dart
+++ b/example/flutter/github_search/lib/search_error_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class SearchErrorWidget extends StatelessWidget {
-  const SearchErrorWidget({Key key}) : super(key: key);
+  const SearchErrorWidget({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -13,7 +13,7 @@ class SearchErrorWidget extends StatelessWidget {
         children: <Widget>[
           Icon(Icons.error_outline, color: Colors.red[300], size: 80.0),
           Container(
-            padding: EdgeInsets.only(top: 16.0),
+            padding: const EdgeInsets.only(top: 16.0),
             child: Text(
               'Rate limit exceeded',
               style: TextStyle(

--- a/example/flutter/github_search/lib/search_intro_widget.dart
+++ b/example/flutter/github_search/lib/search_intro_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class SearchIntro extends StatelessWidget {
-  const SearchIntro({Key key}) : super(key: key);
+  const SearchIntro({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -12,7 +12,7 @@ class SearchIntro extends StatelessWidget {
         children: <Widget>[
           Icon(Icons.info, color: Colors.green[200], size: 80.0),
           Container(
-            padding: EdgeInsets.only(top: 16.0),
+            padding: const EdgeInsets.only(top: 16.0),
             child: Text(
               'Enter a search term to begin',
               style: TextStyle(

--- a/example/flutter/github_search/lib/search_loading_widget.dart
+++ b/example/flutter/github_search/lib/search_loading_widget.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
 class LoadingWidget extends StatelessWidget {
-  const LoadingWidget({Key key}) : super(key: key);
+  const LoadingWidget({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Container(
       alignment: FractionalOffset.center,
-      child: CircularProgressIndicator(),
+      child: const CircularProgressIndicator(),
     );
   }
 }

--- a/example/flutter/github_search/lib/search_result_widget.dart
+++ b/example/flutter/github_search/lib/search_result_widget.dart
@@ -5,7 +5,7 @@ import 'github_api.dart';
 class SearchResultWidget extends StatelessWidget {
   final List<SearchResultItem> items;
 
-  const SearchResultWidget({Key key, @required this.items}) : super(key: key);
+  const SearchResultWidget({Key? key, required this.items}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -18,12 +18,12 @@ class SearchResultWidget extends StatelessWidget {
           onTap: () => showItem(context, item),
           child: Container(
             alignment: FractionalOffset.center,
-            margin: EdgeInsets.fromLTRB(16.0, 12.0, 16.0, 12.0),
+            margin: const EdgeInsets.fromLTRB(16.0, 12.0, 16.0, 12.0),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 Container(
-                  margin: EdgeInsets.only(right: 16.0),
+                  margin: const EdgeInsets.only(right: 16.0),
                   child: Hero(
                     tag: item.fullName,
                     child: ClipOval(
@@ -40,30 +40,28 @@ class SearchResultWidget extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       Container(
-                        margin: EdgeInsets.only(
+                        margin: const EdgeInsets.only(
                           top: 6.0,
                           bottom: 4.0,
                         ),
                         child: Text(
-                          '${item.fullName}',
+                          item.fullName,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
+                          style: const TextStyle(
                             fontFamily: 'Montserrat',
                             fontSize: 16.0,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
                       ),
-                      Container(
-                        child: Text(
-                          '${item.url}',
-                          style: TextStyle(
-                            fontFamily: 'Hind',
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                      Text(
+                        item.url,
+                        style: const TextStyle(
+                          fontFamily: 'Hind',
                         ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       )
                     ],
                   ),
@@ -79,10 +77,10 @@ class SearchResultWidget extends StatelessWidget {
   void showItem(BuildContext context, SearchResultItem item) {
     Navigator.push(
       context,
-      MaterialPageRoute<Null>(
+      MaterialPageRoute<void>(
         builder: (BuildContext context) {
           return Scaffold(
-            resizeToAvoidBottomPadding: false,
+            resizeToAvoidBottomInset: false,
             body: GestureDetector(
               key: Key(item.avatarUrl),
               onTap: () => Navigator.pop(context),

--- a/example/flutter/github_search/lib/search_widget.dart
+++ b/example/flutter/github_search/lib/search_widget.dart
@@ -18,7 +18,7 @@ import 'search_state.dart';
 class SearchScreen extends StatefulWidget {
   final GithubApi api;
 
-  SearchScreen({Key key, this.api}) : super(key: key);
+  const SearchScreen({Key? key, required this.api}) : super(key: key);
 
   @override
   SearchScreenState createState() {
@@ -27,7 +27,7 @@ class SearchScreen extends StatefulWidget {
 }
 
 class SearchScreenState extends State<SearchScreen> {
-  SearchBloc bloc;
+  late final SearchBloc bloc;
 
   @override
   void initState() {
@@ -48,20 +48,20 @@ class SearchScreenState extends State<SearchScreen> {
       stream: bloc.state,
       initialData: SearchNoTerm(),
       builder: (BuildContext context, AsyncSnapshot<SearchState> snapshot) {
-        final state = snapshot.data;
+        final state = snapshot.requireData;
 
         return Scaffold(
           body: Stack(
             children: <Widget>[
               Flex(direction: Axis.vertical, children: <Widget>[
                 Container(
-                  padding: EdgeInsets.fromLTRB(16.0, 24.0, 16.0, 4.0),
+                  padding: const EdgeInsets.fromLTRB(16.0, 24.0, 16.0, 4.0),
                   child: TextField(
-                    decoration: InputDecoration(
+                    decoration: const InputDecoration(
                       border: InputBorder.none,
                       hintText: 'Search Github...',
                     ),
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontSize: 36.0,
                       fontFamily: 'Hind',
                       decoration: TextDecoration.none,
@@ -85,13 +85,13 @@ class SearchScreenState extends State<SearchScreen> {
 
   Widget _buildChild(SearchState state) {
     if (state is SearchNoTerm) {
-      return SearchIntro();
+      return const SearchIntro();
     } else if (state is SearchEmpty) {
-      return EmptyWidget();
+      return const EmptyWidget();
     } else if (state is SearchLoading) {
-      return LoadingWidget();
+      return const LoadingWidget();
     } else if (state is SearchError) {
-      return SearchErrorWidget();
+      return const SearchErrorWidget();
     } else if (state is SearchPopulated) {
       return SearchResultWidget(items: state.result.items);
     }

--- a/example/flutter/github_search/pubspec.yaml
+++ b/example/flutter/github_search/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 description: Flutter Github Search RxDart Example.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
   flutter: ">=2.5.0 <3.0.0"
 
 dependencies:

--- a/example/flutter/github_search/pubspec.yaml
+++ b/example/flutter/github_search/pubspec.yaml
@@ -1,20 +1,23 @@
 name: github_search
-description: A new flutter project.
+publish_to: 'none'
+description: Flutter Github Search RxDart Example.
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.5.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
   rxdart:
     path: ../../../
-  http: ^0.12.2
+  http: ^0.13.3
 
 dev_dependencies:
-  pedantic: ^1.9.0
-  test: ^1.15.4
-  mockito: ^4.1.3
+  flutter_lints: ^1.0.4
+  test: ^1.17.10
+  mockito: ^5.0.15
+  build_runner: ^2.1.2
   flutter_test:
     sdk: flutter
 

--- a/example/flutter/github_search/test/search_bloc_test.dart
+++ b/example/flutter/github_search/test/search_bloc_test.dart
@@ -4,11 +4,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:github_search/github_api.dart';
 import 'package:github_search/search_bloc.dart';
 import 'package:github_search/search_state.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart' show TypeMatcher;
 
-class MockGithubApi extends Mock implements GithubApi {}
+import 'search_bloc_test.mocks.dart';
 
+// To gen 'search_bloc_test.mocks.dart', run: flutter packages pub run build_runner build --delete-conflicting-outputs
+@GenerateMocks([GithubApi])
 void main() {
   group('SearchBloc', () {
     test('starts with an initial no term state', () {
@@ -100,12 +102,12 @@ void main() {
   });
 }
 
-const noTerm = TypeMatcher<SearchNoTerm>();
+final noTerm = isA<SearchNoTerm>();
 
-const loading = TypeMatcher<SearchLoading>();
+final loading = isA<SearchLoading>();
 
-const empty = TypeMatcher<SearchEmpty>();
+final empty = isA<SearchEmpty>();
 
-const populated = TypeMatcher<SearchPopulated>();
+final populated = isA<SearchPopulated>();
 
-const error = TypeMatcher<SearchError>();
+final error = isA<SearchError>();

--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/subscription.dart';
+
 /// Merges the given Streams into one Stream sequence by using the
 /// combiner function whenever any of the source stream sequences emits an
 /// item.
@@ -301,12 +303,14 @@ class CombineLatestStream<T, R> extends StreamView<R> {
         final values = List<T?>.filled(len, null);
         var triggered = 0, completed = 0, index = 0;
 
-        final allHaveEvent = () => triggered == len;
+        bool allHaveEvent() => triggered == len;
 
-        final onDone = () {
+        void onDone() {
           if (++completed == len) controller.close();
-        };
-        final onUpdate = (int index) => (T value) => values[index] = value;
+        }
+
+        T Function(T value) onUpdate(int index) =>
+            (T value) => values[index] = value;
 
         subscriptions = streams.map((stream) {
           final onUpdateForStream = onUpdate(index++);
@@ -334,12 +338,9 @@ class CombineLatestStream<T, R> extends StreamView<R> {
           );
         }).toList(growable: false);
       },
-      onPause: () =>
-          subscriptions.forEach((subscription) => subscription.pause()),
-      onResume: () =>
-          subscriptions.forEach((subscription) => subscription.resume()),
-      onCancel: () => Future.wait<dynamic>(
-          subscriptions.map((subscription) => subscription.cancel())),
+      onPause: () => subscriptions.pauseAll(),
+      onResume: () => subscriptions.resumeAll(),
+      onCancel: () => subscriptions.cancelAll(),
     );
 
     return controller;

--- a/lib/src/streams/fork_join.dart
+++ b/lib/src/streams/fork_join.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/subscription.dart';
+
 /// This operator is best used when you have a group of streams
 /// and only care about the final emitted value of each.
 /// One common use case for this is if you wish to issue multiple
@@ -313,7 +315,7 @@ class ForkJoinStream<T, R> extends StreamView<R> {
         final values = List<T?>.filled(length, null);
         var completed = 0;
 
-        final listen = (Stream<T> stream, int i) {
+        StreamSubscription<T> listen(Stream<T> stream, int i) {
           var hasValue = false;
 
           return stream.listen(
@@ -339,15 +341,15 @@ class ForkJoinStream<T, R> extends StreamView<R> {
               }
             },
           );
-        };
+        }
 
         var i = 0;
         subscriptions =
             streams.map((s) => listen(s, i++)).toList(growable: false);
       },
-      onPause: () => subscriptions.forEach((s) => s.pause()),
-      onResume: () => subscriptions.forEach((s) => s.resume()),
-      onCancel: () => Future.wait(subscriptions.map((s) => s.cancel())),
+      onPause: () => subscriptions.pauseAll(),
+      onResume: () => subscriptions.resumeAll(),
+      onCancel: () => subscriptions.cancelAll(),
     );
 
     return controller.stream;

--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/subscription.dart';
+
 /// Flattens the items emitted by the given streams into a single Stream
 /// sequence.
 ///
@@ -43,23 +45,20 @@ class MergeStream<T> extends Stream<T> {
         onListen: () {
           var completed = 0;
 
-          final onDone = () {
+          void onDone() {
             completed++;
 
             if (completed == len) controller.close();
-          };
+          }
 
           subscriptions = streams
               .map((s) => s.listen(controller.add,
                   onError: controller.addError, onDone: onDone))
               .toList(growable: false);
         },
-        onPause: () =>
-            subscriptions.forEach((subscription) => subscription.pause()),
-        onResume: () =>
-            subscriptions.forEach((subscription) => subscription.resume()),
-        onCancel: () => Future.wait(
-            subscriptions.map((subscription) => subscription.cancel())));
+        onPause: () => subscriptions.pauseAll(),
+        onResume: () => subscriptions.resumeAll(),
+        onCancel: () => subscriptions.cancelAll());
 
     return controller;
   }

--- a/lib/src/streams/race.dart
+++ b/lib/src/streams/race.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/subscription.dart';
+
 /// Given two or more source streams, emit all of the items from only
 /// the first of these streams to emit an item or notification.
 ///
@@ -45,16 +47,16 @@ class RaceStream<T> extends Stream<T> {
         onListen: () {
           var index = 0;
 
-          final reduceToWinner = (int winnerIndex) {
+          void reduceToWinner(int winnerIndex) {
             //ignore: cancel_subscriptions
             final winner = subscriptions.removeAt(winnerIndex);
 
-            subscriptions.forEach((subscription) => subscription.cancel());
+            subscriptions.cancelAll();
 
             subscriptions = [winner];
-          };
+          }
 
-          final doUpdate = (int index) => (T value) {
+          void Function(T value) doUpdate(int index) => (T value) {
                 try {
                   if (subscriptions.length > 1) reduceToWinner(index);
 
@@ -69,12 +71,9 @@ class RaceStream<T> extends Stream<T> {
                   onError: controller.addError, onDone: controller.close))
               .toList();
         },
-        onPause: () =>
-            subscriptions.forEach((subscription) => subscription.pause()),
-        onResume: () =>
-            subscriptions.forEach((subscription) => subscription.resume()),
-        onCancel: () => Future.wait<dynamic>(
-            subscriptions.map((subscription) => subscription.cancel())));
+        onPause: () => subscriptions.pauseAll(),
+        onResume: () => subscriptions.resumeAll(),
+        onCancel: () => subscriptions.cancelAll());
 
     return controller;
   }

--- a/lib/src/streams/range.dart
+++ b/lib/src/streams/range.dart
@@ -24,7 +24,7 @@ class RangeStream extends Stream<int> {
 
   static Stream<int> _buildStream(int startInclusive, int endInclusive) {
     final length = (endInclusive - startInclusive).abs() + 1;
-    final nextValue = (int index) => startInclusive > endInclusive
+    int nextValue(int index) => startInclusive > endInclusive
         ? startInclusive - index
         : startInclusive + index;
 

--- a/lib/src/streams/retry.dart
+++ b/lib/src/streams/retry.dart
@@ -62,21 +62,24 @@ class RetryStream<T> extends Stream<T> {
   }
 
   void _retry() {
-    final onError = (Object e, StackTrace s) {
+    void onError(Object e, StackTrace s) {
       _subscription!.cancel();
       _subscription = null;
 
       _errors.add(ErrorAndStackTrace(e, s));
 
       if (count == _retryStep) {
-        [..._errors]
-            .forEach((e) => _controller.addError(e.error, e.stackTrace));
+        for (var e in [..._errors]) {
+          _controller.addError(e.error, e.stackTrace);
+        }
         _controller.close();
       } else {
         ++_retryStep;
         _retry();
       }
-    };
+    }
+
+    ;
 
     _subscription = streamFactory().listen(
       _controller.add,

--- a/lib/src/streams/retry.dart
+++ b/lib/src/streams/retry.dart
@@ -79,8 +79,6 @@ class RetryStream<T> extends Stream<T> {
       }
     }
 
-    ;
-
     _subscription = streamFactory().listen(
       _controller.add,
       onError: onError,

--- a/lib/src/streams/retry_when.dart
+++ b/lib/src/streams/retry_when.dart
@@ -89,7 +89,7 @@ class RetryWhenStream<T> extends Stream<T> {
   }
 
   void _retry() {
-    final onError = (Object originalError, StackTrace originalStacktrace) {
+    void onError(Object originalError, StackTrace originalStacktrace) {
       _cancelSubscription();
 
       Stream<void> retryStream;
@@ -110,7 +110,7 @@ class RetryWhenStream<T> extends Stream<T> {
         },
         cancelOnError: false,
       );
-    };
+    }
 
     _subscription = streamFactory().listen(
       _controller.add,

--- a/lib/src/streams/sequence_equal.dart
+++ b/lib/src/streams/sequence_equal.dart
@@ -52,11 +52,11 @@ class SequenceEqualStream<S, T> extends Stream<bool> {
     controller = StreamController<bool>(
         sync: true,
         onListen: () {
-          final emitAndClose = ([bool value = true]) => controller
+          void emitAndClose([bool value = true]) => controller
             ..add(value)
             ..close();
 
-          final compare = (Notification<S> s, Notification<T> t) {
+          bool compare(Notification<S> s, Notification<T> t) {
             if (s.kind != t.kind) {
               return false;
             }
@@ -74,7 +74,7 @@ class SequenceEqualStream<S, T> extends Stream<bool> {
                   t.errorAndStackTrace!,
                 );
             }
-          };
+          }
 
           subscription =
               ZipStream.zip2(stream.materialize(), other.materialize(), compare)

--- a/lib/src/streams/sequence_equal.dart
+++ b/lib/src/streams/sequence_equal.dart
@@ -61,14 +61,14 @@ class SequenceEqualStream<S, T> extends Stream<bool> {
               return false;
             }
             switch (s.kind) {
-              case Kind.OnData:
+              case Kind.onData:
                 return dataEquals!(
                   s.requireData,
                   t.requireData,
                 );
-              case Kind.OnDone:
+              case Kind.onDone:
                 return true;
-              case Kind.OnError:
+              case Kind.onError:
                 return errorEquals!(
                   s.errorAndStackTrace!,
                   t.errorAndStackTrace!,

--- a/lib/src/streams/switch_latest.dart
+++ b/lib/src/streams/switch_latest.dart
@@ -52,17 +52,17 @@ class SwitchLatestStream<T> extends Stream<T> {
     controller = StreamController<T>(
         sync: true,
         onListen: () {
-          final closeLeft = () {
+          void closeLeft() {
             leftClosed = true;
 
             if (rightClosed || !hasMainEvent) controller.close();
-          };
+          }
 
-          final closeRight = () {
+          void closeRight() {
             rightClosed = true;
 
             if (leftClosed) controller.close();
-          };
+          }
 
           subscription = streams.listen((stream) {
             try {

--- a/lib/src/streams/using.dart
+++ b/lib/src/streams/using.dart
@@ -34,10 +34,6 @@ class UsingStream<T, R> extends StreamView<T> {
     Stream<T> Function(R) streamFactory,
     FutureOr<void> Function(R) disposer,
   ) {
-    ArgumentError.checkNotNull(resourceFactory, 'resourceFactory');
-    ArgumentError.checkNotNull(streamFactory, 'streamFactory');
-    ArgumentError.checkNotNull(disposer, 'disposer');
-
     late StreamController<T> controller;
     var resourceCreated = false;
     late R resource;

--- a/lib/src/subjects/subject.dart
+++ b/lib/src/subjects/subject.dart
@@ -101,13 +101,14 @@ abstract class Subject<T> extends StreamView<T> implements StreamController<T> {
 
     final completer = Completer<void>();
     var isOnDoneCalled = false;
-    final complete = () {
+    void complete() {
       if (!isOnDoneCalled) {
         isOnDoneCalled = true;
         _isAddingStreamItems = false;
         completer.complete();
       }
-    };
+    }
+
     _isAddingStreamItems = true;
 
     source.listen((T event) {

--- a/lib/src/transformers/backpressure/backpressure.dart
+++ b/lib/src/transformers/backpressure/backpressure.dart
@@ -339,8 +339,9 @@ class BackpressureStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
   });
 
   @override
-  Stream<T> bind(Stream<S> stream) {
-    final sink = () => _BackpressureStreamSink(
+  Stream<T> bind(Stream<S> stream) => forwardStream(
+        stream,
+        () => _BackpressureStreamSink(
           strategy,
           windowStreamFactory,
           onWindowStart,
@@ -350,9 +351,8 @@ class BackpressureStreamTransformer<S, T> extends StreamTransformerBase<S, T> {
           ignoreEmptyWindows,
           dispatchOnClose,
           maxLengthQueue,
-        );
-    return forwardStream(stream, sink);
-  }
+        ),
+      );
 }
 
 extension _RemoveFirstNQueueExtension<T> on Queue<T> {

--- a/lib/src/transformers/delay.dart
+++ b/lib/src/transformers/delay.dart
@@ -4,6 +4,7 @@ import 'dart:collection';
 import 'package:rxdart/src/rx.dart';
 import 'package:rxdart/src/utils/forwarding_sink.dart';
 import 'package:rxdart/src/utils/forwarding_stream.dart';
+import 'package:rxdart/src/utils/subscription.dart';
 
 class _DelayStreamSink<S> extends ForwardingSink<S, S> {
   final Duration _duration;
@@ -40,21 +41,16 @@ class _DelayStreamSink<S> extends ForwardingSink<S, S> {
   }
 
   @override
-  FutureOr<void> onCancel() {
-    if (_subscriptions.isNotEmpty) {
-      return Future.wait(_subscriptions.map((t) => t.cancel()))
-          .whenComplete(() => _subscriptions.clear());
-    }
-  }
+  Future<void>? onCancel() => _subscriptions.cancelAll();
 
   @override
   void onListen() {}
 
   @override
-  void onPause() => _subscriptions.forEach((s) => s.pause());
+  void onPause() => _subscriptions.pauseAll();
 
   @override
-  void onResume() => _subscriptions.forEach((s) => s.resume());
+  void onResume() => _subscriptions.resumeAll();
 }
 
 /// The Delay operator modifies its source Stream by pausing for

--- a/lib/src/transformers/delay_when.dart
+++ b/lib/src/transformers/delay_when.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:rxdart/src/utils/forwarding_sink.dart';
 import 'package:rxdart/src/utils/forwarding_stream.dart';
+import 'package:rxdart/src/utils/subscription.dart';
 
 class _DelayWhenStreamSink<T> extends ForwardingSink<T, T> {
   final Stream<void> Function(T) itemDelaySelector;
@@ -42,7 +43,7 @@ class _DelayWhenStreamSink<T> extends ForwardingSink<T, T> {
   }
 
   @override
-  FutureOr<void> onCancel() {
+  Future<void>? onCancel() {
     final future = subscription?.cancel();
     subscription = null;
 
@@ -85,13 +86,13 @@ class _DelayWhenStreamSink<T> extends ForwardingSink<T, T> {
   @override
   void onPause() {
     subscription?.pause();
-    subscriptions.forEach((s) => s.pause());
+    subscriptions.pauseAll();
   }
 
   @override
   void onResume() {
     subscription?.resume();
-    subscriptions.forEach((s) => s.resume());
+    subscriptions.resumeAll();
   }
 }
 

--- a/lib/src/transformers/flat_map.dart
+++ b/lib/src/transformers/flat_map.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 
 import 'package:rxdart/src/utils/forwarding_sink.dart';
 import 'package:rxdart/src/utils/forwarding_stream.dart';
+import 'package:rxdart/src/utils/subscription.dart';
 
 class _FlatMapStreamSink<S, T> extends ForwardingSink<S, T> {
   final Stream<T> Function(S value) _mapper;
@@ -58,22 +59,19 @@ class _FlatMapStreamSink<S, T> extends ForwardingSink<S, T> {
   }
 
   @override
-  FutureOr<void>? onCancel() {
+  Future<void>? onCancel() {
     queue.clear();
-
-    final futures =
-        _subscriptions.map((s) => s.cancel()).toList(growable: false);
-    return futures.isNotEmpty ? Future.wait(futures) : null;
+    return _subscriptions.cancelAll();
   }
 
   @override
   void onListen() {}
 
   @override
-  void onPause() => _subscriptions.forEach((s) => s.pause());
+  void onPause() => _subscriptions.pauseAll();
 
   @override
-  void onResume() => _subscriptions.forEach((s) => s.resume());
+  void onResume() => _subscriptions.resumeAll();
 }
 
 /// Converts each emitted item into a new Stream using the given mapper function,

--- a/lib/src/transformers/materialize.dart
+++ b/lib/src/transformers/materialize.dart
@@ -8,9 +8,7 @@ class _MaterializeStreamSink<S> implements EventSink<S> {
   _MaterializeStreamSink(this._outputSink);
 
   @override
-  void add(S data) {
-    _outputSink.add(Notification.onData(data));
-  }
+  void add(S data) => _outputSink.add(Notification.onData(data));
 
   @override
   void addError(e, [st]) => _outputSink.add(Notification.onError(e, st));

--- a/lib/src/transformers/on_error_resume.dart
+++ b/lib/src/transformers/on_error_resume.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:rxdart/src/utils/forwarding_sink.dart';
 import 'package:rxdart/src/utils/forwarding_stream.dart';
+import 'package:rxdart/src/utils/subscription.dart';
 
 class _OnErrorResumeStreamSink<S> extends ForwardingSink<S, S> {
   final Stream<S> Function(Object error, StackTrace stackTrace) _recoveryFn;
@@ -44,24 +45,16 @@ class _OnErrorResumeStreamSink<S> extends ForwardingSink<S, S> {
   }
 
   @override
-  FutureOr<void> onCancel() {
-    return _recoverySubscriptions.isEmpty
-        ? null
-        : Future.wait<void>(
-            _recoverySubscriptions.map((subscription) => subscription.cancel()),
-          );
-  }
+  Future<void>? onCancel() => _recoverySubscriptions.cancelAll();
 
   @override
   void onListen() {}
 
   @override
-  void onPause() =>
-      _recoverySubscriptions.forEach((subscription) => subscription.pause());
+  void onPause() => _recoverySubscriptions.pauseAll();
 
   @override
-  void onResume() =>
-      _recoverySubscriptions.forEach((subscription) => subscription.resume());
+  void onResume() => _recoverySubscriptions.resumeAll();
 }
 
 /// Intercepts error events and switches to a recovery stream created by the

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/subscription.dart';
+
 /// Acts as a container for multiple subscriptions that can be canceled at once
 /// e.g. view subscriptions in Flutter that need to be canceled on view disposal
 ///
@@ -56,7 +58,7 @@ class CompositeSubscription {
   ///
   /// This composite can be reused after calling this method.
   void clear() {
-    _subscriptionsList.forEach((it) => it.cancel());
+    _subscriptionsList.cancelAll();
     _subscriptionsList.clear();
   }
 
@@ -70,10 +72,10 @@ class CompositeSubscription {
 
   /// Pauses all subscriptions added to this composite.
   void pauseAll([Future<void>? resumeSignal]) =>
-      _subscriptionsList.forEach((it) => it.pause(resumeSignal));
+      _subscriptionsList.pauseAll(resumeSignal);
 
   /// Resumes all subscriptions added to this composite.
-  void resumeAll() => _subscriptionsList.forEach((it) => it.resume());
+  void resumeAll() => _subscriptionsList.resumeAll();
 }
 
 /// Extends the [StreamSubscription] class with the ability to be added to [CompositeSubscription] container.

--- a/lib/src/utils/min_max.dart
+++ b/lib/src/utils/min_max.dart
@@ -19,13 +19,13 @@ Future<T> minMax<T>(Stream<T> stream, bool findMin, Comparator<T>? comparator) {
   late T accumulator;
   late Comparator<T> comparatorNotNull;
 
-  final cancelAndCompleteError = (Object e, StackTrace st) async {
+  Future<void> cancelAndCompleteError(Object e, StackTrace st) async {
     await subscription.cancel();
 
     completer.completeError(e, st);
-  };
+  }
 
-  final onData = (T element) async {
+  void onData(T element) async {
     if (seenFirst) {
       try {
         accumulator = findMin
@@ -56,14 +56,15 @@ Future<T> minMax<T>(Stream<T> stream, bool findMin, Comparator<T>? comparator) {
     } catch (e, st) {
       await cancelAndCompleteError(e, st);
     }
-  };
-  final onDone = () {
+  }
+
+  void onDone() {
     if (seenFirst) {
       completer.complete(accumulator);
     } else {
       completer.completeError(StateError('No element'));
     }
-  };
+  }
 
   subscription = stream.listen(
     onData,

--- a/lib/src/utils/notification.dart
+++ b/lib/src/utils/notification.dart
@@ -4,13 +4,13 @@ import 'package:rxdart/src/utils/value_wrapper.dart';
 /// The type of event used in [Notification]
 enum Kind {
   /// Specifies an onData event
-  OnData,
+  onData,
 
   /// Specifies an onDone event
-  OnDone,
+  onDone,
 
   /// Specifies an error event
-  OnError
+  onError
 }
 
 /// A class that encapsulates the [Kind] of event, value of the event in case of
@@ -31,20 +31,20 @@ class Notification<T> {
 
   /// Constructs a [Notification] which, depending on the [kind], wraps either
   /// [value], or [errorAndStackTrace], or neither if it is just a
-  /// [Kind.OnData] event.
+  /// [Kind.onData] event.
   const Notification(this.kind, this._value, this.errorAndStackTrace);
 
-  /// Constructs a [Notification] with [Kind.OnData] and wraps a [value]
+  /// Constructs a [Notification] with [Kind.onData] and wraps a [value]
   factory Notification.onData(T value) =>
-      Notification<T>(Kind.OnData, ValueWrapper(value), null);
+      Notification<T>(Kind.onData, ValueWrapper(value), null);
 
-  /// Constructs a [Notification] with [Kind.OnDone]
-  factory Notification.onDone() => const Notification(Kind.OnDone, null, null);
+  /// Constructs a [Notification] with [Kind.onDone]
+  factory Notification.onDone() => const Notification(Kind.onDone, null, null);
 
-  /// Constructs a [Notification] with [Kind.OnError] and wraps an [error] and [stackTrace]
+  /// Constructs a [Notification] with [Kind.onError] and wraps an [error] and [stackTrace]
   factory Notification.onError(Object error, StackTrace? stackTrace) =>
       Notification<T>(
-          Kind.OnError, null, ErrorAndStackTrace(error, stackTrace));
+          Kind.onError, null, ErrorAndStackTrace(error, stackTrace));
 
   @override
   bool operator ==(Object other) =>
@@ -64,14 +64,14 @@ class Notification<T> {
       'Notification{kind: $kind, value: ${_value?.value}, errorAndStackTrace: $errorAndStackTrace}';
 
   /// A test to determine if this [Notification] wraps an onData event
-  bool get isOnData => kind == Kind.OnData;
+  bool get isOnData => kind == Kind.onData;
 
   /// A test to determine if this [Notification] wraps an onDone event
-  bool get isOnDone => kind == Kind.OnDone;
+  bool get isOnDone => kind == Kind.onDone;
 
   /// A test to determine if this [Notification] wraps an error event
-  bool get isOnError => kind == Kind.OnError;
+  bool get isOnError => kind == Kind.onError;
 
-  /// Returns data if [kind] is [Kind.OnData], otherwise throws `"Null check operator used on a null value"` error.
+  /// Returns data if [kind] is [Kind.onData], otherwise throws `"Null check operator used on a null value"` error.
   T get requireData => _value!.value;
 }

--- a/lib/src/utils/subscription.dart
+++ b/lib/src/utils/subscription.dart
@@ -5,11 +5,18 @@ import 'dart:collection';
 extension StreamSubscriptionsIterableExtensions
     on Iterable<StreamSubscription<void>> {
   /// Pause all subscriptions.
-  void pauseAll([Future<void>? resumeSignal]) =>
-      forEach((s) => s.pause(resumeSignal));
+  void pauseAll([Future<void>? resumeSignal]) {
+    for (final s in this) {
+      s.pause(resumeSignal);
+    }
+  }
 
   /// Resume all subscriptions.
-  void resumeAll() => forEach((s) => s.resume());
+  void resumeAll() {
+    for (final s in this) {
+      s.resume();
+    }
+  }
 }
 
 /// Extensions for [List] of [StreamSubscription]s.

--- a/lib/src/utils/subscription.dart
+++ b/lib/src/utils/subscription.dart
@@ -1,15 +1,19 @@
 import 'dart:async';
 import 'dart:collection';
 
-/// Extensions for [List] of [StreamSubscription]s.
-extension StreamSubscriptionsListExtensions on List<StreamSubscription<void>> {
+/// Extensions for [Iterable] of [StreamSubscription]s.
+extension StreamSubscriptionsIterableExtensions
+    on Iterable<StreamSubscription<void>> {
   /// Pause all subscriptions.
   void pauseAll([Future<void>? resumeSignal]) =>
       forEach((s) => s.pause(resumeSignal));
 
   /// Resume all subscriptions.
   void resumeAll() => forEach((s) => s.resume());
+}
 
+/// Extensions for [List] of [StreamSubscription]s.
+extension StreamSubscriptionsListExtension on List<StreamSubscription<void>> {
   /// Cancel all subscriptions.
   Future<void>? cancelAll() {
     if (isEmpty) {
@@ -23,15 +27,7 @@ extension StreamSubscriptionsListExtensions on List<StreamSubscription<void>> {
 }
 
 /// Extensions for [Queue] of [StreamSubscription]s.
-extension StreamSubscriptionsQueueExtensions
-    on Queue<StreamSubscription<void>> {
-  /// Pause all subscriptions.
-  void pauseAll([Future<void>? resumeSignal]) =>
-      forEach((s) => s.pause(resumeSignal));
-
-  /// Resume all subscriptions.
-  void resumeAll() => forEach((s) => s.resume());
-
+extension StreamSubscriptionsQueueExtension on Queue<StreamSubscription<void>> {
   /// Cancel all subscriptions.
   Future<void>? cancelAll() {
     if (isEmpty) {

--- a/lib/src/utils/subscription.dart
+++ b/lib/src/utils/subscription.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+import 'dart:collection';
+
+/// Extensions for [List] of [StreamSubscription]s.
+extension StreamSubscriptionsListExtensions on List<StreamSubscription<void>> {
+  /// Pause all subscriptions.
+  void pauseAll([Future<void>? resumeSignal]) =>
+      forEach((s) => s.pause(resumeSignal));
+
+  /// Resume all subscriptions.
+  void resumeAll() => forEach((s) => s.resume());
+
+  /// Cancel all subscriptions.
+  Future<void>? cancelAll() {
+    if (isEmpty) {
+      return null;
+    }
+    if (length == 1) {
+      return this[0].cancel();
+    }
+    return Future.wait(map((s) => s.cancel()));
+  }
+}
+
+/// Extensions for [Queue] of [StreamSubscription]s.
+extension StreamSubscriptionsQueueExtensions
+    on Queue<StreamSubscription<void>> {
+  /// Pause all subscriptions.
+  void pauseAll([Future<void>? resumeSignal]) =>
+      forEach((s) => s.pause(resumeSignal));
+
+  /// Resume all subscriptions.
+  void resumeAll() => forEach((s) => s.resume());
+
+  /// Cancel all subscriptions.
+  Future<void>? cancelAll() {
+    if (isEmpty) {
+      return null;
+    }
+    if (length == 1) {
+      return first.cancel();
+    }
+    return Future.wait(map((s) => s.cancel()));
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,6 @@ environment:
 dev_dependencies:
   build_runner: ^1.7.0
   build_web_compilers: ^2.7.0
-  pedantic: ^1.11.0
+  lints: ^1.0.1
   stack_trace: ^1.10.0
   test: ^1.17.12

--- a/test/streams/combine_latest_test.dart
+++ b/test/streams/combine_latest_test.dart
@@ -61,8 +61,8 @@ void main() {
     var count = 0;
 
     final stream = Rx.combineLatest3(streamA, streamB, streamC,
-        (int a_value, int b_value, bool c_value) {
-      return '$a_value $b_value $c_value';
+        (int aValue, int bValue, bool cValue) {
+      return '$aValue $bValue $cValue';
     });
 
     stream.listen(expectAsync1((result) {
@@ -73,8 +73,8 @@ void main() {
 
   test('Rx.combineLatest3.single.subscription', () async {
     final stream = Rx.combineLatest3(streamA, streamB, streamC,
-        (int a_value, int b_value, bool c_value) {
-      return '$a_value $b_value $c_value';
+        (int aValue, int bValue, bool cValue) {
+      return '$aValue $bValue $cValue';
     });
 
     stream.listen(null);
@@ -296,8 +296,8 @@ void main() {
 
   test('Rx.combineLatest.asBroadcastStream', () async {
     final stream = Rx.combineLatest3(streamA, streamB, streamC,
-        (int a_value, int b_value, bool c_value) {
-      return '$a_value $b_value $c_value';
+        (int aValue, int bValue, bool cValue) {
+      return '$aValue $bValue $cValue';
     }).asBroadcastStream();
 
     // listen twice on same stream
@@ -310,8 +310,8 @@ void main() {
   test('Rx.combineLatest.error.shouldThrowA', () async {
     final streamWithError = Rx.combineLatest4(Stream.value(1), Stream.value(1),
         Stream.value(1), Stream<int>.error(Exception()),
-        (int a_value, int b_value, int c_value, dynamic _) {
-      return '$a_value $b_value $c_value $_';
+        (int aValue, int bValue, int cValue, dynamic _) {
+      return '$aValue $bValue $cValue $_';
     });
 
     streamWithError.listen(null,
@@ -323,7 +323,7 @@ void main() {
   test('Rx.combineLatest.error.shouldThrowB', () async {
     final streamWithError =
         Rx.combineLatest3(Stream.value(1), Stream.value(1), Stream.value(1),
-            (int a_value, int b_value, int c_value) {
+            (int aValue, int bValue, int cValue) {
       throw Exception('oh noes!');
     });
 
@@ -369,6 +369,6 @@ void main() {
       subscription.cancel();
     }, count: 1));
 
-    subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
+    subscription.pause(Future<void>.delayed(const Duration(milliseconds: 80)));
   });
 }

--- a/test/streams/concat_eager_test.dart
+++ b/test/streams/concat_eager_test.dart
@@ -118,7 +118,7 @@ void main() {
       subscription.cancel();
     }, count: 1));
 
-    subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
+    subscription.pause(Future<void>.delayed(const Duration(milliseconds: 80)));
   });
 
   test('Rx.concatEager.empty', () {

--- a/test/streams/fork_join_test.dart
+++ b/test/streams/fork_join_test.dart
@@ -83,23 +83,15 @@ void main() {
   });
 
   test('Rx.forkJoin3', () async {
-    final stream = Rx.forkJoin3(
-        streamA,
-        streamB,
-        streamC,
-        (int a_value, int b_value, bool c_value) =>
-            '$a_value $b_value $c_value');
+    final stream = Rx.forkJoin3(streamA, streamB, streamC,
+        (int aValue, int bValue, bool cValue) => '$aValue $bValue $cValue');
 
     await expectLater(stream, emitsInOrder(<dynamic>['2 4 true', emitsDone]));
   });
 
   test('Rx.forkJoin3.single.subscription', () async {
-    final stream = Rx.forkJoin3(
-        streamA,
-        streamB,
-        streamC,
-        (int a_value, int b_value, bool c_value) =>
-            '$a_value $b_value $c_value');
+    final stream = Rx.forkJoin3(streamA, streamB, streamC,
+        (int aValue, int bValue, bool cValue) => '$aValue $bValue $cValue');
 
     await expectLater(
       stream,
@@ -326,12 +318,9 @@ void main() {
   });
 
   test('Rx.forkJoin.asBroadcastStream', () async {
-    final stream = Rx.forkJoin3(
-        streamA,
-        streamB,
-        streamC,
-        (int a_value, int b_value, bool c_value) =>
-            '$a_value $b_value $c_value').asBroadcastStream();
+    final stream = Rx.forkJoin3(streamA, streamB, streamC,
+            (int aValue, int bValue, bool cValue) => '$aValue $bValue $cValue')
+        .asBroadcastStream();
 
 // listen twice on same stream
     stream.listen(null);
@@ -346,8 +335,8 @@ void main() {
         Stream.value(1),
         Stream.value(1),
         Stream<int>.error(Exception()),
-        (int a_value, int b_value, int c_value, dynamic _) =>
-            '$a_value $b_value $c_value $_');
+        (int aValue, int bValue, int cValue, dynamic _) =>
+            '$aValue $bValue $cValue $_');
 
     streamWithError.listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -358,7 +347,7 @@ void main() {
   test('Rx.forkJoin.error.shouldThrowB', () async {
     final streamWithError =
         Rx.forkJoin3(Stream.value(1), Stream.value(1), Stream.value(1),
-            (int a_value, int b_value, int c_value) {
+            (int aValue, int bValue, int cValue) {
       throw Exception('oh noes!');
     });
 

--- a/test/streams/merge_test.dart
+++ b/test/streams/merge_test.dart
@@ -61,7 +61,7 @@ void main() {
       subscription.cancel();
     }, count: 1));
 
-    subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
+    subscription.pause(Future<void>.delayed(const Duration(milliseconds: 80)));
   });
 
   test('Rx.merge.empty', () {

--- a/test/streams/never_test.dart
+++ b/test/streams/never_test.dart
@@ -7,7 +7,7 @@ void main() {
   test('NeverStream', () async {
     var onDataCalled = false, onDoneCalled = false, onErrorCalled = false;
 
-    final stream = NeverStream<Null>();
+    final stream = NeverStream<Never>();
 
     final subscription = stream.listen(
         expectAsync1((_) {
@@ -20,7 +20,7 @@ void main() {
           onDataCalled = true;
         }, count: 0));
 
-    await Future<Null>.delayed(Duration(milliseconds: 10));
+    await Future<void>.delayed(Duration(milliseconds: 10));
 
     await subscription.cancel();
 
@@ -32,7 +32,7 @@ void main() {
   });
 
   test('NeverStream.single.subscription', () async {
-    final stream = NeverStream<Null>();
+    final stream = NeverStream<void>();
 
     stream.listen(null);
     await expectLater(() => stream.listen(null), throwsA(isStateError));
@@ -41,7 +41,7 @@ void main() {
   test('Rx.never', () async {
     var onDataCalled = false, onDoneCalled = false, onErrorCalled = false;
 
-    final stream = Rx.never<Null>();
+    final stream = Rx.never<Never>();
 
     final subscription = stream.listen(
         expectAsync1((_) {
@@ -54,7 +54,7 @@ void main() {
           onDataCalled = true;
         }, count: 0));
 
-    await Future<Null>.delayed(Duration(milliseconds: 10));
+    await Future<void>.delayed(Duration(milliseconds: 10));
 
     await subscription.cancel();
 

--- a/test/streams/race_test.dart
+++ b/test/streams/race_test.dart
@@ -4,7 +4,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 Stream<int> getDelayedStream(int delay, int value) async* {
-  final completer = Completer<Null>();
+  final completer = Completer<void>();
 
   Timer(Duration(milliseconds: delay), () => completer.complete());
 
@@ -52,7 +52,7 @@ void main() {
   });
 
   test('Rx.race.shouldThrowB', () async {
-    final stream = Rx.race([Stream<Null>.error(Exception('oh noes!'))]);
+    final stream = Rx.race([Stream<void>.error(Exception('oh noes!'))]);
 
     // listen twice on same stream
     stream.listen(null,
@@ -73,7 +73,7 @@ void main() {
       subscription.cancel();
     }, count: 1));
 
-    subscription.pause(Future<Null>.delayed(const Duration(milliseconds: 80)));
+    subscription.pause(Future<void>.delayed(const Duration(milliseconds: 80)));
   });
 
   test('Rx.race.empty', () {

--- a/test/streams/replay_connectable_stream_test.dart
+++ b/test/streams/replay_connectable_stream_test.dart
@@ -93,7 +93,7 @@ void main() {
       expect(stream, emitsInOrder(<int>[1, 2, 3]));
       expect(stream, emitsInOrder(<int>[1, 2, 3]));
 
-      await Future<Null>.delayed(Duration(milliseconds: 200));
+      await Future<void>.delayed(Duration(milliseconds: 200));
 
       expect(stream, emitsInOrder(<int>[2, 3]));
     });

--- a/test/streams/retry_when_test.dart
+++ b/test/streams/retry_when_test.dart
@@ -106,7 +106,7 @@ void main() {
 
   test('RetryWhenStream.cancel.ensureSubStreamCancels', () async {
     var isCancelled = false, didStopEmitting = true;
-    final subStream = (Object e, StackTrace s) =>
+    Stream<int> subStream(Object e, StackTrace s) =>
         Stream.periodic(const Duration(milliseconds: 100), (count) => count)
             .doOnData((_) {
           if (isCancelled) {
@@ -169,7 +169,7 @@ Stream<int> Function() _sourceStream(int i, [int? throwAt]) {
 Stream<void> _alwaysThrow(dynamic e, StackTrace s) =>
     Stream<void>.error(Error(), StackTrace.fromString('S'));
 
-Stream<void> _neverThrow(dynamic e, StackTrace s) => Stream.value('');
+Stream<void> _neverThrow(dynamic e, StackTrace s) => Stream.value(null);
 
 Stream<int> Function() _getStreamWithExtras(int failCount) {
   var count = 0;
@@ -192,18 +192,18 @@ Stream<int> Function() _getStreamWithExtras(int failCount) {
 
 /// Returns an [Iterable] sequence of [int]s.
 ///
-/// If only one argument is provided, [start_or_stop] is the upper bound for
+/// If only one argument is provided, [startOrStop] is the upper bound for
 /// the sequence. If two or more arguments are provided, [stop] is the upper
 /// bound.
 ///
-/// The sequence starts at 0 if one argument is provided, or [start_or_stop] if
+/// The sequence starts at 0 if one argument is provided, or [startOrStop] if
 /// two or more arguments are provided. The sequence increments by 1, or [step]
 /// if provided. [step] can be negative, in which case the sequence counts down
 /// from the starting point and [stop] must be less than the starting point so
 /// that it becomes the lower bound.
-Iterable<int> range(int start_or_stop, [int? stop, int? step]) sync* {
-  final start = stop == null ? 0 : start_or_stop;
-  stop ??= start_or_stop;
+Iterable<int> range(int startOrStop, [int? stop, int? step]) sync* {
+  final start = stop == null ? 0 : startOrStop;
+  stop ??= startOrStop;
   step ??= 1;
 
   if (step == 0) throw ArgumentError('step cannot be 0');

--- a/test/streams/timer_test.dart
+++ b/test/streams/timer_test.dart
@@ -68,7 +68,8 @@ void main() {
 
     void startWatch() => watch = Stopwatch()..start();
 
-    final delay = () => Future<void>.delayed(const Duration(milliseconds: 200));
+    Future<void> delay() =>
+        Future<void>.delayed(const Duration(milliseconds: 200));
 
     void stopWatch() => elapses = elapses + watch.elapsed;
 

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -91,7 +91,7 @@ void main() {
       expect(stream, emitsInOrder(const <int>[1, 2, 3]));
       expect(stream, emitsInOrder(const <int>[1, 2, 3]));
 
-      await Future<Null>.delayed(Duration(milliseconds: 200));
+      await Future<void>.delayed(Duration(milliseconds: 200));
 
       expect(stream, emits(3));
     });
@@ -105,7 +105,7 @@ void main() {
       expect(stream, emitsInOrder(const <int>[3]));
       expect(stream, emitsInOrder(const <int>[3]));
 
-      await Future<Null>.delayed(Duration(milliseconds: 200));
+      await Future<void>.delayed(Duration(milliseconds: 200));
 
       expect(stream, emits(3));
     });
@@ -119,7 +119,7 @@ void main() {
       expect(stream, emitsInOrder(const <int?>[null]));
       expect(stream, emitsInOrder(const <int?>[null]));
 
-      await Future<Null>.delayed(Duration(milliseconds: 200));
+      await Future<void>.delayed(Duration(milliseconds: 200));
 
       expect(stream, emits(null));
     });

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -344,10 +344,10 @@ void main() {
     test('allows items to be added once addStream completes with an error',
         () async {
       // ignore: close_sinks
-      final subject = BehaviorSubject<void>();
+      final subject = BehaviorSubject<int>();
 
       unawaited(subject
-          .addStream(Stream<void>.error(Exception()), cancelOnError: true)
+          .addStream(Stream<int>.error(Exception()), cancelOnError: true)
           .whenComplete(() => subject.add(1)));
 
       await expectLater(subject.stream,
@@ -405,7 +405,7 @@ void main() {
     });
 
     test('returns onListen callback set in constructor', () async {
-      final testOnListen = () {};
+      void testOnListen() {}
       // ignore: close_sinks
       final subject = BehaviorSubject<void>(onListen: testOnListen);
 
@@ -413,7 +413,7 @@ void main() {
     });
 
     test('sets onListen callback', () async {
-      final testOnListen = () {};
+      void testOnListen() {}
       // ignore: close_sinks
       final subject = BehaviorSubject<void>();
 
@@ -425,7 +425,7 @@ void main() {
     });
 
     test('returns onCancel callback set in constructor', () async {
-      final onCancel = () => Future<void>.value(null);
+      Future<void> onCancel() => Future<void>.value(null);
       // ignore: close_sinks
       final subject = BehaviorSubject<void>(onCancel: onCancel);
 
@@ -433,7 +433,7 @@ void main() {
     });
 
     test('sets onCancel callback', () async {
-      final testOnCancel = () {};
+      void testOnCancel() {}
       // ignore: close_sinks
       final subject = BehaviorSubject<void>();
 
@@ -810,7 +810,7 @@ void main() {
     test('rxdart #477/#500 - a', () async {
       final a = BehaviorSubject.seeded('a')
           .switchMap((_) => BehaviorSubject.seeded('a'))
-            ..listen(print);
+        ..listen(print);
       await pumpEventQueue();
       expect(await a.first, 'a');
     });
@@ -819,7 +819,7 @@ void main() {
       final b = BehaviorSubject.seeded('b')
           .map((_) => 'b')
           .switchMap((_) => BehaviorSubject.seeded('b'))
-            ..listen(print);
+        ..listen(print);
       await pumpEventQueue();
       expect(await b.first, 'b');
     });

--- a/test/subject/publish_subject_test.dart
+++ b/test/subject/publish_subject_test.dart
@@ -5,7 +5,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:rxdart/subjects.dart';
 import 'package:test/test.dart';
 
-typedef AsyncVoidCallBack = Future<Null> Function();
+typedef AsyncVoidCallBack = Future<void> Function();
 
 void main() {
   group('PublishSubject', () {
@@ -169,7 +169,7 @@ void main() {
     });
 
     test('returns onListen callback set in constructor', () async {
-      final testOnListen = () {};
+      void testOnListen() {}
       // ignore: close_sinks
       final subject = PublishSubject<int>(onListen: testOnListen);
 
@@ -177,7 +177,7 @@ void main() {
     });
 
     test('sets onListen callback', () async {
-      final testOnListen = () {};
+      void testOnListen() {}
       // ignore: close_sinks
       final subject = PublishSubject<int>();
 
@@ -189,7 +189,7 @@ void main() {
     });
 
     test('returns onCancel callback set in constructor', () async {
-      final onCancel = () => Future<Null>.value(null);
+      Future<void> onCancel() => Future<void>.value(null);
       // ignore: close_sinks
       final subject = PublishSubject<int>(onCancel: onCancel);
 
@@ -197,7 +197,7 @@ void main() {
     });
 
     test('sets onCancel callback', () async {
-      final testOnCancel = () {};
+      void testOnCancel() {}
       // ignore: close_sinks
       final subject = PublishSubject<int>();
 

--- a/test/subject/replay_subject_test.dart
+++ b/test/subject/replay_subject_test.dart
@@ -264,7 +264,7 @@ void main() {
     });
 
     test('returns onListen callback set in constructor', () async {
-      final testOnListen = () {};
+      void testOnListen() {}
 
       final subject = ReplaySubject<int>(onListen: testOnListen);
 
@@ -272,7 +272,7 @@ void main() {
     });
 
     test('sets onListen callback', () async {
-      final testOnListen = () {};
+      void testOnListen() {}
 
       final subject = ReplaySubject<int>();
 
@@ -284,7 +284,7 @@ void main() {
     });
 
     test('returns onCancel callback set in constructor', () async {
-      final onCancel = () => Future<void>.value(null);
+      Future<void> onCancel() => Future<void>.value(null);
 
       final subject = ReplaySubject<void>(onCancel: onCancel);
 
@@ -292,7 +292,7 @@ void main() {
     });
 
     test('sets onCancel callback', () async {
-      final testOnCancel = () {};
+      void testOnCancel() {}
 
       final subject = ReplaySubject<void>();
 

--- a/test/transformers/backpressure/buffer_test.dart
+++ b/test/transformers/backpressure/buffer_test.dart
@@ -7,7 +7,7 @@ Stream<int> getStream(int n) async* {
   var k = 0;
 
   while (k < n) {
-    await Future<Null>.delayed(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
 
     yield k++;
   }
@@ -17,7 +17,7 @@ void main() {
   test('Rx.buffer', () async {
     await expectLater(
         getStream(4).buffer(
-            Stream<Null>.periodic(const Duration(milliseconds: 160)).take(3)),
+            Stream<void>.periodic(const Duration(milliseconds: 160)).take(3)),
         emitsInOrder(<dynamic>[
           const [0, 1],
           const [2, 3],
@@ -28,9 +28,9 @@ void main() {
   test('Rx.buffer.sampleBeforeEvent.shouldEmit', () async {
     await expectLater(
         Stream.fromFuture(
-            Future<Null>.delayed(const Duration(milliseconds: 200))
+            Future<void>.delayed(const Duration(milliseconds: 200))
                 .then((_) => 'end')).startWith('start').buffer(
-            Stream<Null>.periodic(const Duration(milliseconds: 40)).take(10)),
+            Stream<void>.periodic(const Duration(milliseconds: 40)).take(10)),
         emitsInOrder(<dynamic>[
           const ['start'], // after 40ms
           const <String>[], // 80ms
@@ -42,13 +42,17 @@ void main() {
   });
 
   test('Rx.buffer.shouldClose', () async {
-    final controller = StreamController<int>()..add(0)..add(1)..add(2)..add(3);
+    final controller = StreamController<int>()
+      ..add(0)
+      ..add(1)
+      ..add(2)
+      ..add(3);
 
     scheduleMicrotask(controller.close);
 
     await expectLater(
         controller.stream
-            .buffer(Stream<Null>.periodic(const Duration(seconds: 3)))
+            .buffer(Stream<void>.periodic(const Duration(seconds: 3)))
             .take(1),
         emitsInOrder(<dynamic>[
           const [0, 1, 2, 3], // done
@@ -58,7 +62,7 @@ void main() {
 
   test('Rx.buffer.reusable', () async {
     final transformer = BufferStreamTransformer<int>((_) =>
-        Stream<Null>.periodic(const Duration(milliseconds: 160))
+        Stream<void>.periodic(const Duration(milliseconds: 160))
             .take(3)
             .asBroadcastStream());
 
@@ -81,7 +85,7 @@ void main() {
 
   test('Rx.buffer.asBroadcastStream', () async {
     final stream = getStream(4).asBroadcastStream().buffer(
-        Stream<Null>.periodic(const Duration(milliseconds: 160))
+        Stream<void>.periodic(const Duration(milliseconds: 160))
             .take(10)
             .asBroadcastStream());
 
@@ -99,8 +103,8 @@ void main() {
 
   test('Rx.buffer.error.shouldThrowA', () async {
     await expectLater(
-        Stream<Null>.error(Exception())
-            .buffer(Stream<Null>.periodic(const Duration(milliseconds: 160))),
+        Stream<void>.error(Exception())
+            .buffer(Stream<void>.periodic(const Duration(milliseconds: 160))),
         emitsError(isException));
   });
 }

--- a/test/transformers/backpressure/buffer_time_test.dart
+++ b/test/transformers/backpressure/buffer_time_test.dart
@@ -10,7 +10,7 @@ Stream<int> getStream(int n) async* {
   yield 0;
 
   while (k < n) {
-    yield await Future<Null>.delayed(const Duration(milliseconds: 100))
+    yield await Future<void>.delayed(const Duration(milliseconds: 100))
         .then((_) => k++);
   }
 }
@@ -27,7 +27,11 @@ void main() {
   });
 
   test('Rx.bufferTime.shouldClose', () async {
-    final controller = StreamController<int>()..add(0)..add(1)..add(2)..add(3);
+    final controller = StreamController<int>()
+      ..add(0)
+      ..add(1)
+      ..add(2)
+      ..add(3);
 
     scheduleMicrotask(controller.close);
 

--- a/test/transformers/backpressure/throttle_test.dart
+++ b/test/transformers/backpressure/throttle_test.dart
@@ -145,8 +145,8 @@ void main() {
     await expectLater(
         controller.stream, emitsInOrder(<dynamic>[1, 4, emitsDone]));
 
-    await Future<Null>.delayed(const Duration(milliseconds: 150)).whenComplete(
+    await Future<void>.delayed(const Duration(milliseconds: 150)).whenComplete(
         () => subscription
-            .pause(Future<Null>.delayed(const Duration(milliseconds: 150))));
+            .pause(Future<void>.delayed(const Duration(milliseconds: 150))));
   });
 }

--- a/test/transformers/backpressure/throttle_time_test.dart
+++ b/test/transformers/backpressure/throttle_time_test.dart
@@ -70,9 +70,9 @@ void main() {
     await expectLater(
         controller.stream, emitsInOrder(<dynamic>[1, 4, emitsDone]));
 
-    await Future<Null>.delayed(const Duration(milliseconds: 150)).whenComplete(
+    await Future<void>.delayed(const Duration(milliseconds: 150)).whenComplete(
         () => subscription
-            .pause(Future<Null>.delayed(const Duration(milliseconds: 150))));
+            .pause(Future<void>.delayed(const Duration(milliseconds: 150))));
   });
 
   test('issue/417 trailing true', () async {

--- a/test/transformers/backpressure/window_test.dart
+++ b/test/transformers/backpressure/window_test.dart
@@ -7,7 +7,7 @@ Stream<int> getStream(int n) async* {
   var k = 0;
 
   while (k < n) {
-    await Future<Null>.delayed(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
 
     yield k++;
   }
@@ -17,7 +17,7 @@ void main() {
   test('Rx.window', () async {
     await expectLater(
         getStream(4)
-            .window(Stream<Null>.periodic(const Duration(milliseconds: 160))
+            .window(Stream<void>.periodic(const Duration(milliseconds: 160))
                 .take(3))
             .asyncMap((stream) => stream.toList()),
         emitsInOrder(<dynamic>[
@@ -30,10 +30,10 @@ void main() {
   test('Rx.window.sampleBeforeEvent.shouldEmit', () async {
     await expectLater(
         Stream.fromFuture(
-                Future<Null>.delayed(const Duration(milliseconds: 200))
+                Future<void>.delayed(const Duration(milliseconds: 200))
                     .then((_) => 'end'))
             .startWith('start')
-            .window(Stream<Null>.periodic(const Duration(milliseconds: 40))
+            .window(Stream<void>.periodic(const Duration(milliseconds: 40))
                 .take(10))
             .asyncMap((stream) => stream.toList()),
         emitsInOrder(<dynamic>[
@@ -47,13 +47,17 @@ void main() {
   });
 
   test('Rx.window.shouldClose', () async {
-    final controller = StreamController<int>()..add(0)..add(1)..add(2)..add(3);
+    final controller = StreamController<int>()
+      ..add(0)
+      ..add(1)
+      ..add(2)
+      ..add(3);
 
     scheduleMicrotask(controller.close);
 
     await expectLater(
         controller.stream
-            .window(Stream<Null>.periodic(const Duration(seconds: 3)))
+            .window(Stream<void>.periodic(const Duration(seconds: 3)))
             .asyncMap((stream) => stream.toList())
             .take(1),
         emitsInOrder(<dynamic>[
@@ -64,7 +68,7 @@ void main() {
 
   test('Rx.window.reusable', () async {
     final transformer = WindowStreamTransformer<int>((_) =>
-        Stream<Null>.periodic(const Duration(milliseconds: 160))
+        Stream<void>.periodic(const Duration(milliseconds: 160))
             .take(3)
             .asBroadcastStream());
 
@@ -92,7 +96,7 @@ void main() {
   test('Rx.window.asBroadcastStream', () async {
     final future = getStream(4)
         .asBroadcastStream()
-        .window(Stream<Null>.periodic(const Duration(milliseconds: 160))
+        .window(Stream<void>.periodic(const Duration(milliseconds: 160))
             .take(10)
             .asBroadcastStream())
         .drain<void>();
@@ -104,8 +108,8 @@ void main() {
 
   test('Rx.window.error.shouldThrowA', () async {
     await expectLater(
-        Stream<Null>.error(Exception())
-            .window(Stream<Null>.periodic(const Duration(milliseconds: 160))),
+        Stream<void>.error(Exception())
+            .window(Stream<void>.periodic(const Duration(milliseconds: 160))),
         emitsError(isException));
   });
 }

--- a/test/transformers/backpressure/window_time_test.dart
+++ b/test/transformers/backpressure/window_time_test.dart
@@ -10,7 +10,7 @@ Stream<int> getStream(int n) async* {
   yield 0;
 
   while (k < n) {
-    yield await Future<Null>.delayed(const Duration(milliseconds: 100))
+    yield await Future<void>.delayed(const Duration(milliseconds: 100))
         .then((_) => k++);
   }
 }
@@ -29,7 +29,11 @@ void main() {
   });
 
   test('Rx.windowTime.shouldClose', () async {
-    final controller = StreamController<int>()..add(0)..add(1)..add(2)..add(3);
+    final controller = StreamController<int>()
+      ..add(0)
+      ..add(1)
+      ..add(2)
+      ..add(3);
 
     scheduleMicrotask(controller.close);
 

--- a/test/transformers/delay_when_test.dart
+++ b/test/transformers/delay_when_test.dart
@@ -86,7 +86,7 @@ void main() {
   test('Rx.delayWhen.shouldBeDelayed.listenDelay', () {
     var value = 1;
 
-    final onData = (TimeInterval<int> result) {
+    void onData(TimeInterval<int> result) {
       expect(result.value, value++);
 
       if (result.value == 1) {
@@ -100,7 +100,7 @@ void main() {
           lessThanOrEqualTo(20),
         ); // should be near instantaneous
       }
-    };
+    }
 
     _getStream()
         .delayWhen(

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -123,7 +123,9 @@ void main() {
     });
 
     test('onData only emits correctly with ReplaySubject', () async {
-      final controller = ReplaySubject<int>(sync: true)..add(1)..add(2);
+      final controller = ReplaySubject<int>(sync: true)
+        ..add(1)
+        ..add(2);
       final actual = <int>[];
 
       await controller.close();
@@ -193,7 +195,10 @@ void main() {
         'calls onListen once when multiple subscribers open, without cancelling',
         () async {
       var onListenCallCount = 0;
-      final sc = StreamController<int>.broadcast()..add(1)..add(2)..add(3);
+      final sc = StreamController<int>.broadcast()
+        ..add(1)
+        ..add(2)
+        ..add(3);
 
       final stream = sc.stream.doOnListen(() => onListenCallCount++);
 
@@ -208,7 +213,10 @@ void main() {
         'calls onListen every time after all previous subscribers have cancelled',
         () async {
       var onListenCallCount = 0;
-      final sc = StreamController<int>.broadcast()..add(1)..add(2)..add(3);
+      final sc = StreamController<int>.broadcast()
+        ..add(1)
+        ..add(2)
+        ..add(3);
 
       final stream = sc.stream.doOnListen(() => onListenCallCount++);
 
@@ -330,16 +338,16 @@ void main() {
               onError: expectAsync2(
                 (Exception e, StackTrace s) => expect(e, isException),
               ))
-            ..pause()
-            ..resume();
+        ..pause()
+        ..resume();
 
       Stream.value(1)
           .doOnResume(() => throw Exception('catch me if you can! doOnResume'))
           .listen(null,
               onError: expectAsync2(
                   (Exception e, StackTrace s) => expect(e, isException)))
-            ..pause()
-            ..resume();
+        ..pause()
+        ..resume();
     });
 
     test(
@@ -445,14 +453,14 @@ void main() {
       ];
       late StreamSubscription<int> subscription;
 
-      final addToResult = (String value) {
+      void addToResult(String value) {
         result.add(value);
 
         if (result.length == expectedOutput.length) {
           subscription.cancel();
           completer.complete();
         }
-      };
+      }
 
       subscription = Stream.value(1)
           .exhaustMap((_) => stream.doOnData((data) => addToResult('A: $data')))

--- a/test/transformers/ignore_elements_test.dart
+++ b/test/transformers/ignore_elements_test.dart
@@ -38,14 +38,14 @@ void main() {
     final ignored = _getStream().ignoreElements();
 
     expect(ignored, isA<Stream<void>>());
-    expect(ignored, isA<Stream<Null>>());
+    expect(ignored, isA<Stream<Null>>()); // ignore: prefer_void_to_null
     expect(ignored, isA<Stream<int>>());
     expect(ignored, isA<Stream<int?>>());
     expect(ignored, isA<Stream<Object>>());
     expect(ignored, isA<Stream<Object?>>());
 
     ignored as Stream<void>; // ignore: unnecessary_cast
-    ignored as Stream<Null>; // ignore: unnecessary_cast
+    ignored as Stream<void>; // ignore: unnecessary_cast, prefer_void_to_null
     ignored as Stream<int>; // ignore: unnecessary_cast
     ignored as Stream<int?>; // ignore: unnecessary_cast
     ignored as Stream<Object>; // ignore: unnecessary_cast

--- a/test/transformers/ignore_elements_test.dart
+++ b/test/transformers/ignore_elements_test.dart
@@ -45,7 +45,7 @@ void main() {
     expect(ignored, isA<Stream<Object?>>());
 
     ignored as Stream<void>; // ignore: unnecessary_cast
-    ignored as Stream<void>; // ignore: unnecessary_cast, prefer_void_to_null
+    ignored as Stream<Null>; // ignore: unnecessary_cast, prefer_void_to_null
     ignored as Stream<int>; // ignore: unnecessary_cast
     ignored as Stream<int?>; // ignore: unnecessary_cast
     ignored as Stream<Object>; // ignore: unnecessary_cast

--- a/test/transformers/materialize_test.dart
+++ b/test/transformers/materialize_test.dart
@@ -74,8 +74,8 @@ void main() {
         Notification<int>.onDone()
       ]);
     }))
-          ..pause()
-          ..resume();
+      ..pause()
+      ..resume();
   });
 
   test('Rx.materialize accidental broadcast', () async {

--- a/test/transformers/skip_last_test.dart
+++ b/test/transformers/skip_last_test.dart
@@ -39,13 +39,13 @@ void main() {
   });
 
   test('Rx.skipLast.countCantBeNegative', () async {
-    final stream = () => Stream.fromIterable([1, 2, 3, 4, 5]).skipLast(-1);
+    Stream<int> stream() => Stream.fromIterable([1, 2, 3, 4, 5]).skipLast(-1);
     expect(stream, throwsA(isArgumentError));
   });
 
   test('Rx.skipLast.reusable', () async {
     final transformer = SkipLastStreamTransformer<int>(1);
-    final stream = () => Stream.fromIterable([1, 2, 3, 4, 5]).skipLast(2);
+    Stream<int> stream() => Stream.fromIterable([1, 2, 3, 4, 5]).skipLast(2);
     var valueA = 1, valueB = 1;
 
     stream().transform(transformer).listen(expectAsync1(

--- a/test/transformers/take_last_test.dart
+++ b/test/transformers/take_last_test.dart
@@ -30,13 +30,13 @@ void main() {
   });
 
   test('Rx.takeLast.countCantBeNegative', () async {
-    final stream = () => Stream.fromIterable([1, 2, 3, 4, 5]).takeLast(-1);
+    Stream<int> stream() => Stream.fromIterable([1, 2, 3, 4, 5]).takeLast(-1);
     expect(stream, throwsA(isArgumentError));
   });
 
   test('Rx.takeLast.reusable', () async {
     final transformer = TakeLastStreamTransformer<int>(3);
-    final stream = () => Stream.fromIterable([1, 2, 3, 4, 5]).takeLast(3);
+    Stream<int> stream() => Stream.fromIterable([1, 2, 3, 4, 5]).takeLast(3);
     var valueA = 3, valueB = 3;
 
     stream().transform(transformer).listen(expectAsync1((result) {


### PR DESCRIPTION
- `pedantic` is now deprecated.
- Migrate to `lints` and `flutter_lints`
- Rename
  - `Kind.OnData` to `Kind.onData`
  - `Kind.OnError` to `Kind.onError`
  - `Kind.OnDone` to `Kind.onDone`
 - Update Flutter example to Null-safety, flutter 2.5