### PR TITLE
refactor(Connectable): introduce AbstractConnectableStream

### DIFF
--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -485,25 +485,3 @@ extension ConnectableStreamExtensions<T> on Stream<T> {
   ReplayStream<T> shareReplay({int? maxSize}) =>
       publishReplay(maxSize: maxSize).refCount();
 }
-
-void main() async {
-  final s = StreamController<int>.broadcast();
-  final shared$ = s.stream.share();
-
-  var sub = shared$.listen(print);
-  s.add(1);
-  s.add(2);
-  await Future(() {});
-
-  await sub.cancel();
-  await Future<void>.delayed(const Duration(milliseconds: 200));
-  s.add(-1);
-
-  shared$.listen(print);
-
-  s.add(3);
-  s.add(4);
-  await Future(() {});
-
-  await sub.cancel();
-}

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -514,6 +514,24 @@ extension ConnectableStreamExtensions<T> on Stream<T> {
       publishReplay(maxSize: maxSize).refCount();
 }
 
-void main() {
-  final s = PublishSubject<int>();
+void main() async {
+  final s = StreamController<int>.broadcast();
+  final shared$ = s.stream.share();
+
+  var sub = shared$.listen(print);
+  s.add(1);
+  s.add(2);
+  await Future(() {});
+
+  await sub.cancel();
+  await Future<void>.delayed(const Duration(milliseconds: 200));
+  s.add(-1);
+
+  shared$.listen(print);
+
+  s.add(3);
+  s.add(4);
+  await Future(() {});
+
+  await sub.cancel();
 }

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -62,7 +62,7 @@ abstract class AbstractConnectableStream<T, S extends Subject<T>,
 
     _wasListened = true;
 
-    onListen(_subject);
+    onListen(_subject, _source);
     return ConnectableStreamSubscription<T>(
       _source.listen(
         _subject.add,
@@ -128,7 +128,7 @@ abstract class AbstractConnectableStream<T, S extends Subject<T>,
   /// An extension point for sub-classes.
   /// This method called when listening to single-subscription at the first time
   /// or broadcast Stream at any times.
-  void onListen(S subject) {}
+  void onListen(S subject, Stream<T> source) {}
 }
 
 /// A [ConnectableStream] that converts a single-subscription Stream into

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -70,18 +70,13 @@ abstract class AbstractConnectableStream<T, S extends Subject<T>,
   );
 
   bool _checkUsed(_ConnectableStreamUse use) {
-    if (_use == null) {
-      _use = use;
-      return false;
+    if (_use != null && _use != use) {
+      throw StateError(
+          'Do not mix autoConnect(), connect() and refCount() together, must use one of them!');
     }
-
-    if (_use == use) {
-      _use = use;
-      return true;
-    }
-
-    throw StateError(
-        'Call autoConnect() or connect() or refCount() only once!');
+    final shouldReuse = _use == null || _use == use;
+    _use = use;
+    return shouldReuse;
   }
 
   @override

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -265,7 +265,7 @@ extension ConnectableStreamExtensions<T> on Stream<T> {
   /// // Subject
   /// subscription.cancel();
   /// ```
-  ConnectableStream<T> publish() =>
+  PublishConnectableStream<T> publish() =>
       PublishConnectableStream<T>(this, sync: true);
 
   /// Convert the current Stream into a [ValueConnectableStream]

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -72,11 +72,12 @@ abstract class AbstractConnectableStream<T, S extends Subject<T>,
   bool _checkUsed(_ConnectableStreamUse use) {
     if (_use != null && _use != use) {
       throw StateError(
-          'Do not mix autoConnect(), connect() and refCount() together, must use one of them!');
+          'Do not mix autoConnect, connect and refCount together, you should only use one of them!');
     }
-    final shouldReuse = _use == null || _use == use;
+
+    final reuseAllowed = _use != null && _use == use;
     _use = use;
-    return shouldReuse;
+    return reuseAllowed;
   }
 
   @override

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -206,12 +206,9 @@ class ConnectableStreamSubscription<T> extends StreamSubscription<T> {
       this._source, this._subject, this._closeSubject);
 
   @override
-  Future<dynamic> cancel() {
-    print('[Cancel] $_closeSubject');
-    return _closeSubject
-        ? _source.cancel().then<void>((_) => _subject.close())
-        : _source.cancel();
-  }
+  Future<dynamic> cancel() => _closeSubject
+      ? _source.cancel().then<void>((_) => _subject.close())
+      : _source.cancel();
 
   @override
   Never asFuture<E>([E? futureValue]) => _unsupportedError();

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -61,6 +61,8 @@ abstract class AbstractConnectableStream<T, S extends Subject<T>,
     }
 
     _wasListened = true;
+
+    onListen(_subject);
     return ConnectableStreamSubscription<T>(
       _source.listen(
         _subject.add,
@@ -121,6 +123,12 @@ abstract class AbstractConnectableStream<T, S extends Subject<T>,
 
     return _subject as R;
   }
+
+  /// @protected
+  /// An extension point for sub-classes.
+  /// This method called when listening to single-subscription at the first time
+  /// or broadcast Stream at any times.
+  void onListen(S subject) {}
 }
 
 /// A [ConnectableStream] that converts a single-subscription Stream into
@@ -504,4 +512,8 @@ extension ConnectableStreamExtensions<T> on Stream<T> {
   /// ```
   ReplayStream<T> shareReplay({int? maxSize}) =>
       publishReplay(maxSize: maxSize).refCount();
+}
+
+void main() {
+  final s = PublishSubject<int>();
 }

--- a/test/streams/publish_connectable_stream_test.dart
+++ b/test/streams/publish_connectable_stream_test.dart
@@ -124,12 +124,6 @@ void main() {
       expect(
         () => stream()
           ..autoConnect()
-          ..autoConnect(),
-        throwsStateError,
-      );
-      expect(
-        () => stream()
-          ..autoConnect()
           ..connect(),
         throwsStateError,
       );
@@ -142,18 +136,6 @@ void main() {
       expect(
         () => stream()
           ..connect()
-          ..connect(),
-        throwsStateError,
-      );
-      expect(
-        () => stream()
-          ..connect()
-          ..refCount(),
-        throwsStateError,
-      );
-      expect(
-        () => stream()
-          ..refCount()
           ..refCount(),
         throwsStateError,
       );

--- a/test/streams/publish_connectable_stream_test.dart
+++ b/test/streams/publish_connectable_stream_test.dart
@@ -118,7 +118,9 @@ void main() {
       expect(isCanceled.future, completes);
     });
 
-    test('throws StateError', () {
+    test(
+        'throws StateError when mixing autoConnect, connect and refCount together',
+        () {
       PublishConnectableStream<int> stream() => Stream.value(1).publish();
 
       expect(

--- a/test/streams/publish_connectable_stream_test.dart
+++ b/test/streams/publish_connectable_stream_test.dart
@@ -142,5 +142,23 @@ void main() {
         throwsStateError,
       );
     });
+
+    test('calling autoConnect() multiple times returns the same value', () {
+      final s = Stream.value(1).publish();
+      expect(s.autoConnect(), same(s.autoConnect()));
+      expect(s.autoConnect(), same(s.autoConnect()));
+    });
+
+    test('calling connect() multiple times returns the same value', () {
+      final s = Stream.value(1).publish();
+      expect(s.connect(), same(s.connect()));
+      expect(s.connect(), same(s.connect()));
+    });
+
+    test('calling refCount() multiple times returns the same value', () {
+      final s = Stream.value(1).publish();
+      expect(s.refCount(), same(s.refCount()));
+      expect(s.refCount(), same(s.refCount()));
+    });
   });
 }

--- a/test/streams/publish_connectable_stream_test.dart
+++ b/test/streams/publish_connectable_stream_test.dart
@@ -117,5 +117,46 @@ void main() {
 
       expect(isCanceled.future, completes);
     });
+
+    test('throws StateError', () {
+      PublishConnectableStream<int> stream() => Stream.value(1).publish();
+
+      expect(
+        () => stream()
+          ..autoConnect()
+          ..autoConnect(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..autoConnect()
+          ..connect(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..autoConnect()
+          ..refCount(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..connect()
+          ..connect(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..connect()
+          ..refCount(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..refCount()
+          ..refCount(),
+        throwsStateError,
+      );
+    });
   });
 }

--- a/test/streams/replay_connectable_stream_test.dart
+++ b/test/streams/replay_connectable_stream_test.dart
@@ -207,5 +207,23 @@ void main() {
         throwsStateError,
       );
     });
+
+    test('calling autoConnect() multiple times returns the same value', () {
+      final s = Stream.value(1).publishReplay(maxSize: 1);
+      expect(s.autoConnect(), same(s.autoConnect()));
+      expect(s.autoConnect(), same(s.autoConnect()));
+    });
+
+    test('calling connect() multiple times returns the same value', () {
+      final s = Stream.value(1).publishReplay(maxSize: 1);
+      expect(s.connect(), same(s.connect()));
+      expect(s.connect(), same(s.connect()));
+    });
+
+    test('calling refCount() multiple times returns the same value', () {
+      final s = Stream.value(1).publishReplay(maxSize: 1);
+      expect(s.refCount(), same(s.refCount()));
+      expect(s.refCount(), same(s.refCount()));
+    });
   });
 }

