### PR TITLE
fix example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The extension methods provided by RxDart can be used on any `Stream`. They conve
 ```dart
 Stream.fromIterable([1, 2, 3])
   .throttleTime(Duration(seconds: 1))
-  .listen(print); // prints 3
+  .listen(print); // prints 1
 ``` 
 
 #### List of Extension Methods


### PR DESCRIPTION
The default behavior of the `throttle` and `throttleTime` is to emit the leading item of the time window.  The implementation is correct, but the example of the README needs to be corrected. The example should print `1`, not `3`.