### PR TITLE
fix(example): SearchResultItem.fromJson type error

### DIFF
--- a/example/flutter/github_search/lib/github_api.dart
+++ b/example/flutter/github_search/lib/github_api.dart
@@ -62,11 +62,11 @@ class SearchResultItem {
 
   SearchResultItem(this.fullName, this.url, this.avatarUrl);
 
-  factory SearchResultItem.fromJson(Map<String, Object> json) {
+  factory SearchResultItem.fromJson(Map<String, dynamic> json) {
     return SearchResultItem(
       json['full_name'] as String,
       json['html_url'] as String,
-      (json['owner'] as Map<String, Object>)['avatar_url'] as String,
+      (json['owner'] as Map<String, dynamic>)['avatar_url'] as String,
     );
   }
 }


### PR DESCRIPTION
If it uses Object will error.
My sdk is not >2.14, So I am not sure it is a bug, but I think it is a bug. because I searched history commit, no one changed this.  see: #628 