### PR TITLE
feat(CompositeSubscription): `CompositeSubscription` implements `StreamSubscription`

### DIFF
--- a/lib/src/streams/race.dart
+++ b/lib/src/streams/race.dart
@@ -51,7 +51,11 @@ class RaceStream<T> extends Stream<T> {
             //ignore: cancel_subscriptions
             final winner = subscriptions.removeAt(winnerIndex);
 
-            subscriptions.cancelAll();
+            subscriptions.cancelAll()?.onError<Object>((e, s) {
+              if (!controller.isClosed && controller.hasListener) {
+                controller.addError(e, s);
+              }
+            });
 
             subscriptions = [winner];
           }

--- a/lib/src/utils/composite_subscription.dart
+++ b/lib/src/utils/composite_subscription.dart
@@ -14,7 +14,7 @@ import 'package:rxdart/src/utils/subscription.dart';
 ///
 /// // clear them all at once
 /// composite.clear();
-class CompositeSubscription {
+class CompositeSubscription implements StreamSubscription<Never> {
   bool _isDisposed = false;
 
   final List<StreamSubscription<dynamic>> _subscriptionsList = [];
@@ -33,9 +33,9 @@ class CompositeSubscription {
   bool get isNotEmpty => _subscriptionsList.isNotEmpty;
 
   /// Whether all managed [StreamSubscription]s are currently paused.
-  bool get allPaused => _subscriptionsList.isNotEmpty
-      ? _subscriptionsList.every((it) => it.isPaused)
-      : false;
+  bool get allPaused =>
+      _subscriptionsList.isNotEmpty &&
+      _subscriptionsList.every((s) => s.isPaused);
 
   /// Adds new subscription to this composite.
   ///
@@ -82,6 +82,35 @@ class CompositeSubscription {
 
   /// Resumes all subscriptions added to this composite.
   void resumeAll() => _subscriptionsList.resumeAll();
+
+  // implements StreamSubscription
+
+  @override
+  Future<void> cancel() => dispose() ?? Future<void>.value(null);
+
+  @override
+  bool get isPaused => allPaused;
+
+  @override
+  void pause([Future<void>? resumeSignal]) => pauseAll(resumeSignal);
+
+  @override
+  void resume() => resumeAll();
+
+  @override
+  Never asFuture<E>([E? futureValue]) => _unsupportedError();
+
+  @override
+  Never onData(void Function(Never data)? handleData) => _unsupportedError();
+
+  @override
+  Never onDone(void Function()? handleDone) => _unsupportedError();
+
+  @override
+  Never onError(Function? handleError) => _unsupportedError();
+
+  Never _unsupportedError() => throw UnsupportedError(
+      'Cannot change handlers of CompositeSubscription.');
 }
 
 /// Extends the [StreamSubscription] class with the ability to be added to [CompositeSubscription] container.

--- a/lib/src/utils/subscription.dart
+++ b/lib/src/utils/subscription.dart
@@ -29,7 +29,7 @@ extension StreamSubscriptionsListExtension on List<StreamSubscription<void>> {
     if (length == 1) {
       return this[0].cancel();
     }
-    return Future.wait(map((s) => s.cancel()));
+    return Future.wait(map((s) => s.cancel())).then((_) => null);
   }
 }
 
@@ -43,6 +43,6 @@ extension StreamSubscriptionsQueueExtension on Queue<StreamSubscription<void>> {
     if (length == 1) {
       return first.cancel();
     }
-    return Future.wait(map((s) => s.cancel()));
+    return Future.wait(map((s) => s.cancel())).then((value) => null);
   }
 }

--- a/test/streams/composite_subscription_test.dart
+++ b/test/streams/composite_subscription_test.dart
@@ -5,6 +5,50 @@ import 'package:test/test.dart';
 
 void main() {
   group('CompositeSubscription', () {
+    test('can be casted to any of StreamSubscription', () {
+      final cs = CompositeSubscription();
+
+      expect(cs, isA<StreamSubscription<void>>());
+      // ignore: prefer_void_to_null
+      expect(cs, isA<StreamSubscription<Null>>());
+      expect(cs, isA<StreamSubscription<int>>());
+      expect(cs, isA<StreamSubscription<int?>>());
+      expect(cs, isA<StreamSubscription<Object>>());
+      expect(cs, isA<StreamSubscription<Object?>>());
+
+      cs as StreamSubscription<void>; // ignore: unnecessary_cast
+      // ignore: unnecessary_cast, prefer_void_to_null
+      cs as StreamSubscription<Null>;
+      cs as StreamSubscription<int>; // ignore: unnecessary_cast
+      cs as StreamSubscription<int?>; // ignore: unnecessary_cast
+      cs as StreamSubscription<Object>; // ignore: unnecessary_cast
+      cs as StreamSubscription<Object?>; // ignore: unnecessary_cast
+
+      expect(true, true);
+    });
+
+    group('throws UnsupportedError', () {
+      test('when calling asFuture()', () {
+        expect(
+            () => CompositeSubscription().asFuture(0), throwsUnsupportedError);
+      });
+
+      test('when calling onData()', () {
+        expect(() => CompositeSubscription().onData((_) {}),
+            throwsUnsupportedError);
+      });
+
+      test('when calling onError()', () {
+        expect(() => CompositeSubscription().onError((Object _) {}),
+            throwsUnsupportedError);
+      });
+
+      test('when calling onDone()', () {
+        expect(() => CompositeSubscription().onDone(() {}),
+            throwsUnsupportedError);
+      });
+    });
+
     group('Rx.compositeSubscription.clear', () {
       test('should cancel all subscriptions', () {
         final stream = Stream.fromIterable(const [1, 2, 3]).shareValue();
@@ -20,18 +64,19 @@ void main() {
         expect(stream, neverEmits(anything));
         expect(done, isA<Future>());
       });
-      test('should return null since no subscription has been canceled clear()',
-          () {
-        final composite = CompositeSubscription();
 
-        final done = composite.clear();
-
-        expect(done, null);
-      });
+      test(
+        'should return null since no subscription has been canceled clear()',
+        () {
+          final composite = CompositeSubscription();
+          final done = composite.clear();
+          expect(done, null);
+        },
+      );
     });
 
     group('Rx.compositeSubscription.onDispose', () {
-      test('should cancel all subscriptions', () {
+      test('should cancel all subscriptions when calling dispose()', () {
         final stream = Stream.fromIterable(const [1, 2, 3]).shareValue();
         final composite = CompositeSubscription();
 
@@ -45,25 +90,63 @@ void main() {
         expect(stream, neverEmits(anything));
         expect(done, isA<Future>());
       });
-      test(
-          'should return null since no subscription has been canceled on dispose()',
-          () {
-        final composite = CompositeSubscription();
 
-        final done = composite.dispose();
-
-        expect(done, null);
-      });
-      test(
-          'should throw exception if trying to add subscription to disposed composite',
-          () {
+      test('should cancel all subscriptions when calling cancel()', () {
         final stream = Stream.fromIterable(const [1, 2, 3]).shareValue();
         final composite = CompositeSubscription();
 
-        composite.dispose();
+        composite
+          ..add(stream.listen(null))
+          ..add(stream.listen(null))
+          ..add(stream.listen(null));
 
-        expect(() => composite.add(stream.listen(null)), throwsA(anything));
+        final done = composite.cancel();
+
+        expect(stream, neverEmits(anything));
+        expect(done, isA<Future>());
       });
+
+      test(
+        'should return null since no subscription has been canceled on dispose()',
+        () {
+          final composite = CompositeSubscription();
+          final done = composite.dispose();
+          expect(done, null);
+        },
+      );
+
+      test(
+        'should return Future completed with null since no subscription has been canceled on cancel()',
+        () {
+          final composite = CompositeSubscription();
+          final done = composite.cancel();
+          expect(done, completion(null));
+        },
+      );
+
+      test(
+        'should throw exception if trying to add subscription to disposed composite, after calling dispose()',
+        () {
+          final stream = Stream.fromIterable(const [1, 2, 3]).shareValue();
+          final composite = CompositeSubscription();
+
+          composite.dispose();
+
+          expect(() => composite.add(stream.listen(null)), throwsA(anything));
+        },
+      );
+
+      test(
+        'should throw exception if trying to add subscription to disposed composite, after calling cancel()',
+        () {
+          final stream = Stream.fromIterable(const [1, 2, 3]).shareValue();
+          final composite = CompositeSubscription();
+
+          composite.cancel();
+
+          expect(() => composite.add(stream.listen(null)), throwsA(anything));
+        },
+      );
     });
 
     group('Rx.compositeSubscription.remove', () {
@@ -79,19 +162,21 @@ void main() {
         expect(stream, neverEmits(anything));
         expect(done, isA<Future>());
       });
+
       test(
-          'should not cancel the subscription since it is not present in the composite',
-          () {
-        const value = 1;
-        final stream = Stream.fromIterable([value]).shareValue();
-        final composite = CompositeSubscription();
-        final subscription = stream.listen(null);
+        'should not cancel the subscription since it is not present in the composite',
+        () {
+          const value = 1;
+          final stream = Stream.fromIterable([value]).shareValue();
+          final composite = CompositeSubscription();
+          final subscription = stream.listen(null);
 
-        final done = composite.remove(subscription);
+          final done = composite.remove(subscription);
 
-        expect(stream, emits(anything));
-        expect(done, null);
-      });
+          expect(stream, emits(anything));
+          expect(done, null);
+        },
+      );
     });
 
     test('Rx.compositeSubscription.pauseAndResume()', () {
@@ -101,18 +186,40 @@ void main() {
 
       composite.add(s1);
       composite.add(s2);
+
+      void expectPaused() {
+        expect(composite.allPaused, isTrue);
+        expect(composite.isPaused, isTrue);
+
+        expect(s1.isPaused, isTrue);
+        expect(s2.isPaused, isTrue);
+      }
+
+      void expectResumed() {
+        expect(composite.allPaused, isFalse);
+        expect(composite.isPaused, isFalse);
+
+        expect(s1.isPaused, isFalse);
+        expect(s2.isPaused, isFalse);
+      }
+
       composite.pauseAll();
 
-      expect(composite.allPaused, isTrue);
-      expect(s1.isPaused, isTrue);
-      expect(s2.isPaused, isTrue);
+      expectPaused();
 
       composite.resumeAll();
 
-      expect(composite.allPaused, isFalse);
-      expect(s1.isPaused, isFalse);
-      expect(s2.isPaused, isFalse);
+      expectResumed();
+
+      composite.pause();
+
+      expectPaused();
+
+      composite.resume();
+
+      expectResumed();
     });
+
     test('Rx.compositeSubscription.resumeWithFuture', () async {
       final composite = CompositeSubscription();
       final s1 = Stream.fromIterable(const [1, 2, 3]).listen(null),
@@ -124,34 +231,43 @@ void main() {
       composite.pauseAll(completer.future);
 
       expect(composite.allPaused, isTrue);
+      expect(composite.isPaused, isTrue);
 
       completer.complete();
 
       await expectLater(completer.future.then((_) => composite.allPaused),
           completion(isFalse));
+      await expectLater(completer.future.then((_) => composite.isPaused),
+          completion(isFalse));
     });
+
     test('Rx.compositeSubscription.allPaused', () {
       final composite = CompositeSubscription();
       final s1 = Stream.fromIterable(const [1, 2, 3]).listen(null),
           s2 = Stream.fromIterable(const [4, 5, 6]).listen(null);
 
       expect(composite.allPaused, isFalse);
+      expect(composite.isPaused, isFalse);
 
       composite.add(s1);
       composite.add(s2);
 
       expect(composite.allPaused, isFalse);
+      expect(composite.isPaused, isFalse);
 
       composite.pauseAll();
 
       expect(composite.allPaused, isTrue);
+      expect(composite.isPaused, isTrue);
 
       composite.remove(s1);
       composite.remove(s2);
 
       /// all subscriptions are removed, allPaused should yield false
       expect(composite.allPaused, isFalse);
+      expect(composite.isPaused, isFalse);
     });
+
     test('Rx.compositeSubscription.allPaused.indirectly', () {
       final composite = CompositeSubscription();
       final s1 = Stream.fromIterable(const [1, 2, 3]).listen(null),
@@ -164,12 +280,15 @@ void main() {
       composite.add(s2);
 
       expect(composite.allPaused, isTrue);
+      expect(composite.isPaused, isTrue);
 
       s1.resume();
       s2.resume();
 
       expect(composite.allPaused, isFalse);
+      expect(composite.isPaused, isFalse);
     });
+
     test('Rx.compositeSubscription.size', () {
       final composite = CompositeSubscription();
       final s1 = Stream.fromIterable(const [1, 2, 3]).listen(null),

--- a/test/streams/composite_subscription_test.dart
+++ b/test/streams/composite_subscription_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('CompositeSubscription', () {
-    test('can be casted to any of StreamSubscription', () {
+    test('cast to StreamSubscription of any type', () {
       final cs = CompositeSubscription();
 
       expect(cs, isA<StreamSubscription<void>>());

--- a/test/streams/race_test.dart
+++ b/test/streams/race_test.dart
@@ -79,4 +79,31 @@ void main() {
   test('Rx.race.empty', () {
     expect(Rx.race<int>(const []), emitsDone);
   });
+
+  test('Rx.race.cancelThrowing', () async {
+    Stream<int> stream() {
+      final controller = StreamController<int>();
+      controller.onCancel = () async {
+        throw Exception('Exception when cancelling!');
+      };
+
+      return Rx.race<int>([
+        controller.stream,
+        Rx.concat([
+          Rx.timer(1, const Duration(milliseconds: 100)),
+          Rx.timer(2, const Duration(milliseconds: 100)),
+        ]),
+      ]);
+    }
+
+    await expectLater(
+      stream(),
+      emitsInOrder(<Object>[1, emitsError(isException), 2, emitsDone]),
+    );
+
+    await expectLater(
+      stream().take(1),
+      emitsInOrder(<Object>[1, emitsDone]),
+    );
+  });
 }

--- a/test/streams/race_test.dart
+++ b/test/streams/race_test.dart
@@ -80,7 +80,7 @@ void main() {
     expect(Rx.race<int>(const []), emitsDone);
   });
 
-  test('Rx.race.cancelThrowing', () async {
+  test('Rx.race.cancel.throws', () async {
     Stream<int> stream() {
       final controller = StreamController<int>();
       controller.onCancel = () async {


### PR DESCRIPTION
- **BREAKING CHANGE: NO**
- `CompositeSubscription`s can be used as `StreamSubscription<...>`s