### PR TITLE
fix(withLatestFrom): should iterate over `Iterable<Stream>` once

### DIFF
--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/collection_extensions.dart';
 import 'package:rxdart/src/utils/forwarding_sink.dart';
 import 'package:rxdart/src/utils/forwarding_stream.dart';
 import 'package:rxdart/src/utils/subscription.dart';
@@ -7,20 +8,19 @@ import 'package:rxdart/src/utils/subscription.dart';
 class _WithLatestFromStreamSink<S, T, R> extends ForwardingSink<S, R> {
   final Iterable<Stream<T>> _latestFromStreams;
   final R Function(S t, List<T> values) _combiner;
-  final List<bool> _hasValues;
-  final List<T?> _latestValues;
-  List<StreamSubscription<T>>? _subscriptions;
 
-  _WithLatestFromStreamSink(this._latestFromStreams, this._combiner)
-      : _hasValues = List.filled(_latestFromStreams.length, false),
-        _latestValues = List<T?>.filled(_latestFromStreams.length, null);
+  bool _hasAllValues = false;
+  List<T?>? _latestValues;
+  late List<StreamSubscription<T>> _subscriptions;
+
+  _WithLatestFromStreamSink(this._latestFromStreams, this._combiner);
 
   @override
   void onData(S data) {
-    if (_hasValues.every((value) => value)) {
+    if (_hasAllValues && _latestValues != null) {
       final R combinedValue;
       try {
-        combinedValue = _combiner(data, List<T>.unmodifiable(_latestValues));
+        combinedValue = _combiner(data, List<T>.unmodifiable(_latestValues!));
       } catch (e, s) {
         sink.addError(e, s);
         return;
@@ -36,31 +36,45 @@ class _WithLatestFromStreamSink<S, T, R> extends ForwardingSink<S, R> {
   void onDone() => sink.close();
 
   @override
-  Future<void>? onCancel() => _subscriptions?.cancelAll();
+  Future<void>? onCancel() {
+    _latestValues = null;
+    return _subscriptions.cancelAll();
+  }
 
   @override
   void onListen() {
-    var index = 0;
+    var count = 0;
 
-    StreamSubscription<T> mapper(Stream<T> stream) {
-      var i = index++;
+    StreamSubscription<T> mapper(int index, Stream<T> stream) {
+      var hasValue = false;
+
       return stream.listen(
-        (it) {
-          _hasValues[i] = true;
-          _latestValues[i] = it;
+        (value) {
+          if (!hasValue) {
+            hasValue = true;
+            if (++count == _subscriptions.length) {
+              _hasAllValues = true;
+            }
+          }
+          _latestValues![index] = value;
         },
         onError: sink.addError,
       );
     }
 
-    _subscriptions = _latestFromStreams.map(mapper).toList(growable: false);
+    _subscriptions =
+        _latestFromStreams.mapIndexed(mapper).toList(growable: false);
+    if (_subscriptions.isEmpty) {
+      return sink.close();
+    }
+    _latestValues = List.filled(_subscriptions.length, null);
   }
 
   @override
-  void onPause() => _subscriptions?.pauseAll();
+  void onPause() => _subscriptions.pauseAll();
 
   @override
-  void onResume() => _subscriptions?.resumeAll();
+  void onResume() => _subscriptions.resumeAll();
 }
 
 /// A StreamTransformer that emits when the source stream emits, combining

--- a/lib/src/transformers/with_latest_from.dart
+++ b/lib/src/transformers/with_latest_from.dart
@@ -9,7 +9,7 @@ class _WithLatestFromStreamSink<S, T, R> extends ForwardingSink<S, R> {
   final Iterable<Stream<T>> _latestFromStreams;
   final R Function(S t, List<T> values) _combiner;
 
-  bool _hasAllValues = false;
+  bool _hasValues = false;
   List<T?>? _latestValues;
   late List<StreamSubscription<T>> _subscriptions;
 
@@ -17,7 +17,7 @@ class _WithLatestFromStreamSink<S, T, R> extends ForwardingSink<S, R> {
 
   @override
   void onData(S data) {
-    if (_hasAllValues && _latestValues != null) {
+    if (_hasValues && _latestValues != null) {
       final R combinedValue;
       try {
         combinedValue = _combiner(data, List<T>.unmodifiable(_latestValues!));
@@ -53,7 +53,7 @@ class _WithLatestFromStreamSink<S, T, R> extends ForwardingSink<S, R> {
           if (!hasValue) {
             hasValue = true;
             if (++count == _subscriptions.length) {
-              _hasAllValues = true;
+              _hasValues = true;
             }
           }
           _latestValues![index] = value;
@@ -65,7 +65,7 @@ class _WithLatestFromStreamSink<S, T, R> extends ForwardingSink<S, R> {
     _subscriptions =
         _latestFromStreams.mapIndexed(mapper).toList(growable: false);
     if (_subscriptions.isEmpty) {
-      return sink.close();
+      _hasValues = true;
     }
     _latestValues = List.filled(_subscriptions.length, null);
   }

--- a/test/transformers/with_latest_from_test.dart
+++ b/test/transformers/with_latest_from_test.dart
@@ -55,6 +55,25 @@ void main() {
         emitsInOrder(expectedOutput));
   });
 
+  test('Rx.withLatestFrom.iterate.once', () async {
+    var iterationCount = 0;
+
+    final combined = Stream.value(1).withLatestFromList(() sync* {
+      ++iterationCount;
+      yield Stream.value(2);
+      yield Stream.value(3);
+    }());
+
+    await expectLater(
+      combined,
+      emitsInOrder(<dynamic>[
+        [1, 2, 3],
+        emitsDone,
+      ]),
+    );
+    expect(iterationCount, 1);
+  });
+
   test('Rx.withLatestFrom.reusable', () async {
     final streams = _createTestStreams();
     final transformer = WithLatestFromStreamTransformer.with1<int, int, Pair>(


### PR DESCRIPTION
Also use less resources