### PR TITLE
add ability to identify if latest data in the stream was value

### DIFF
--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -155,6 +155,9 @@ class ValueConnectableStream<T>
   bool get hasValue => _subject.hasValue;
 
   @override
+  bool get isLatestValue => _subject.isLatestValue;
+
+  @override
   T get value => _subject.value;
 
   @override

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -12,6 +12,9 @@ abstract class ValueStream<T> implements Stream<T> {
   /// Returns `true` when [value] is available.
   bool get hasValue;
 
+  /// Returns `true` when last emitted data in the [ValueStream] was [value]
+  bool get isLatestValue;
+
   /// Returns last emitted error, failing if there is no error.
   ///
   /// Throws [ValueStreamError] if this Stream has no error.

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -138,6 +138,9 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   bool get hasValue => isNotEmpty(_wrapper.value);
 
   @override
+  bool get isLatestValue => _wrapper.isValue;
+
+  @override
   T get value {
     final value = _wrapper.value;
     if (isNotEmpty(value)) {
@@ -240,6 +243,9 @@ class _BehaviorSubjectStream<T> extends Stream<T> implements ValueStream<T> {
 
   @override
   bool get hasValue => _subject.hasValue;
+
+  @override
+  bool get isLatestValue => _subject.isLatestValue;
 
   @override
   StackTrace? get stackTrace => _subject.stackTrace;

--- a/test/streams/value_connectable_stream_test.dart
+++ b/test/streams/value_connectable_stream_test.dart
@@ -169,6 +169,8 @@ void main() {
           expect(stream.value, 3);
           expect(stream.hasValue, isTrue);
 
+          expect(stream.isLatestValue, isFalse);
+
           expect(stream.errorOrNull, error);
           expect(stream.error, error);
           expect(stream.hasError, isTrue);

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -1251,5 +1251,41 @@ void main() {
       expect(identical(subject.stream, subject.stream), isFalse);
       expect(subject.stream == subject.stream, isTrue);
     });
+
+    test('isLatestValue returns false for an unseeded subject after addError', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>();
+
+      subject.add(1);
+      subject.addError('error');
+
+      expect(subject.isLatestValue, isFalse);
+    });
+
+    test('isLatestValue returns false for a seeded subject after addError', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>.seeded(1);
+
+      subject.addError('error');
+
+      expect(subject.isLatestValue, isFalse);
+    });
+
+    test('isLatestValue returns true for an seeded subject', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>.seeded(1);
+
+      expect(subject.isLatestValue, isTrue);
+    });
+
+    test('isLatestValue returns true after data event', () {
+      // ignore: close_sinks
+      final subject = BehaviorSubject<int>();
+
+      subject.addError('error');
+      subject.add(1);
+
+      expect(subject.isLatestValue, isTrue);
+    });
   });
 }


### PR DESCRIPTION
Provides proxy getter for Wrapper.isValue field, to identify if most recent data in the stream was value

fixes #603