### PR TITLE
docs: update `rxmarbles` URL for `RaceStream`

### DIFF
--- a/lib/src/streams/race.dart
+++ b/lib/src/streams/race.dart
@@ -9,7 +9,7 @@ import 'package:rxdart/src/utils/subscription.dart';
 /// If the provided streams is empty, the resulting sequence completes immediately
 /// without emitting any items.
 ///
-/// [Interactive marble diagram](http://rxmarbles.com/#amb)
+/// [Interactive marble diagram](http://rxmarbles.com/#race)
 ///
 /// ### Example
 ///


### PR DESCRIPTION
The old link http://rxmarbles.com/#amb does not exist.

This PR fixes the issue by updating the link to http://rxmarbles.com/#race.