### PR TITLE
README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Additional information about the following situations can be found by reading th
 | Cold Observables  | Multiple subscribers can listen to the same cold Observable, and each subscription will receive a unique Stream of data | Single subscriber only | 
 | Hot Observables  | Yes | Yes, known as Broadcast Streams | 
 | Is {Publish, Behavior, Replay}Subject hot? | Yes | Yes |
-| Single/Maybe/Complete ? | Yes | No, uses Dart `Future` |
+| Single/Maybe/Complete ? | Yes | Yes, `Stream<T>.value(...)` / `Stream<T>.error(...)` |
 | Support back pressure| Yes | Yes |
 | Can emit null? | Yes, except RxJava | Yes |
 | Sync by default | Yes | No |


### PR DESCRIPTION
Fix of the single line in the README.md. 

The `Stream<T>.value(...)` constructor was added in the 2.5.0 version of the SDK, and that part of the README was a bit misleading.