### PR TITLE
fix(combineLatest, concat, concatEager, forkJoin): should iterate over `Iterable<Stream>` once

### DIFF
--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/collection_extensions.dart';
 import 'package:rxdart/src/utils/subscription.dart';
 
 /// Merges the given Streams into one Stream sequence by using the
@@ -289,59 +290,60 @@ class CombineLatestStream<T, R> extends StreamView<R> {
     Iterable<Stream<T>> streams,
     R Function(List<T> values) combiner,
   ) {
-    if (streams.isEmpty) {
-      return StreamController<R>()..close();
-    }
+    final controller = StreamController<R>(sync: true);
+    late List<StreamSubscription<T>> subscriptions;
+    List<T?>? values;
 
-    final len = streams.length;
-    late List<StreamSubscription<dynamic>> subscriptions;
-    late StreamController<R> controller;
+    controller.onListen = () {
+      var triggered = 0, completed = 0;
 
-    controller = StreamController<R>(
-      sync: true,
-      onListen: () {
-        final values = List<T?>.filled(len, null);
-        var triggered = 0, completed = 0, index = 0;
+      void onDone() {
+        if (++completed == subscriptions.length) controller.close();
+      }
 
-        bool allHaveEvent() => triggered == len;
+      subscriptions = streams.mapIndexed((index, stream) {
+        var hasFirstEvent = false;
 
-        void onDone() {
-          if (++completed == len) controller.close();
-        }
+        return stream.listen(
+          (T value) {
+            values![index] = value;
 
-        T Function(T value) onUpdate(int index) =>
-            (T value) => values[index] = value;
+            if (!hasFirstEvent) {
+              hasFirstEvent = true;
+              triggered++;
+            }
 
-        subscriptions = streams.map((stream) {
-          final onUpdateForStream = onUpdate(index++);
-          var hasFirstEvent = false;
-
-          return stream.listen(
-            (T value) {
-              onUpdateForStream(value);
-
-              if (!hasFirstEvent) {
-                hasFirstEvent = true;
-                triggered++;
+            if (values == null) {
+              // cancelled
+              return;
+            }
+            if (triggered == subscriptions.length) {
+              final R combined;
+              try {
+                combined = combiner(List<T>.unmodifiable(values!));
+              } catch (e, s) {
+                controller.addError(e, s);
+                return;
               }
-
-              if (allHaveEvent()) {
-                try {
-                  controller.add(combiner(List<T>.unmodifiable(values)));
-                } catch (e, s) {
-                  controller.addError(e, s);
-                }
-              }
-            },
-            onError: controller.addError,
-            onDone: onDone,
-          );
-        }).toList(growable: false);
-      },
-      onPause: () => subscriptions.pauseAll(),
-      onResume: () => subscriptions.resumeAll(),
-      onCancel: () => subscriptions.cancelAll(),
-    );
+              controller.add(combined);
+            }
+          },
+          onError: controller.addError,
+          onDone: onDone,
+        );
+      }).toList(growable: false);
+      if (subscriptions.isEmpty) {
+        controller.close();
+      } else {
+        values = List<T?>.filled(subscriptions.length, null);
+      }
+    };
+    controller.onPause = () => subscriptions.pauseAll();
+    controller.onResume = () => subscriptions.resumeAll();
+    controller.onCancel = () {
+      values = null;
+      return subscriptions.cancelAll();
+    };
 
     return controller;
   }

--- a/lib/src/streams/combine_latest.dart
+++ b/lib/src/streams/combine_latest.dart
@@ -298,7 +298,9 @@ class CombineLatestStream<T, R> extends StreamView<R> {
       var triggered = 0, completed = 0;
 
       void onDone() {
-        if (++completed == subscriptions.length) controller.close();
+        if (++completed == subscriptions.length) {
+          controller.close();
+        }
       }
 
       subscriptions = streams.mapIndexed((index, stream) {
@@ -306,6 +308,10 @@ class CombineLatestStream<T, R> extends StreamView<R> {
 
         return stream.listen(
           (T value) {
+            if (values == null) {
+              return;
+            }
+
             values![index] = value;
 
             if (!hasFirstEvent) {
@@ -313,10 +319,6 @@ class CombineLatestStream<T, R> extends StreamView<R> {
               triggered++;
             }
 
-            if (values == null) {
-              // cancelled
-              return;
-            }
             if (triggered == subscriptions.length) {
               final R combined;
               try {

--- a/lib/src/streams/concat_eager.dart
+++ b/lib/src/streams/concat_eager.dart
@@ -37,11 +37,11 @@ class ConcatEagerStream<T> extends StreamView<T> {
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
     final controller = StreamController<T>(sync: true);
     late List<StreamSubscription<T>> subscriptions;
-
-    final completeEvents = <Completer<void>>[];
     StreamSubscription<T>? activeSubscription;
 
     controller.onListen = () {
+      final completeEvents = <Completer<void>>[];
+
       void Function() onDone(int index) {
         return () {
           if (index < subscriptions.length - 1) {

--- a/lib/src/streams/concat_eager.dart
+++ b/lib/src/streams/concat_eager.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:rxdart/src/streams/concat.dart';
+import 'package:rxdart/src/utils/collection_extensions.dart';
 import 'package:rxdart/src/utils/subscription.dart';
 
 /// Concatenates all of the specified stream sequences, as long as the
@@ -24,76 +25,75 @@ import 'package:rxdart/src/utils/subscription.dart';
 ///       Stream.fromIterable([3])
 ///     ])
 ///     .listen(print); // prints 1, 2, 3
-class ConcatEagerStream<T> extends Stream<T> {
-  final StreamController<T> _controller;
-
+class ConcatEagerStream<T> extends StreamView<T> {
   /// Constructs a [Stream] which emits all events from [streams].
   /// Unlike [ConcatStream], all [Stream]s inside [streams] are
   /// immediately subscribed to and events captured at the correct time,
   /// but emitted only after the previous [Stream] in [streams] is
   /// successfully closed.
   ConcatEagerStream(Iterable<Stream<T>> streams)
-      : _controller = _buildController(streams);
+      : super(_buildController(streams).stream);
 
-  @override
-  StreamSubscription<T> listen(void Function(T event)? onData,
-      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
-    return _controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
-  }
+  static StreamController<T> _buildController<T>(
+      Iterable<Stream<T>> streamsIterable) {
+    final controller = StreamController<T>(sync: true);
 
-  static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
-    if (streams.isEmpty) {
-      return StreamController<T>()..close();
-    }
+    List<StreamSubscription<T>>? subscriptions;
+    List<Completer>? completeEvents;
+    StreamSubscription<T>? activeSubscription;
 
-    final len = streams.length;
-    final completeEvents = List.generate(len, (_) => Completer<dynamic>());
-    late List<StreamSubscription<T>> subscriptions;
-    late StreamController<T> controller;
-    //ignore: cancel_subscriptions
-    late StreamSubscription<T> activeSubscription;
+    controller.onListen = () {
+      final streams = streamsIterable.evaluated;
+      if (streams.isEmpty) {
+        controller.close();
+        return;
+      }
 
-    controller = StreamController<T>(
-        sync: true,
-        onListen: () {
-          var index = -1, completed = 0;
+      final length = streams.length;
+      var completed = 0;
 
-          void Function() onDone(int index) {
-            final completer = completeEvents[index];
-
-            return () {
-              completer.complete();
-
-              if (++completed == len) {
-                controller.close();
-              } else {
-                activeSubscription = subscriptions[index + 1];
-              }
-            };
+      void Function() onDone(int index) {
+        return () {
+          if (index < length - 1) {
+            completeEvents![index].complete();
           }
 
-          StreamSubscription<T> createSubscription(Stream<T> stream) {
-            index++;
-            //ignore: cancel_subscriptions
-            final subscription = stream.listen(controller.add,
-                onError: controller.addError, onDone: onDone(index));
-
-            // pause all subscriptions, except the first, initially
-            if (index > 0) subscription.pause(completeEvents[index - 1].future);
-
-            return subscription;
+          if (++completed == length) {
+            controller.close();
+          } else {
+            activeSubscription = subscriptions?[index + 1];
           }
+        };
+      }
 
-          subscriptions =
-              streams.map(createSubscription).toList(growable: false);
+      StreamSubscription<T> createSubscription(int index, Stream<T> stream) {
+        final subscription = stream.listen(controller.add,
+            onError: controller.addError, onDone: onDone(index));
 
-          // initially, the very first subscription is the active one
-          activeSubscription = subscriptions.first;
-        },
-        onPause: () => activeSubscription.pause(),
-        onResume: () => activeSubscription.resume(),
-        onCancel: () => subscriptions.cancelAll());
+        // pause all subscriptions, except the first, initially
+        if (index > 0) {
+          subscription.pause(completeEvents![index - 1].future);
+        }
+
+        return subscription;
+      }
+
+      completeEvents = List.generate(length - 1, (_) => Completer<void>());
+      subscriptions =
+          streams.mapIndexed(createSubscription).toList(growable: false);
+
+      // initially, the very first subscription is the active one
+      activeSubscription = subscriptions?.first;
+    };
+    controller.onPause = () => activeSubscription?.pause();
+    controller.onResume = () => activeSubscription?.resume();
+    controller.onCancel = () {
+      final future = subscriptions?.cancelAll();
+      activeSubscription = null;
+      completeEvents = null;
+      subscriptions = null;
+      return future;
+    };
 
     return controller;
   }

--- a/lib/src/streams/fork_join.dart
+++ b/lib/src/streams/fork_join.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/collection_extensions.dart';
 import 'package:rxdart/src/utils/subscription.dart';
 
 /// This operator is best used when you have a group of streams
@@ -301,56 +302,63 @@ class ForkJoinStream<T, R> extends StreamView<R> {
     Iterable<Stream<T>> streams,
     R Function(List<T> values) combiner,
   ) {
-    if (streams.isEmpty) {
-      return (StreamController<R>()..close()).stream;
-    }
-
-    late StreamController<R> controller;
+    final controller = StreamController<R>(sync: true);
     late List<StreamSubscription<T>> subscriptions;
-    final length = streams.length;
+    List<T?>? values;
 
-    controller = StreamController<R>(
-      sync: true,
-      onListen: () {
-        final values = List<T?>.filled(length, null);
-        var completed = 0;
+    controller.onListen = () {
+      var completed = 0;
 
-        StreamSubscription<T> listen(Stream<T> stream, int i) {
-          var hasValue = false;
+      StreamSubscription<T> listen(int i, Stream<T> stream) {
+        var hasValue = false;
 
-          return stream.listen(
-            (value) {
-              hasValue = true;
-              values[i] = value;
-            },
-            onError: controller.addError,
-            onDone: () {
-              if (!hasValue) {
-                controller.addError(StateError('No element'));
+        return stream.listen(
+          (value) {
+            hasValue = true;
+            values![i] = value;
+          },
+          onError: controller.addError,
+          onDone: () {
+            if (!hasValue) {
+              controller.addError(StateError('No element'));
+              controller.close();
+              return;
+            }
+
+            if (values == null) {
+              // cancelled
+              return;
+            }
+            if (++completed == subscriptions.length) {
+              final R combined;
+              try {
+                combined = combiner(List<T>.unmodifiable(values!));
+              } catch (e, s) {
+                controller.addError(e, s);
                 controller.close();
                 return;
               }
 
-              if (++completed == length) {
-                try {
-                  controller.add(combiner(List<T>.unmodifiable(values)));
-                } catch (e, s) {
-                  controller.addError(e, s);
-                }
-                controller.close();
-              }
-            },
-          );
-        }
+              controller.add(combined);
+              controller.close();
+            }
+          },
+        );
+      }
 
-        var i = 0;
-        subscriptions =
-            streams.map((s) => listen(s, i++)).toList(growable: false);
-      },
-      onPause: () => subscriptions.pauseAll(),
-      onResume: () => subscriptions.resumeAll(),
-      onCancel: () => subscriptions.cancelAll(),
-    );
+      subscriptions = streams.mapIndexed(listen).toList(growable: false);
+      if (subscriptions.isEmpty) {
+        controller.close();
+      } else {
+        values = List<T?>.filled(subscriptions.length, null);
+      }
+    };
+    controller.onPause = () => subscriptions.pauseAll();
+    controller.onResume = () => subscriptions.resumeAll();
+    controller.onCancel = () {
+      values = null;
+      return subscriptions.cancelAll();
+    };
 
     return controller.stream;
   }

--- a/lib/src/streams/fork_join.dart
+++ b/lib/src/streams/fork_join.dart
@@ -315,7 +315,7 @@ class ForkJoinStream<T, R> extends StreamView<R> {
         return stream.listen(
           (value) {
             hasValue = true;
-            values![i] = value;
+            values?[i] = value;
           },
           onError: controller.addError,
           onDone: () {
@@ -326,7 +326,6 @@ class ForkJoinStream<T, R> extends StreamView<R> {
             }
 
             if (values == null) {
-              // cancelled
               return;
             }
             if (++completed == subscriptions.length) {

--- a/lib/src/utils/collection_extensions.dart
+++ b/lib/src/utils/collection_extensions.dart
@@ -17,6 +17,14 @@ extension MapNotNullIterableExtension<T> on Iterable<T> {
       }
     }
   }
+
+  /// Maps each element and its index to a new value.
+  Iterable<R> mapIndexed<R>(R Function(int index, T element) transform) sync* {
+    var index = 0;
+    for (final e in this) {
+      yield transform(index++, e);
+    }
+  }
 }
 
 /// Provides [removeFirstElements] extension method on [Queue].

--- a/lib/src/utils/collection_extensions.dart
+++ b/lib/src/utils/collection_extensions.dart
@@ -25,6 +25,12 @@ extension MapNotNullIterableExtension<T> on Iterable<T> {
       yield transform(index++, e);
     }
   }
+
+  /// Evaluates a lazy iterable.
+  ///
+  /// Known non-lazy types are returned directly instead.
+  Iterable<T> get evaluated =>
+      this is List || this is Set ? this : toList(growable: false);
 }
 
 /// Provides [removeFirstElements] extension method on [Queue].

--- a/lib/src/utils/collection_extensions.dart
+++ b/lib/src/utils/collection_extensions.dart
@@ -25,12 +25,6 @@ extension MapNotNullIterableExtension<T> on Iterable<T> {
       yield transform(index++, e);
     }
   }
-
-  /// Evaluates a lazy iterable.
-  ///
-  /// Known non-lazy types are returned directly instead.
-  Iterable<T> get evaluated =>
-      this is List || this is Set ? this : toList(growable: false);
 }
 
 /// Provides [removeFirstElements] extension method on [Queue].

--- a/test/streams/combine_latest_test.dart
+++ b/test/streams/combine_latest_test.dart
@@ -36,10 +36,10 @@ void main() {
   });
 
   test('Rx.combineLatestList.iterate.once', () async {
-    var iteratedCount = 0;
+    var iterationCount = 0;
 
     final combined = Rx.combineLatestList<int>(() sync* {
-      ++iteratedCount;
+      ++iterationCount;
       yield Stream.value(1);
       yield Stream.value(2);
       yield Stream.value(3);
@@ -52,7 +52,7 @@ void main() {
         emitsDone,
       ]),
     );
-    expect(iteratedCount, 1);
+    expect(iterationCount, 1);
   });
 
   test('Rx.combineLatestList.empty', () async {

--- a/test/streams/combine_latest_test.dart
+++ b/test/streams/combine_latest_test.dart
@@ -35,6 +35,26 @@ void main() {
     );
   });
 
+  test('Rx.combineLatestList.iterate.once', () async {
+    var iteratedCount = 0;
+
+    final combined = Rx.combineLatestList<int>(() sync* {
+      ++iteratedCount;
+      yield Stream.value(1);
+      yield Stream.value(2);
+      yield Stream.value(3);
+    }());
+
+    await expectLater(
+      combined,
+      emitsInOrder(<dynamic>[
+        [1, 2, 3],
+        emitsDone,
+      ]),
+    );
+    expect(iteratedCount, 1);
+  });
+
   test('Rx.combineLatestList.empty', () async {
     final combined = Rx.combineLatestList<int>([]);
     expect(combined, emitsDone);

--- a/test/streams/concat_eager_test.dart
+++ b/test/streams/concat_eager_test.dart
@@ -31,6 +31,14 @@ void main() {
     }, count: expectedOutput.length));
   });
 
+  test('Rx.concatEager.single', () async {
+    final stream = Rx.concatEager([
+      Stream.fromIterable([1, 2, 3, 4, 5])
+    ]);
+
+    await expectLater(stream, emitsInOrder(<Object>[1, 2, 3, 4, 5, emitsDone]));
+  });
+
   test('Rx.concatEager.eagerlySubscription', () async {
     var subscribed2 = false;
     var subscribed3 = false;

--- a/test/streams/concat_eager_test.dart
+++ b/test/streams/concat_eager_test.dart
@@ -162,10 +162,10 @@ void main() {
   });
 
   test('Rx.concatEager.iterate.once', () async {
-    var iteratedCount = 0;
+    var iterationCount = 0;
 
     final stream = Rx.concatEager<int>(() sync* {
-      ++iteratedCount;
+      ++iterationCount;
       yield Stream.value(1);
       yield Stream.value(2);
       yield Stream.value(3);
@@ -180,6 +180,6 @@ void main() {
         emitsDone,
       ]),
     );
-    expect(iteratedCount, 1);
+    expect(iterationCount, 1);
   });
 }

--- a/test/streams/concat_eager_test.dart
+++ b/test/streams/concat_eager_test.dart
@@ -31,6 +31,34 @@ void main() {
     }, count: expectedOutput.length));
   });
 
+  test('Rx.concatEager.eagerlySubscription', () async {
+    var subscribed2 = false;
+    var subscribed3 = false;
+
+    final stream = Rx.concatEager<int>([
+      Rx.timer(1, Duration(milliseconds: 100)).doOnDone(
+          expectAsync0(() => expect(subscribed2 && subscribed3, true))),
+      Rx.timer([2, 3, 4], Duration(milliseconds: 100))
+          .exhaustMap((v) => Stream.fromIterable(v))
+          .doOnListen(() => subscribed2 = true)
+          .doOnDone(expectAsync0(() => expect(subscribed3, true))),
+      Rx.timer(5, Duration(milliseconds: 100))
+          .doOnListen(() => subscribed3 = true),
+    ]);
+
+    await expectLater(
+      stream,
+      emitsInOrder(<Object>[
+        1,
+        2,
+        3,
+        4,
+        5,
+        emitsDone,
+      ]),
+    );
+  });
+
   test('Rx.concatEager.single.subscription', () async {
     final stream = Rx.concatEager(_getStreams());
 

--- a/test/streams/concat_eager_test.dart
+++ b/test/streams/concat_eager_test.dart
@@ -160,4 +160,26 @@ void main() {
   test('Rx.concatEager.empty', () {
     expect(Rx.concatEager<int>(const []), emitsDone);
   });
+
+  test('Rx.concatEager.iterate.once', () async {
+    var iteratedCount = 0;
+
+    final stream = Rx.concatEager<int>(() sync* {
+      ++iteratedCount;
+      yield Stream.value(1);
+      yield Stream.value(2);
+      yield Stream.value(3);
+    }());
+
+    await expectLater(
+      stream,
+      emitsInOrder(<dynamic>[
+        1,
+        2,
+        3,
+        emitsDone,
+      ]),
+    );
+    expect(iteratedCount, 1);
+  });
 }

--- a/test/streams/concat_test.dart
+++ b/test/streams/concat_test.dart
@@ -104,4 +104,26 @@ void main() {
   test('Rx.concat.empty', () {
     expect(Rx.concat<int>(const []), emitsDone);
   });
+
+  test('Rx.concat.iterate.once', () async {
+    var iteratedCount = 0;
+
+    final stream = Rx.concat<int>(() sync* {
+      ++iteratedCount;
+      yield Stream.value(1);
+      yield Stream.value(2);
+      yield Stream.value(3);
+    }());
+
+    await expectLater(
+      stream,
+      emitsInOrder(<dynamic>[
+        1,
+        2,
+        3,
+        emitsDone,
+      ]),
+    );
+    expect(iteratedCount, 1);
+  });
 }

--- a/test/streams/concat_test.dart
+++ b/test/streams/concat_test.dart
@@ -106,10 +106,10 @@ void main() {
   });
 
   test('Rx.concat.iterate.once', () async {
-    var iteratedCount = 0;
+    var iterationCount = 0;
 
     final stream = Rx.concat<int>(() sync* {
-      ++iteratedCount;
+      ++iterationCount;
       yield Stream.value(1);
       yield Stream.value(2);
       yield Stream.value(3);
@@ -124,6 +124,6 @@ void main() {
         emitsDone,
       ]),
     );
-    expect(iteratedCount, 1);
+    expect(iterationCount, 1);
   });
 }

--- a/test/streams/concat_test.dart
+++ b/test/streams/concat_test.dart
@@ -105,6 +105,13 @@ void main() {
     expect(Rx.concat<int>(const []), emitsDone);
   });
 
+  test('Rx.concat.single', () {
+    expect(
+      Rx.concat<int>([Stream.value(1)]),
+      emitsInOrder(<Object>[1, emitsDone]),
+    );
+  });
+
   test('Rx.concat.iterate.once', () async {
     var iterationCount = 0;
 

--- a/test/streams/fork_join_test.dart
+++ b/test/streams/fork_join_test.dart
@@ -49,10 +49,10 @@ void main() {
   });
 
   test('Rx.concatEager.iterate.once', () async {
-    var iteratedCount = 0;
+    var iterationCount = 0;
 
     final stream = Rx.forkJoinList<int>(() sync* {
-      ++iteratedCount;
+      ++iterationCount;
       yield Stream.value(1);
       yield Stream.value(2);
       yield Stream.value(3);
@@ -65,7 +65,7 @@ void main() {
         emitsDone,
       ]),
     );
-    expect(iteratedCount, 1);
+    expect(iterationCount, 1);
   });
 
   test('Rx.forkJoin.empty', () {

--- a/test/streams/fork_join_test.dart
+++ b/test/streams/fork_join_test.dart
@@ -48,6 +48,26 @@ void main() {
     );
   });
 
+  test('Rx.concatEager.iterate.once', () async {
+    var iteratedCount = 0;
+
+    final stream = Rx.forkJoinList<int>(() sync* {
+      ++iteratedCount;
+      yield Stream.value(1);
+      yield Stream.value(2);
+      yield Stream.value(3);
+    }());
+
+    await expectLater(
+      stream,
+      emitsInOrder(<dynamic>[
+        [1, 2, 3],
+        emitsDone,
+      ]),
+    );
+    expect(iteratedCount, 1);
+  });
+
   test('Rx.forkJoin.empty', () {
     expect(Rx.forkJoinList<int>([]), emitsDone);
   });


### PR DESCRIPTION
Consider example:
```dart
Iterable<Stream<int>> ff() sync* {
  print('YIELD 1');
  yield Stream.value(1);
  print('YIELD 2');
  yield Stream.value(2);
  print('YIELD 3');
  yield Stream.value(3);
}

void main() async {
  await ConcatEagerStream(ff()).forEach(print);
}

// Console
YIELD 1
YIELD 1
YIELD 2
YIELD 3
YIELD 1
YIELD 2
YIELD 3
1
2
3
```
The iterable yielded many times, that is unexpected behavior.
```
// Expected behavior
YIELD 1
YIELD 3
YIELD 3
1
2
3
```

This PR will fix `combineLatest`, `concat`, `concatEager`, `forkJoin`.