--- a/test/streams/replay_connectable_stream_test.dart
+++ b/test/streams/replay_connectable_stream_test.dart
@@ -180,5 +180,47 @@ void main() {
 
       expect(isCanceled.future, completes);
     });
+
+    test('throws StateError', () {
+      ReplayConnectableStream<int> stream() =>
+          Stream.value(1).publishReplay(maxSize: 1);
+
+      expect(
+        () => stream()
+          ..autoConnect()
+          ..autoConnect(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..autoConnect()
+          ..connect(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..autoConnect()
+          ..refCount(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..connect()
+          ..connect(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..connect()
+          ..refCount(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..refCount()
+          ..refCount(),
+        throwsStateError,
+      );
+    });
   });
 }

--- a/test/streams/replay_connectable_stream_test.dart
+++ b/test/streams/replay_connectable_stream_test.dart
@@ -188,12 +188,6 @@ void main() {
       expect(
         () => stream()
           ..autoConnect()
-          ..autoConnect(),
-        throwsStateError,
-      );
-      expect(
-        () => stream()
-          ..autoConnect()
           ..connect(),
         throwsStateError,
       );
@@ -203,21 +197,10 @@ void main() {
           ..refCount(),
         throwsStateError,
       );
+
       expect(
         () => stream()
           ..connect()
-          ..connect(),
-        throwsStateError,
-      );
-      expect(
-        () => stream()
-          ..connect()
-          ..refCount(),
-        throwsStateError,
-      );
-      expect(
-        () => stream()
-          ..refCount()
           ..refCount(),
         throwsStateError,
       );

--- a/test/streams/replay_connectable_stream_test.dart
+++ b/test/streams/replay_connectable_stream_test.dart
@@ -181,7 +181,9 @@ void main() {
       expect(isCanceled.future, completes);
     });
 
-    test('throws StateError', () {
+    test(
+        'throws StateError when mixing autoConnect, connect and refCount together',
+        () {
       ReplayConnectableStream<int> stream() =>
           Stream.value(1).publishReplay(maxSize: 1);
 

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -248,5 +248,46 @@ void main() {
         await expectLater(isCanceled.future, completes);
       }
     });
+
+    test('throws StateError', () {
+      ValueConnectableStream<int> stream() => Stream.value(1).publishValue();
+
+      expect(
+        () => stream()
+          ..autoConnect()
+          ..autoConnect(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..autoConnect()
+          ..connect(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..autoConnect()
+          ..refCount(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..connect()
+          ..connect(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..connect()
+          ..refCount(),
+        throwsStateError,
+      );
+      expect(
+        () => stream()
+          ..refCount()
+          ..refCount(),
+        throwsStateError,
+      );
+    });
   });
 }

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -255,12 +255,6 @@ void main() {
       expect(
         () => stream()
           ..autoConnect()
-          ..autoConnect(),
-        throwsStateError,
-      );
-      expect(
-        () => stream()
-          ..autoConnect()
           ..connect(),
         throwsStateError,
       );
@@ -273,18 +267,6 @@ void main() {
       expect(
         () => stream()
           ..connect()
-          ..connect(),
-        throwsStateError,
-      );
-      expect(
-        () => stream()
-          ..connect()
-          ..refCount(),
-        throwsStateError,
-      );
-      expect(
-        () => stream()
-          ..refCount()
           ..refCount(),
         throwsStateError,
       );

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -249,7 +249,9 @@ void main() {
       }
     });
 
-    test('throws StateError', () {
+    test(
+        'throws StateError when mixing autoConnect, connect and refCount together',
+        () {
       ValueConnectableStream<int> stream() => Stream.value(1).publishValue();
 
       expect(

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -273,5 +273,23 @@ void main() {
         throwsStateError,
       );
     });
+
+    test('calling autoConnect() multiple times returns the same value', () {
+      final s = Stream.value(1).publishValueSeeded(1);
+      expect(s.autoConnect(), same(s.autoConnect()));
+      expect(s.autoConnect(), same(s.autoConnect()));
+    });
+
+    test('calling connect() multiple times returns the same value', () {
+      final s = Stream.value(1).publishValueSeeded(1);
+      expect(s.connect(), same(s.connect()));
+      expect(s.connect(), same(s.connect()));
+    });
+
+    test('calling refCount() multiple times returns the same value', () {
+      final s = Stream.value(1).publishValueSeeded(1);
+      expect(s.refCount(), same(s.refCount()));
+      expect(s.refCount(), same(s.refCount()));
+    });
   });
 }

--- a/test/transformers/timeout_test.dart
+++ b/test/transformers/timeout_test.dart
@@ -11,7 +11,7 @@ void main() {
         .timeout(Duration(milliseconds: 1));
 
     subscription = stream.listen((_) {},
-        onError: expectAsync2((TimeoutException e, StackTrace s) {
+        onError: expectAsync2((Object e, StackTrace s) {
           expect(e is TimeoutException, isTrue);
           subscription.cancel();
         }, count: 1));

--- a/test/transformers/where_type_test.dart
+++ b/test/transformers/where_type_test.dart
@@ -29,7 +29,7 @@ void main() {
   });
 
   test('Rx.whereType.polymorphism', () async {
-    _getStream().whereType<num>().listen(expectAsync1((result) {
+    _getStream().whereType<num>().listen(expectAsync1((Object result) {
           expect(result is num, true);
         }, count: 2));
   });


### PR DESCRIPTION
- **BREAKING CHANGE: NO**
- Introduce `AbstractConnectableStream` and deduplication.
- Disallow mixing `autoConnect`, `connect` and `refCount` together `->` only use one of them