### PR TITLE
ci: remove deprecated `packages` flag

### DIFF
--- a/.github/workflows/rxdart-test.yml
+++ b/.github/workflows/rxdart-test.yml
@@ -66,7 +66,6 @@ jobs:
           --lcov
           --in=coverage.json
           --out=lcov.info
-          --packages=.packages
           --report-on=lib
 
       - uses: codecov/codecov-action@v2.1.0


### PR DESCRIPTION
Hi there.

Form `coverage`  [v1.3.0 - 2022-5-11 changelog](https://github.com/dart-lang/coverage/blob/master/CHANGELOG.md#130---2022-5-11):
>Add a --package flag, which takes the package's root directory, instead of the .package file. Deprecate the --packages flag.

Our ci raised an issue the same as dart-lang/coverage#382, the quick fix would be remove deprecated `packages` flag as metioned [here](https://github.com/dart-lang/coverage/issues/382#issuecomment-1125493001).

Thanks.