### PR TITLE
fix(range): make sure `RangeStream` can only be listened to once

### DIFF
--- a/lib/src/streams/range.dart
+++ b/lib/src/streams/range.dart
@@ -42,7 +42,11 @@ class RangeStream extends Stream<int> {
       controller.onPause = subscription!.pause;
       controller.onResume = subscription!.resume;
     };
-    controller.onCancel = () => subscription?.cancel();
+    controller.onCancel = () {
+      final future = subscription?.cancel();
+      subscription = null;
+      return future;
+    };
 
     return controller.stream;
   }

--- a/lib/src/streams/range.dart
+++ b/lib/src/streams/range.dart
@@ -23,11 +23,27 @@ class RangeStream extends Stream<int> {
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   static Stream<int> _buildStream(int startInclusive, int endInclusive) {
-    final length = (endInclusive - startInclusive).abs() + 1;
-    int nextValue(int index) => startInclusive > endInclusive
-        ? startInclusive - index
-        : startInclusive + index;
+    final controller = StreamController<int>(sync: true);
+    StreamSubscription<int>? subscription;
 
-    return Stream.fromIterable(Iterable.generate(length, nextValue));
+    controller.onListen = () {
+      final length = (endInclusive - startInclusive).abs() + 1;
+      int nextValue(int index) => startInclusive > endInclusive
+          ? startInclusive - index
+          : startInclusive + index;
+
+      subscription =
+          Stream.fromIterable(Iterable.generate(length, nextValue)).listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+
+      controller.onPause = subscription!.pause;
+      controller.onResume = subscription!.resume;
+    };
+    controller.onCancel = () => subscription?.cancel();
+
+    return controller.stream;
   }
 }


### PR DESCRIPTION
since Dart 2.18.0, the Stream.fromIterable stream can now be listened to more than once (https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#dartasync)