### PR TITLE
refactor: remove unneeded export in `rxdart.dart`

### DIFF
--- a/lib/rxdart.dart
+++ b/lib/rxdart.dart
@@ -1,7 +1,6 @@
 library rx;
 
 export 'src/rx.dart';
-export 'src/streams/connectable_stream.dart';
 export 'src/utils/composite_subscription.dart';
 export 'src/utils/error_and_stacktrace.dart';
 export 'src/utils/notification.dart';


### PR DESCRIPTION
Remove unneeded `export 'src/streams/connectable_stream.dart'` in `'rxdart.dart'`, since it has been exported in `'streams.dart'`