### PR TITLE
fix(merge, race, zip): should iterate over `Iterable<Stream>` once

### DIFF
--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -17,48 +17,38 @@ import 'package:rxdart/src/utils/subscription.dart';
 ///       Stream.fromIterable([2])
 ///     ])
 ///     .listen(print); // prints 2, 1
-class MergeStream<T> extends Stream<T> {
-  final StreamController<T> _controller;
-
+class MergeStream<T> extends StreamView<T> {
   /// Constructs a [Stream] which flattens all events in [streams] and emits
   /// them in a single sequence.
   MergeStream(Iterable<Stream<T>> streams)
-      : _controller = _buildController(streams);
-
-  @override
-  StreamSubscription<T> listen(void Function(T event)? onData,
-          {Function? onError, void Function()? onDone, bool? cancelOnError}) =>
-      _controller.stream.listen(onData,
-          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+      : super(_buildController(streams).stream);
 
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
-    if (streams.isEmpty) {
-      return StreamController<T>()..close();
-    }
-
-    final len = streams.length;
+    final controller = StreamController<T>(sync: true);
     late List<StreamSubscription<T>> subscriptions;
-    late StreamController<T> controller;
 
-    controller = StreamController<T>(
-        sync: true,
-        onListen: () {
-          var completed = 0;
+    controller.onListen = () {
+      var completed = 0;
 
-          void onDone() {
-            completed++;
+      void onDone() {
+        if (++completed == subscriptions.length) {
+          controller.close();
+        }
+      }
 
-            if (completed == len) controller.close();
-          }
+      subscriptions = streams
+          .map((s) => s.listen(controller.add,
+              onError: controller.addError, onDone: onDone))
+          .toList(growable: false);
 
-          subscriptions = streams
-              .map((s) => s.listen(controller.add,
-                  onError: controller.addError, onDone: onDone))
-              .toList(growable: false);
-        },
-        onPause: () => subscriptions.pauseAll(),
-        onResume: () => subscriptions.resumeAll(),
-        onCancel: () => subscriptions.cancelAll());
+      if (subscriptions.isEmpty) {
+        controller.close();
+        return;
+      }
+    };
+    controller.onPause = () => subscriptions.pauseAll();
+    controller.onResume = () => subscriptions.resumeAll();
+    controller.onCancel = () => subscriptions.cancelAll();
 
     return controller;
   }

--- a/lib/src/streams/merge.dart
+++ b/lib/src/streams/merge.dart
@@ -43,7 +43,6 @@ class MergeStream<T> extends StreamView<T> {
 
       if (subscriptions.isEmpty) {
         controller.close();
-        return;
       }
     };
     controller.onPause = () => subscriptions.pauseAll();

--- a/lib/src/streams/race.dart
+++ b/lib/src/streams/race.dart
@@ -17,67 +17,58 @@ import 'package:rxdart/src/utils/subscription.dart';
 ///       TimerStream(2, Duration(days: 2)),
 ///       TimerStream(3, Duration(seconds: 3))
 ///     ]).listen(print); // prints 3
-class RaceStream<T> extends Stream<T> {
-  final StreamController<T> _controller;
-
+class RaceStream<T> extends StreamView<T> {
   /// Constructs a [Stream] which emits all events from a single [Stream]
   /// inside [streams]. The selected [Stream] is the first one which emits
   /// an event.
   /// After this event, all other [Stream]s in [streams] are discarded.
   RaceStream(Iterable<Stream<T>> streams)
-      : _controller = _buildController(streams);
-
-  @override
-  StreamSubscription<T> listen(void Function(T event)? onData,
-      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
-    return _controller.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
-  }
+      : super(_buildController(streams).stream);
 
   static StreamController<T> _buildController<T>(Iterable<Stream<T>> streams) {
-    if (streams.isEmpty) {
-      return StreamController<T>()..close();
-    }
-
+    final controller = StreamController<T>(sync: true);
     late List<StreamSubscription<T>> subscriptions;
-    late StreamController<T> controller;
 
-    controller = StreamController<T>(
-        sync: true,
-        onListen: () {
-          var index = 0;
+    controller.onListen = () {
+      var index = 0;
 
-          void reduceToWinner(int winnerIndex) {
-            //ignore: cancel_subscriptions
-            final winner = subscriptions.removeAt(winnerIndex);
+      void reduceToWinner(int winnerIndex) {
+        final winner = subscriptions.removeAt(winnerIndex);
 
-            subscriptions.cancelAll()?.onError<Object>((e, s) {
-              if (!controller.isClosed && controller.hasListener) {
-                controller.addError(e, s);
-              }
-            });
-
-            subscriptions = [winner];
+        subscriptions.cancelAll()?.onError<Object>((e, s) {
+          if (!controller.isClosed && controller.hasListener) {
+            controller.addError(e, s);
           }
+        });
 
-          void Function(T value) doUpdate(int index) => (T value) {
-                try {
-                  if (subscriptions.length > 1) reduceToWinner(index);
+        subscriptions = [winner];
+      }
 
-                  controller.add(value);
-                } catch (e, s) {
-                  controller.addError(e, s);
-                }
-              };
+      void Function(T value) doUpdate(int index) {
+        return (T value) {
+          try {
+            if (subscriptions.length > 1) reduceToWinner(index);
 
-          subscriptions = streams
-              .map((stream) => stream.listen(doUpdate(index++),
-                  onError: controller.addError, onDone: controller.close))
-              .toList();
-        },
-        onPause: () => subscriptions.pauseAll(),
-        onResume: () => subscriptions.resumeAll(),
-        onCancel: () => subscriptions.cancelAll());
+            controller.add(value);
+          } catch (e, s) {
+            controller.addError(e, s);
+          }
+        };
+      }
+
+      subscriptions = streams
+          .map((stream) => stream.listen(doUpdate(index++),
+              onError: controller.addError, onDone: controller.close))
+          .toList();
+
+      if (subscriptions.isEmpty) {
+        controller.close();
+        return;
+      }
+    };
+    controller.onPause = () => subscriptions.pauseAll();
+    controller.onResume = () => subscriptions.resumeAll();
+    controller.onCancel = () => subscriptions.cancelAll();
 
     return controller;
   }

--- a/lib/src/streams/race.dart
+++ b/lib/src/streams/race.dart
@@ -63,7 +63,6 @@ class RaceStream<T> extends StreamView<T> {
 
       if (subscriptions.isEmpty) {
         controller.close();
-        return;
       }
     };
     controller.onPause = () => subscriptions.pauseAll();

--- a/lib/src/streams/zip.dart
+++ b/lib/src/streams/zip.dart
@@ -277,69 +277,69 @@ class ZipStream<T, R> extends StreamView<R> {
     Iterable<Stream<T>> streams,
     R Function(List<T> values) zipper,
   ) {
-    if (streams.isEmpty) {
-      return StreamController<R>()..close();
-    }
+    final controller = StreamController<R>(sync: true);
+    late List<StreamSubscription<T>> subscriptions;
+    var pendingSubscriptions = <StreamSubscription<T>>[];
 
-    late StreamController<R> controller;
-    final len = streams.length;
-    late List<StreamSubscription<T>> subscriptions, pendingSubscriptions;
+    controller.onListen = () {
+      try {
+        Completer<List<T>?>? completeCurrent;
+        late final _Window<T> window;
+        var index = 0;
 
-    controller = StreamController<R>(
-        sync: true,
-        onListen: () {
-          try {
-            Completer<List<T>?>? completeCurrent;
-            final window = _Window<T>(len);
-            var index = 0;
+        // resets variables for the next zip window
+        void next() {
+          completeCurrent?.complete(null);
 
-            // resets variables for the next zip window
-            void next() {
-              completeCurrent?.complete(null);
+          completeCurrent = Completer<List<T>?>();
 
-              completeCurrent = Completer<List<T>?>();
+          pendingSubscriptions = subscriptions.toList();
+        }
 
-              pendingSubscriptions = subscriptions.toList();
+        void Function(T value) doUpdate(int index) {
+          return (T value) {
+            window.onValue(index, value);
+
+            if (window.isComplete) {
+              // all streams emitted for the current zip index
+              // dispatch event and reset for next
+              try {
+                controller.add(zipper(window.flush()));
+                // reset for next zip event
+                next();
+              } catch (e, s) {
+                controller.addError(e, s);
+              }
+            } else {
+              // other streams are still pending to get to the next
+              // zip event index.
+              // pause this subscription while we await the others
+              //ignore: cancel_subscriptions
+              final subscription = subscriptions[index]
+                ..pause(completeCurrent!.future);
+
+              pendingSubscriptions.remove(subscription);
             }
+          };
+        }
 
-            void Function(T value) doUpdate(int index) => (T value) {
-                  window.onValue(index, value);
-
-                  if (window.isComplete) {
-                    // all streams emitted for the current zip index
-                    // dispatch event and reset for next
-                    try {
-                      controller.add(zipper(window.flush()));
-                      // reset for next zip event
-                      next();
-                    } catch (e, s) {
-                      controller.addError(e, s);
-                    }
-                  } else {
-                    // other streams are still pending to get to the next
-                    // zip event index.
-                    // pause this subscription while we await the others
-                    //ignore: cancel_subscriptions
-                    final subscription = subscriptions[index]
-                      ..pause(completeCurrent!.future);
-
-                    pendingSubscriptions.remove(subscription);
-                  }
-                };
-
-            subscriptions = streams
-                .map((stream) => stream.listen(doUpdate(index++),
-                    onError: controller.addError, onDone: controller.close))
-                .toList(growable: false);
-
-            next();
-          } catch (e, s) {
-            controller.addError(e, s);
-          }
-        },
-        onPause: () => pendingSubscriptions.pauseAll(),
-        onResume: () => pendingSubscriptions.resumeAll(),
-        onCancel: () => pendingSubscriptions.cancelAll());
+        subscriptions = streams
+            .map((stream) => stream.listen(doUpdate(index++),
+                onError: controller.addError, onDone: controller.close))
+            .toList(growable: false);
+        if (subscriptions.isEmpty) {
+          controller.close();
+        } else {
+          window = _Window<T>(subscriptions.length);
+          next();
+        }
+      } catch (e, s) {
+        controller.addError(e, s);
+      }
+    };
+    controller.onPause = () => pendingSubscriptions.pauseAll();
+    controller.onResume = () => pendingSubscriptions.resumeAll();
+    controller.onCancel = () => pendingSubscriptions.cancelAll();
 
     return controller;
   }

--- a/test/streams/fork_join_test.dart
+++ b/test/streams/fork_join_test.dart
@@ -48,7 +48,7 @@ void main() {
     );
   });
 
-  test('Rx.concatEager.iterate.once', () async {
+  test('Rx.forkJoin.iterate.once', () async {
     var iterationCount = 0;
 
     final stream = Rx.forkJoinList<int>(() sync* {

--- a/test/streams/merge_test.dart
+++ b/test/streams/merge_test.dart
@@ -18,6 +18,28 @@ void main() {
     await expectLater(stream, emitsInOrder(const <int>[1, 2, 3, 4, 0, 1, 2]));
   });
 
+  test('Rx.merge.iterate.once', () async {
+    var iterationCount = 0;
+
+    final stream = Rx.merge<int>(() sync* {
+      ++iterationCount;
+      yield Stream.value(1);
+      yield Stream.value(2);
+      yield Stream.value(3);
+    }());
+
+    await expectLater(
+      stream,
+      emitsInOrder(<dynamic>[
+        1,
+        2,
+        3,
+        emitsDone,
+      ]),
+    );
+    expect(iterationCount, 1);
+  });
+
   test('Rx.merge.single.subscription', () async {
     final stream = Rx.merge(_getStreams());
 

--- a/test/streams/race_test.dart
+++ b/test/streams/race_test.dart
@@ -28,6 +28,23 @@ void main() {
     }, count: 3));
   });
 
+  test('Rx.race.iterate.once', () async {
+    var iterationCount = 0;
+
+    final stream = Rx.race<int>(() sync* {
+      ++iterationCount;
+      yield Stream.value(1);
+      yield Stream.value(2);
+      yield Stream.value(3);
+    }());
+
+    await expectLater(
+      stream,
+      emitsInOrder(<dynamic>[1, emitsDone]),
+    );
+    expect(iterationCount, 1);
+  });
+
   test('Rx.race.single.subscription', () async {
     final first = getDelayedStream(50, 1);
 

--- a/test/streams/race_test.dart
+++ b/test/streams/race_test.dart
@@ -97,6 +97,16 @@ void main() {
     expect(Rx.race<int>(const []), emitsDone);
   });
 
+  test('Rx.race.single', () {
+    expect(
+      Rx.race<int>([Stream.value(1)]),
+      emitsInOrder(<Object>[
+        1,
+        emitsDone,
+      ]),
+    );
+  });
+
   test('Rx.race.cancel.throws', () async {
     Stream<int> stream() {
       final controller = StreamController<int>();

--- a/test/streams/zip_test.dart
+++ b/test/streams/zip_test.dart
@@ -18,6 +18,26 @@ void main() {
     expect(Rx.zipList<int>([]), emitsDone);
   });
 
+  test('Rx.zip.iterate.once', () async {
+    var iterationCount = 0;
+
+    final stream = Rx.zipList<int>(() sync* {
+      ++iterationCount;
+      yield Stream.value(1);
+      yield Stream.value(2);
+      yield Stream.value(3);
+    }());
+
+    await expectLater(
+      stream,
+      emitsInOrder(<dynamic>[
+        [1, 2, 3],
+        emitsDone,
+      ]),
+    );
+    expect(iterationCount, 1);
+  });
+
   test('Rx.zipList', () async {
     expect(
       Rx.zipList([

--- a/test/streams/zip_test.dart
+++ b/test/streams/zip_test.dart
@@ -18,6 +18,16 @@ void main() {
     expect(Rx.zipList<int>([]), emitsDone);
   });
 
+  test('Rx.zip.single', () {
+    expect(
+      Rx.zipList<int>([Stream.value(1)]),
+      emitsInOrder(<Object>[
+        [1],
+        emitsDone
+      ]),
+    );
+  });
+
   test('Rx.zip.iterate.once', () async {
     var iterationCount = 0;
 


### PR DESCRIPTION
Continue #647 