### PR TITLE
refactor(utils): rename Notification to StreamNotification, Kind to NotificationKind

### DIFF
--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -174,7 +174,7 @@ class ValueConnectableStream<T>
   StackTrace? get stackTrace => _subject.stackTrace;
 
   @override
-  Notification<T>? get lastEventOrNull => _subject.lastEventOrNull;
+  RxNotification<T>? get lastEventOrNull => _subject.lastEventOrNull;
 }
 
 /// A [ConnectableStream] that converts a single-subscription Stream into

--- a/lib/src/streams/connectable_stream.dart
+++ b/lib/src/streams/connectable_stream.dart
@@ -174,7 +174,7 @@ class ValueConnectableStream<T>
   StackTrace? get stackTrace => _subject.stackTrace;
 
   @override
-  RxNotification<T>? get lastEventOrNull => _subject.lastEventOrNull;
+  StreamNotification<T>? get lastEventOrNull => _subject.lastEventOrNull;
 }
 
 /// A [ConnectableStream] that converts a single-subscription Stream into

--- a/lib/src/streams/replay_stream.dart
+++ b/lib/src/streams/replay_stream.dart
@@ -1,3 +1,6 @@
+import 'package:rxdart/src/utils/collection_extensions.dart';
+import 'package:rxdart/src/utils/error_and_stacktrace.dart';
+
 /// An [Stream] that provides synchronous access to the emitted values
 abstract class ReplayStream<T> implements Stream<T> {
   /// Synchronously get the values stored in Subject. May be empty.
@@ -8,4 +11,16 @@ abstract class ReplayStream<T> implements Stream<T> {
 
   /// Synchronously get the stack traces of errors stored in Subject. May be empty.
   List<StackTrace?> get stackTraces;
+}
+
+/// Extension method on [ReplayStream] to access the emitted [ErrorAndStackTrace]s.
+extension ErrorAndStackTracesReplayStreamExtension<T> on ReplayStream<T> {
+  /// Returns the emitted [ErrorAndStackTrace]s.
+  /// May be empty.
+  List<ErrorAndStackTrace> get errorAndStackTraces =>
+      errors.zipWith<ErrorAndStackTrace, StackTrace?>(
+        stackTraces,
+        (e, s) => ErrorAndStackTrace(e, s),
+        growable: false,
+      );
 }

--- a/lib/src/streams/sequence_equal.dart
+++ b/lib/src/streams/sequence_equal.dart
@@ -56,7 +56,7 @@ class SequenceEqualStream<S, T> extends Stream<bool> {
             ..add(value)
             ..close();
 
-          bool compare(RxNotification<S> s, RxNotification<T> t) {
+          bool compare(StreamNotification<S> s, StreamNotification<T> t) {
             if (s.kind != t.kind) {
               return false;
             }

--- a/lib/src/streams/sequence_equal.dart
+++ b/lib/src/streams/sequence_equal.dart
@@ -56,7 +56,7 @@ class SequenceEqualStream<S, T> extends Stream<bool> {
             ..add(value)
             ..close();
 
-          bool compare(Notification<S> s, Notification<T> t) {
+          bool compare(RxNotification<S> s, RxNotification<T> t) {
             if (s.kind != t.kind) {
               return false;
             }

--- a/lib/src/streams/sequence_equal.dart
+++ b/lib/src/streams/sequence_equal.dart
@@ -60,18 +60,19 @@ class SequenceEqualStream<S, T> extends Stream<bool> {
             if (s.kind != t.kind) {
               return false;
             }
+
             switch (s.kind) {
-              case Kind.onData:
+              case NotificationKind.data:
                 return dataEquals!(
-                  s.requireData,
-                  t.requireData,
+                  s.requireDataValue,
+                  t.requireDataValue,
                 );
-              case Kind.onDone:
+              case NotificationKind.done:
                 return true;
-              case Kind.onError:
+              case NotificationKind.error:
                 return errorEquals!(
-                  s.errorAndStackTrace!,
-                  t.errorAndStackTrace!,
+                  s.requireErrorAndStackTrace,
+                  t.requireErrorAndStackTrace,
                 );
             }
           }

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -48,10 +48,10 @@ abstract class ValueStream<T> implements Stream<T> {
 /// Extension methods on [ValueStream] related to [lastEventOrNull].
 extension LastEventValueStreamExtensions<T> on ValueStream<T> {
   /// Returns `true` if the last emitted event is a data event (aka. a value event).
-  bool get isLastEventValue => lastEventOrNull?.isOnData ?? false;
+  bool get isLastEventValue => lastEventOrNull?.isData ?? false;
 
   /// Returns `true` if the last emitted event is an error event.
-  bool get isLastEventError => lastEventOrNull?.isOnError ?? false;
+  bool get isLastEventError => lastEventOrNull?.isError ?? false;
 }
 
 /// Extension method on [ValueStream] to access the last emitted [ErrorAndStackTrace].

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -42,7 +42,7 @@ abstract class ValueStream<T> implements Stream<T> {
 
   /// Returns the last emitted event (either data/value or error event).
   /// `null` if no value or error events have been emitted yet.
-  RxNotification<T>? get lastEventOrNull;
+  StreamNotification<T>? get lastEventOrNull;
 }
 
 /// Extension methods on [ValueStream] related to [lastEventOrNull].

--- a/lib/src/streams/value_stream.dart
+++ b/lib/src/streams/value_stream.dart
@@ -42,7 +42,7 @@ abstract class ValueStream<T> implements Stream<T> {
 
   /// Returns the last emitted event (either data/value or error event).
   /// `null` if no value or error events have been emitted yet.
-  Notification<T>? get lastEventOrNull;
+  RxNotification<T>? get lastEventOrNull;
 }
 
 /// Extension methods on [ValueStream] related to [lastEventOrNull].

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -172,10 +172,10 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   StackTrace? get stackTrace => _wrapper.errorAndStackTrace?.stackTrace;
 
   @override
-  RxNotification<T>? get lastEventOrNull {
+  StreamNotification<T>? get lastEventOrNull {
     // data event
     if (_wrapper.isValue) {
-      return RxNotification.data(_wrapper.value as T);
+      return StreamNotification.data(_wrapper.value as T);
     }
 
     // error event
@@ -271,5 +271,5 @@ class _BehaviorSubjectStream<T> extends Stream<T> implements ValueStream<T> {
   T? get valueOrNull => _subject.valueOrNull;
 
   @override
-  RxNotification<T>? get lastEventOrNull => _subject.lastEventOrNull;
+  StreamNotification<T>? get lastEventOrNull => _subject.lastEventOrNull;
 }

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -175,13 +175,13 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   RxNotification<T>? get lastEventOrNull {
     // data event
     if (_wrapper.isValue) {
-      return RxNotification.onData(_wrapper.value as T);
+      return RxNotification.data(_wrapper.value as T);
     }
 
     // error event
     final errorAndSt = _wrapper.errorAndStackTrace;
     if (errorAndSt != null) {
-      return RxNotification.onErrorFrom(errorAndStackTrace: errorAndSt);
+      return ErrorNotification(errorAndSt);
     }
 
     // no event

--- a/lib/src/subjects/behavior_subject.dart
+++ b/lib/src/subjects/behavior_subject.dart
@@ -172,16 +172,16 @@ class BehaviorSubject<T> extends Subject<T> implements ValueStream<T> {
   StackTrace? get stackTrace => _wrapper.errorAndStackTrace?.stackTrace;
 
   @override
-  Notification<T>? get lastEventOrNull {
+  RxNotification<T>? get lastEventOrNull {
     // data event
     if (_wrapper.isValue) {
-      return Notification.onData(_wrapper.value as T);
+      return RxNotification.onData(_wrapper.value as T);
     }
 
     // error event
     final errorAndSt = _wrapper.errorAndStackTrace;
     if (errorAndSt != null) {
-      return Notification.onErrorFrom(errorAndStackTrace: errorAndSt);
+      return RxNotification.onErrorFrom(errorAndStackTrace: errorAndSt);
     }
 
     // no event
@@ -271,5 +271,5 @@ class _BehaviorSubjectStream<T> extends Stream<T> implements ValueStream<T> {
   T? get valueOrNull => _subject.valueOrNull;
 
   @override
-  Notification<T>? get lastEventOrNull => _subject.lastEventOrNull;
+  RxNotification<T>? get lastEventOrNull => _subject.lastEventOrNull;
 }

--- a/lib/src/transformers/dematerialize.dart
+++ b/lib/src/transformers/dematerialize.dart
@@ -3,13 +3,13 @@ import 'dart:async';
 import 'package:rxdart/src/utils/forwarding_sink.dart';
 import 'package:rxdart/src/utils/notification.dart';
 
-class _DematerializeStreamSink<S> implements EventSink<RxNotification<S>> {
+class _DematerializeStreamSink<S> implements EventSink<StreamNotification<S>> {
   final EventSink<S> _outputSink;
 
   _DematerializeStreamSink(this._outputSink);
 
   @override
-  void add(RxNotification<S> data) => data.when(
+  void add(StreamNotification<S> data) => data.when(
         data: _outputSink.add,
         done: _outputSink.close,
         error: _outputSink.addErrorAndStackTrace,
@@ -22,59 +22,59 @@ class _DematerializeStreamSink<S> implements EventSink<RxNotification<S>> {
   void close() => _outputSink.close();
 }
 
-/// Converts the onData, onDone, and onError [RxNotification] objects from a
+/// Converts the onData, onDone, and onError [StreamNotification] objects from a
 /// materialized stream into normal onData, onDone, and onError events.
 ///
 /// When a stream has been materialized, it emits onData, onDone, and onError
-/// events as [RxNotification] objects. Dematerialize simply reverses this by
-/// transforming [RxNotification] objects back to a normal stream of events.
+/// events as [StreamNotification] objects. Dematerialize simply reverses this by
+/// transforming [StreamNotification] objects back to a normal stream of events.
 ///
 /// ### Example
 ///
-///     Stream<RxNotification<int>>
-///         .fromIterable([RxNotification.onData(1), RxNotification.onDone()])
+///     Stream<StreamNotification<int>>
+///         .fromIterable([StreamNotification.onData(1), StreamNotification.onDone()])
 ///         .transform(DematerializeStreamTransformer())
 ///         .listen((i) => print(i)); // Prints 1
 ///
 /// ### Error example
 ///
-///     Stream<RxNotification<int>>
-///         .fromIterable([RxNotification.onError(Exception(), null)])
+///     Stream<StreamNotification<int>>
+///         .fromIterable([StreamNotification.onError(Exception(), null)])
 ///         .transform(DematerializeStreamTransformer())
 ///         .listen(null, onError: (e, s) { print(e) }); // Prints Exception
 class DematerializeStreamTransformer<S>
-    extends StreamTransformerBase<RxNotification<S>, S> {
+    extends StreamTransformerBase<StreamNotification<S>, S> {
   /// Constructs a [StreamTransformer] which converts the onData, onDone, and
-  /// onError [RxNotification] objects from a materialized stream into normal
+  /// onError [StreamNotification] objects from a materialized stream into normal
   /// onData, onDone, and onError events.
   DematerializeStreamTransformer();
 
   @override
-  Stream<S> bind(Stream<RxNotification<S>> stream) =>
+  Stream<S> bind(Stream<StreamNotification<S>> stream) =>
       Stream.eventTransformed(stream, (sink) => _DematerializeStreamSink(sink));
 }
 
-/// Converts the onData, onDone, and onError [RxNotification]s from a
+/// Converts the onData, onDone, and onError [StreamNotification]s from a
 /// materialized stream into normal onData, onDone, and onError events.
-extension DematerializeExtension<T> on Stream<RxNotification<T>> {
-  /// Converts the onData, onDone, and onError [RxNotification] objects from a
+extension DematerializeExtension<T> on Stream<StreamNotification<T>> {
+  /// Converts the onData, onDone, and onError [StreamNotification] objects from a
   /// materialized stream into normal onData, onDone, and onError events.
   ///
   /// When a stream has been materialized, it emits onData, onDone, and onError
-  /// events as [RxNotification] objects. Dematerialize simply reverses this by
-  /// transforming [RxNotification] objects back to a normal stream of events.
+  /// events as [StreamNotification] objects. Dematerialize simply reverses this by
+  /// transforming [StreamNotification] objects back to a normal stream of events.
   ///
   /// ### Example
   ///
-  ///     Stream<RxNotification<int>>
-  ///         .fromIterable([RxNotification.onData(1), RxNotification.onDone()])
+  ///     Stream<StreamNotification<int>>
+  ///         .fromIterable([StreamNotification.onData(1), StreamNotification.onDone()])
   ///         .dematerialize()
   ///         .listen((i) => print(i)); // Prints 1
   ///
   /// ### Error example
   ///
-  ///     Stream<RxNotification<int>>
-  ///         .fromIterable([RxNotification.onError(Exception(), null)])
+  ///     Stream<StreamNotification<int>>
+  ///         .fromIterable([StreamNotification.onError(Exception(), null)])
   ///         .dematerialize()
   ///         .listen(null, onError: (e, s) { print(e) }); // Prints Exception
   Stream<T> dematerialize() => DematerializeStreamTransformer<T>().bind(this);

--- a/lib/src/transformers/dematerialize.dart
+++ b/lib/src/transformers/dematerialize.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/forwarding_sink.dart';
 import 'package:rxdart/src/utils/notification.dart';
 
 class _DematerializeStreamSink<S> implements EventSink<RxNotification<S>> {
@@ -8,19 +9,11 @@ class _DematerializeStreamSink<S> implements EventSink<RxNotification<S>> {
   _DematerializeStreamSink(this._outputSink);
 
   @override
-  void add(RxNotification<S> data) {
-    if (data.isOnData) {
-      _outputSink.add(data.requireData);
-    } else if (data.isOnDone) {
-      _outputSink.close();
-    } else if (data.isOnError) {
-      final errorAndStackTrace = data.errorAndStackTrace!;
-      _outputSink.addError(
-        errorAndStackTrace.error,
-        errorAndStackTrace.stackTrace,
+  void add(RxNotification<S> data) => data.when(
+        data: _outputSink.add,
+        done: _outputSink.close,
+        error: _outputSink.addErrorAndStackTrace,
       );
-    }
-  }
 
   @override
   void addError(e, [st]) => _outputSink.addError(e, st);

--- a/lib/src/transformers/dematerialize.dart
+++ b/lib/src/transformers/dematerialize.dart
@@ -2,13 +2,13 @@ import 'dart:async';
 
 import 'package:rxdart/src/utils/notification.dart';
 
-class _DematerializeStreamSink<S> implements EventSink<Notification<S>> {
+class _DematerializeStreamSink<S> implements EventSink<RxNotification<S>> {
   final EventSink<S> _outputSink;
 
   _DematerializeStreamSink(this._outputSink);
 
   @override
-  void add(Notification<S> data) {
+  void add(RxNotification<S> data) {
     if (data.isOnData) {
       _outputSink.add(data.requireData);
     } else if (data.isOnDone) {
@@ -29,59 +29,59 @@ class _DematerializeStreamSink<S> implements EventSink<Notification<S>> {
   void close() => _outputSink.close();
 }
 
-/// Converts the onData, onDone, and onError [Notification] objects from a
+/// Converts the onData, onDone, and onError [RxNotification] objects from a
 /// materialized stream into normal onData, onDone, and onError events.
 ///
 /// When a stream has been materialized, it emits onData, onDone, and onError
-/// events as [Notification] objects. Dematerialize simply reverses this by
-/// transforming [Notification] objects back to a normal stream of events.
+/// events as [RxNotification] objects. Dematerialize simply reverses this by
+/// transforming [RxNotification] objects back to a normal stream of events.
 ///
 /// ### Example
 ///
-///     Stream<Notification<int>>
-///         .fromIterable([Notification.onData(1), Notification.onDone()])
+///     Stream<RxNotification<int>>
+///         .fromIterable([RxNotification.onData(1), RxNotification.onDone()])
 ///         .transform(DematerializeStreamTransformer())
 ///         .listen((i) => print(i)); // Prints 1
 ///
 /// ### Error example
 ///
-///     Stream<Notification<int>>
-///         .fromIterable([Notification.onError(Exception(), null)])
+///     Stream<RxNotification<int>>
+///         .fromIterable([RxNotification.onError(Exception(), null)])
 ///         .transform(DematerializeStreamTransformer())
 ///         .listen(null, onError: (e, s) { print(e) }); // Prints Exception
 class DematerializeStreamTransformer<S>
-    extends StreamTransformerBase<Notification<S>, S> {
+    extends StreamTransformerBase<RxNotification<S>, S> {
   /// Constructs a [StreamTransformer] which converts the onData, onDone, and
-  /// onError [Notification] objects from a materialized stream into normal
+  /// onError [RxNotification] objects from a materialized stream into normal
   /// onData, onDone, and onError events.
   DematerializeStreamTransformer();
 
   @override
-  Stream<S> bind(Stream<Notification<S>> stream) =>
+  Stream<S> bind(Stream<RxNotification<S>> stream) =>
       Stream.eventTransformed(stream, (sink) => _DematerializeStreamSink(sink));
 }
 
-/// Converts the onData, onDone, and onError [Notification]s from a
+/// Converts the onData, onDone, and onError [RxNotification]s from a
 /// materialized stream into normal onData, onDone, and onError events.
-extension DematerializeExtension<T> on Stream<Notification<T>> {
-  /// Converts the onData, onDone, and onError [Notification] objects from a
+extension DematerializeExtension<T> on Stream<RxNotification<T>> {
+  /// Converts the onData, onDone, and onError [RxNotification] objects from a
   /// materialized stream into normal onData, onDone, and onError events.
   ///
   /// When a stream has been materialized, it emits onData, onDone, and onError
-  /// events as [Notification] objects. Dematerialize simply reverses this by
-  /// transforming [Notification] objects back to a normal stream of events.
+  /// events as [RxNotification] objects. Dematerialize simply reverses this by
+  /// transforming [RxNotification] objects back to a normal stream of events.
   ///
   /// ### Example
   ///
-  ///     Stream<Notification<int>>
-  ///         .fromIterable([Notification.onData(1), Notification.onDone()])
+  ///     Stream<RxNotification<int>>
+  ///         .fromIterable([RxNotification.onData(1), RxNotification.onDone()])
   ///         .dematerialize()
   ///         .listen((i) => print(i)); // Prints 1
   ///
   /// ### Error example
   ///
-  ///     Stream<Notification<int>>
-  ///         .fromIterable([Notification.onError(Exception(), null)])
+  ///     Stream<RxNotification<int>>
+  ///         .fromIterable([RxNotification.onError(Exception(), null)])
   ///         .dematerialize()
   ///         .listen(null, onError: (e, s) { print(e) }); // Prints Exception
   Stream<T> dematerialize() => DematerializeStreamTransformer<T>().bind(this);

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -33,7 +33,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
       sink.addError(e, s);
     }
     try {
-      _onEach?.call(RxNotification.onData(data));
+      _onEach?.call(RxNotification.data(data));
     } catch (e, s) {
       sink.addError(e, s);
     }
@@ -48,7 +48,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
       sink.addError(e, s);
     }
     try {
-      _onEach?.call(RxNotification.onError(e, st));
+      _onEach?.call(RxNotification.error(e, st));
     } catch (e, s) {
       sink.addError(e, s);
     }
@@ -63,7 +63,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
       sink.addError(e, s);
     }
     try {
-      _onEach?.call(RxNotification.onDone());
+      _onEach?.call(RxNotification.done());
     } catch (e, s) {
       sink.addError(e, s);
     }
@@ -120,7 +120,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
 ///
 /// In addition, the `onEach` argument is called at `onData`, `onDone`, and
 /// `onError` with a [RxNotification] passed in. The [RxNotification] argument
-/// contains the [Kind] of event (OnData, OnDone, OnError), and the item or
+/// contains the [NotificationKind] of event (OnData, OnDone, OnError), and the item or
 /// error that was emitted. In the case of onDone, no data is emitted as part
 /// of the [RxNotification].
 ///
@@ -243,7 +243,7 @@ extension DoExtensions<T> on Stream<T> {
   /// Invokes the given callback function when the stream emits data, emits
   /// an error, or emits done. The callback receives a [RxNotification] object.
   ///
-  /// The [RxNotification] object contains the [Kind] of event (OnData, onDone,
+  /// The [RxNotification] object contains the [NotificationKind] of event (OnData, onDone,
   /// or OnError), and the item or error that was emitted. In the case of
   /// onDone, no data is emitted as part of the [RxNotification].
   ///

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -8,7 +8,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
   final FutureOr<void> Function()? _onCancel;
   final void Function(S event)? _onData;
   final void Function()? _onDone;
-  final void Function(Notification<S> notification)? _onEach;
+  final void Function(RxNotification<S> notification)? _onEach;
   final void Function(Object, StackTrace)? _onError;
   final void Function()? _onListen;
   final void Function()? _onPause;
@@ -33,7 +33,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
       sink.addError(e, s);
     }
     try {
-      _onEach?.call(Notification.onData(data));
+      _onEach?.call(RxNotification.onData(data));
     } catch (e, s) {
       sink.addError(e, s);
     }
@@ -48,7 +48,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
       sink.addError(e, s);
     }
     try {
-      _onEach?.call(Notification.onError(e, st));
+      _onEach?.call(RxNotification.onError(e, st));
     } catch (e, s) {
       sink.addError(e, s);
     }
@@ -63,7 +63,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
       sink.addError(e, s);
     }
     try {
-      _onEach?.call(Notification.onDone());
+      _onEach?.call(RxNotification.onDone());
     } catch (e, s) {
       sink.addError(e, s);
     }
@@ -119,10 +119,10 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
 ///   - onResume
 ///
 /// In addition, the `onEach` argument is called at `onData`, `onDone`, and
-/// `onError` with a [Notification] passed in. The [Notification] argument
+/// `onError` with a [RxNotification] passed in. The [RxNotification] argument
 /// contains the [Kind] of event (OnData, OnDone, OnError), and the item or
 /// error that was emitted. In the case of onDone, no data is emitted as part
-/// of the [Notification].
+/// of the [RxNotification].
 ///
 /// If no callbacks are passed in, a runtime error will be thrown in dev mode
 /// in order to 'fail fast' and alert the developer that the transformer should
@@ -147,7 +147,7 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
   final void Function()? onDone;
 
   /// fires on data, close and error
-  final void Function(Notification<S> notification)? onEach;
+  final void Function(RxNotification<S> notification)? onEach;
 
   /// fires on errors
   final void Function(Object, StackTrace)? onError;
@@ -241,18 +241,18 @@ extension DoExtensions<T> on Stream<T> {
       DoStreamTransformer<T>(onDone: onDone).bind(this);
 
   /// Invokes the given callback function when the stream emits data, emits
-  /// an error, or emits done. The callback receives a [Notification] object.
+  /// an error, or emits done. The callback receives a [RxNotification] object.
   ///
-  /// The [Notification] object contains the [Kind] of event (OnData, onDone,
+  /// The [RxNotification] object contains the [Kind] of event (OnData, onDone,
   /// or OnError), and the item or error that was emitted. In the case of
-  /// onDone, no data is emitted as part of the [Notification].
+  /// onDone, no data is emitted as part of the [RxNotification].
   ///
   /// ### Example
   ///
   ///     Stream.fromIterable([1])
   ///       .doOnEach(print)
-  ///       .listen(null); // prints Notification{kind: OnData, value: 1, errorAndStackTrace: null}, Notification{kind: OnDone, value: null, errorAndStackTrace: null}
-  Stream<T> doOnEach(void Function(Notification<T> notification) onEach) =>
+  ///       .listen(null); // prints RxNotification{kind: OnData, value: 1, errorAndStackTrace: null}, RxNotification{kind: OnDone, value: null, errorAndStackTrace: null}
+  Stream<T> doOnEach(void Function(RxNotification<T> notification) onEach) =>
       DoStreamTransformer<T>(onEach: onEach).bind(this);
 
   /// Invokes the given callback function when the stream emits an error.

--- a/lib/src/transformers/do.dart
+++ b/lib/src/transformers/do.dart
@@ -8,7 +8,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
   final FutureOr<void> Function()? _onCancel;
   final void Function(S event)? _onData;
   final void Function()? _onDone;
-  final void Function(RxNotification<S> notification)? _onEach;
+  final void Function(StreamNotification<S> notification)? _onEach;
   final void Function(Object, StackTrace)? _onError;
   final void Function()? _onListen;
   final void Function()? _onPause;
@@ -33,7 +33,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
       sink.addError(e, s);
     }
     try {
-      _onEach?.call(RxNotification.data(data));
+      _onEach?.call(StreamNotification.data(data));
     } catch (e, s) {
       sink.addError(e, s);
     }
@@ -48,7 +48,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
       sink.addError(e, s);
     }
     try {
-      _onEach?.call(RxNotification.error(e, st));
+      _onEach?.call(StreamNotification.error(e, st));
     } catch (e, s) {
       sink.addError(e, s);
     }
@@ -63,7 +63,7 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
       sink.addError(e, s);
     }
     try {
-      _onEach?.call(RxNotification.done());
+      _onEach?.call(StreamNotification.done());
     } catch (e, s) {
       sink.addError(e, s);
     }
@@ -119,10 +119,10 @@ class _DoStreamSink<S> extends ForwardingSink<S, S> {
 ///   - onResume
 ///
 /// In addition, the `onEach` argument is called at `onData`, `onDone`, and
-/// `onError` with a [RxNotification] passed in. The [RxNotification] argument
+/// `onError` with a [StreamNotification] passed in. The [StreamNotification] argument
 /// contains the [NotificationKind] of event (OnData, OnDone, OnError), and the item or
 /// error that was emitted. In the case of onDone, no data is emitted as part
-/// of the [RxNotification].
+/// of the [StreamNotification].
 ///
 /// If no callbacks are passed in, a runtime error will be thrown in dev mode
 /// in order to 'fail fast' and alert the developer that the transformer should
@@ -147,7 +147,7 @@ class DoStreamTransformer<S> extends StreamTransformerBase<S, S> {
   final void Function()? onDone;
 
   /// fires on data, close and error
-  final void Function(RxNotification<S> notification)? onEach;
+  final void Function(StreamNotification<S> notification)? onEach;
 
   /// fires on errors
   final void Function(Object, StackTrace)? onError;
@@ -241,18 +241,19 @@ extension DoExtensions<T> on Stream<T> {
       DoStreamTransformer<T>(onDone: onDone).bind(this);
 
   /// Invokes the given callback function when the stream emits data, emits
-  /// an error, or emits done. The callback receives a [RxNotification] object.
+  /// an error, or emits done. The callback receives a [StreamNotification] object.
   ///
-  /// The [RxNotification] object contains the [NotificationKind] of event (OnData, onDone,
+  /// The [StreamNotification] object contains the [NotificationKind] of event (OnData, onDone,
   /// or OnError), and the item or error that was emitted. In the case of
-  /// onDone, no data is emitted as part of the [RxNotification].
+  /// onDone, no data is emitted as part of the [StreamNotification].
   ///
   /// ### Example
   ///
   ///     Stream.fromIterable([1])
   ///       .doOnEach(print)
-  ///       .listen(null); // prints RxNotification{kind: OnData, value: 1, errorAndStackTrace: null}, RxNotification{kind: OnDone, value: null, errorAndStackTrace: null}
-  Stream<T> doOnEach(void Function(RxNotification<T> notification) onEach) =>
+  ///       .listen(null); // prints StreamNotification{kind: OnData, value: 1, errorAndStackTrace: null}, StreamNotification{kind: OnDone, value: null, errorAndStackTrace: null}
+  Stream<T> doOnEach(
+          void Function(StreamNotification<T> notification) onEach) =>
       DoStreamTransformer<T>(onEach: onEach).bind(this);
 
   /// Invokes the given callback function when the stream emits an error.

--- a/lib/src/transformers/materialize.dart
+++ b/lib/src/transformers/materialize.dart
@@ -8,14 +8,14 @@ class _MaterializeStreamSink<S> implements EventSink<S> {
   _MaterializeStreamSink(this._outputSink);
 
   @override
-  void add(S data) => _outputSink.add(RxNotification.onData(data));
+  void add(S data) => _outputSink.add(RxNotification.data(data));
 
   @override
-  void addError(e, [st]) => _outputSink.add(RxNotification.onError(e, st));
+  void addError(e, [st]) => _outputSink.add(RxNotification.error(e, st));
 
   @override
   void close() {
-    _outputSink.add(RxNotification.onDone());
+    _outputSink.add(RxNotification.done());
     _outputSink.close();
   }
 }
@@ -23,7 +23,7 @@ class _MaterializeStreamSink<S> implements EventSink<S> {
 /// Converts the onData, on Done, and onError events into [RxNotification]
 /// objects that are passed into the downstream onData listener.
 ///
-/// The [RxNotification] object contains the [Kind] of event (OnData, onDone, or
+/// The [RxNotification] object contains the [NotificationKind] of event (OnData, onDone, or
 /// OnError), and the item or error that was emitted. In the case of onDone,
 /// no data is emitted as part of the [RxNotification].
 ///
@@ -50,7 +50,7 @@ extension MaterializeExtension<T> on Stream<T> {
   /// Converts the onData, on Done, and onError events into [RxNotification]
   /// objects that are passed into the downstream onData listener.
   ///
-  /// The [RxNotification] object contains the [Kind] of event (OnData, onDone, or
+  /// The [RxNotification] object contains the [NotificationKind] of event (OnData, onDone, or
   /// OnError), and the item or error that was emitted. In the case of onDone,
   /// no data is emitted as part of the [RxNotification].
   ///

--- a/lib/src/transformers/materialize.dart
+++ b/lib/src/transformers/materialize.dart
@@ -3,65 +3,65 @@ import 'dart:async';
 import 'package:rxdart/src/utils/notification.dart';
 
 class _MaterializeStreamSink<S> implements EventSink<S> {
-  final EventSink<Notification<S>> _outputSink;
+  final EventSink<RxNotification<S>> _outputSink;
 
   _MaterializeStreamSink(this._outputSink);
 
   @override
-  void add(S data) => _outputSink.add(Notification.onData(data));
+  void add(S data) => _outputSink.add(RxNotification.onData(data));
 
   @override
-  void addError(e, [st]) => _outputSink.add(Notification.onError(e, st));
+  void addError(e, [st]) => _outputSink.add(RxNotification.onError(e, st));
 
   @override
   void close() {
-    _outputSink.add(Notification.onDone());
+    _outputSink.add(RxNotification.onDone());
     _outputSink.close();
   }
 }
 
-/// Converts the onData, on Done, and onError events into [Notification]
+/// Converts the onData, on Done, and onError events into [RxNotification]
 /// objects that are passed into the downstream onData listener.
 ///
-/// The [Notification] object contains the [Kind] of event (OnData, onDone, or
+/// The [RxNotification] object contains the [Kind] of event (OnData, onDone, or
 /// OnError), and the item or error that was emitted. In the case of onDone,
-/// no data is emitted as part of the [Notification].
+/// no data is emitted as part of the [RxNotification].
 ///
 /// ### Example
 ///
 ///     Stream<int>.fromIterable([1])
 ///         .transform(MaterializeStreamTransformer())
-///         .listen((i) => print(i)); // Prints onData & onDone Notification
+///         .listen((i) => print(i)); // Prints onData & onDone RxNotification
 class MaterializeStreamTransformer<S>
-    extends StreamTransformerBase<S, Notification<S>> {
+    extends StreamTransformerBase<S, RxNotification<S>> {
   /// Constructs a [StreamTransformer] which transforms the onData, on Done,
-  /// and onError events into [Notification] objects.
+  /// and onError events into [RxNotification] objects.
   MaterializeStreamTransformer();
 
   @override
-  Stream<Notification<S>> bind(Stream<S> stream) => Stream.eventTransformed(
+  Stream<RxNotification<S>> bind(Stream<S> stream) => Stream.eventTransformed(
       stream, (sink) => _MaterializeStreamSink<S>(sink));
 }
 
 /// Extends the Stream class with the ability to convert the onData, on Done,
-/// and onError events into [Notification]s that are passed into the
+/// and onError events into [RxNotification]s that are passed into the
 /// downstream onData listener.
 extension MaterializeExtension<T> on Stream<T> {
-  /// Converts the onData, on Done, and onError events into [Notification]
+  /// Converts the onData, on Done, and onError events into [RxNotification]
   /// objects that are passed into the downstream onData listener.
   ///
-  /// The [Notification] object contains the [Kind] of event (OnData, onDone, or
+  /// The [RxNotification] object contains the [Kind] of event (OnData, onDone, or
   /// OnError), and the item or error that was emitted. In the case of onDone,
-  /// no data is emitted as part of the [Notification].
+  /// no data is emitted as part of the [RxNotification].
   ///
   /// Example:
   ///     Stream<int>.fromIterable([1])
   ///         .materialize()
-  ///         .listen((i) => print(i)); // Prints onData & onDone Notification
+  ///         .listen((i) => print(i)); // Prints onData & onDone RxNotification
   ///
   ///     Stream<int>.error(Exception())
   ///         .materialize()
-  ///         .listen((i) => print(i)); // Prints onError Notification
-  Stream<Notification<T>> materialize() =>
+  ///         .listen((i) => print(i)); // Prints onError RxNotification
+  Stream<RxNotification<T>> materialize() =>
       MaterializeStreamTransformer<T>().bind(this);
 }

--- a/lib/src/transformers/materialize.dart
+++ b/lib/src/transformers/materialize.dart
@@ -3,65 +3,66 @@ import 'dart:async';
 import 'package:rxdart/src/utils/notification.dart';
 
 class _MaterializeStreamSink<S> implements EventSink<S> {
-  final EventSink<RxNotification<S>> _outputSink;
+  final EventSink<StreamNotification<S>> _outputSink;
 
   _MaterializeStreamSink(this._outputSink);
 
   @override
-  void add(S data) => _outputSink.add(RxNotification.data(data));
+  void add(S data) => _outputSink.add(StreamNotification.data(data));
 
   @override
-  void addError(e, [st]) => _outputSink.add(RxNotification.error(e, st));
+  void addError(e, [st]) => _outputSink.add(StreamNotification.error(e, st));
 
   @override
   void close() {
-    _outputSink.add(RxNotification.done());
+    _outputSink.add(StreamNotification.done());
     _outputSink.close();
   }
 }
 
-/// Converts the onData, on Done, and onError events into [RxNotification]
+/// Converts the onData, on Done, and onError events into [StreamNotification]
 /// objects that are passed into the downstream onData listener.
 ///
-/// The [RxNotification] object contains the [NotificationKind] of event (OnData, onDone, or
+/// The [StreamNotification] object contains the [NotificationKind] of event (OnData, onDone, or
 /// OnError), and the item or error that was emitted. In the case of onDone,
-/// no data is emitted as part of the [RxNotification].
+/// no data is emitted as part of the [StreamNotification].
 ///
 /// ### Example
 ///
 ///     Stream<int>.fromIterable([1])
 ///         .transform(MaterializeStreamTransformer())
-///         .listen((i) => print(i)); // Prints onData & onDone RxNotification
+///         .listen((i) => print(i)); // Prints onData & onDone StreamNotification
 class MaterializeStreamTransformer<S>
-    extends StreamTransformerBase<S, RxNotification<S>> {
+    extends StreamTransformerBase<S, StreamNotification<S>> {
   /// Constructs a [StreamTransformer] which transforms the onData, on Done,
-  /// and onError events into [RxNotification] objects.
+  /// and onError events into [StreamNotification] objects.
   MaterializeStreamTransformer();
 
   @override
-  Stream<RxNotification<S>> bind(Stream<S> stream) => Stream.eventTransformed(
-      stream, (sink) => _MaterializeStreamSink<S>(sink));
+  Stream<StreamNotification<S>> bind(Stream<S> stream) =>
+      Stream.eventTransformed(
+          stream, (sink) => _MaterializeStreamSink<S>(sink));
 }
 
 /// Extends the Stream class with the ability to convert the onData, on Done,
-/// and onError events into [RxNotification]s that are passed into the
+/// and onError events into [StreamNotification]s that are passed into the
 /// downstream onData listener.
 extension MaterializeExtension<T> on Stream<T> {
-  /// Converts the onData, on Done, and onError events into [RxNotification]
+  /// Converts the onData, on Done, and onError events into [StreamNotification]
   /// objects that are passed into the downstream onData listener.
   ///
-  /// The [RxNotification] object contains the [NotificationKind] of event (OnData, onDone, or
+  /// The [StreamNotification] object contains the [NotificationKind] of event (OnData, onDone, or
   /// OnError), and the item or error that was emitted. In the case of onDone,
-  /// no data is emitted as part of the [RxNotification].
+  /// no data is emitted as part of the [StreamNotification].
   ///
   /// Example:
   ///     Stream<int>.fromIterable([1])
   ///         .materialize()
-  ///         .listen((i) => print(i)); // Prints onData & onDone RxNotification
+  ///         .listen((i) => print(i)); // Prints onData & onDone StreamNotification
   ///
   ///     Stream<int>.error(Exception())
   ///         .materialize()
-  ///         .listen((i) => print(i)); // Prints onError RxNotification
-  Stream<RxNotification<T>> materialize() =>
+  ///         .listen((i) => print(i)); // Prints onError StreamNotification
+  Stream<StreamNotification<T>> materialize() =>
       MaterializeStreamTransformer<T>().bind(this);
 }

--- a/lib/src/utils/collection_extensions.dart
+++ b/lib/src/utils/collection_extensions.dart
@@ -1,8 +1,30 @@
 import 'dart:collection';
+import 'dart:math';
 
 /// @internal
-/// Provides [mapNotNull] extension method on [Iterable].
-extension MapNotNullIterableExtension<T> on Iterable<T> {
+/// @nodoc
+/// Provides extension methods on [List].
+extension ListExtensions<T> on List<T> {
+  /// @internal
+  /// Returns a list of values built from the elements of this list
+  /// and the other list with the same index
+  /// using the provided transform function applied to each pair of elements.
+  /// The returned list has length of the shortest list.
+  List<R> zipWith<R, S>(
+    List<S> other,
+    R Function(T, S) transform, {
+    bool growable = true,
+  }) =>
+      List.generate(
+        min(length, other.length),
+        (index) => transform(this[index], other[index]),
+        growable: growable,
+      );
+}
+
+/// @internal
+/// Provides extension methods on [Iterable].
+extension IterableExtensions<T> on Iterable<T> {
   /// @internal
   /// The non-`null` results of calling [transform] on the elements of [this].
   ///

--- a/lib/src/utils/error_and_stacktrace.dart
+++ b/lib/src/utils/error_and_stacktrace.dart
@@ -13,7 +13,7 @@ class ErrorAndStackTrace {
 
   @override
   String toString() =>
-      'ErrorAndStackTrace{error: $error, stacktrace: $stackTrace}';
+      'ErrorAndStackTrace{error: $error, stackTrace: $stackTrace}';
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/utils/forwarding_sink.dart
+++ b/lib/src/utils/forwarding_sink.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:rxdart/src/utils/error_and_stacktrace.dart';
+
 /// A [Sink] that supports event hooks.
 ///
 /// This makes it suitable for certain rx transformers that need to
@@ -39,4 +41,13 @@ abstract class ForwardingSink<T, R> {
 
   /// Fires when a subscriber cancels.
   FutureOr<void> onCancel();
+}
+
+/// @internal
+/// @nodoc
+extension EventSinkExtension<T> on EventSink<T> {
+  /// @internal
+  /// @nodoc
+  void addErrorAndStackTrace(ErrorAndStackTrace errorAndSt) =>
+      addError(errorAndSt.error, errorAndSt.stackTrace);
 }

--- a/lib/src/utils/notification.dart
+++ b/lib/src/utils/notification.dart
@@ -1,105 +1,166 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 
-import 'package:rxdart/src/utils/empty.dart';
 import 'package:rxdart/src/utils/error_and_stacktrace.dart';
 
-/// The type of event used in [Notification]
-enum Kind {
-  /// Specifies an onData event
-  onData,
+/// The type of event used in [RxNotification]
+enum NotificationKind {
+  /// Specifies a data event
+  data,
 
-  /// Specifies an onDone event
-  onDone,
+  /// Specifies a done event
+  done,
 
   /// Specifies an error event
-  onError
+  error
 }
 
-/// This is an alias for [RxNotification].
-@Deprecated('Use RxNotification<T> instead. Will be removed in v0.29.0')
-typedef Notification<T> = RxNotification<T>;
-
-/// A class that encapsulates the [Kind] of event, value of the event in case of
+/// A class that encapsulates the [NotificationKind] of event, value of the event in case of
 /// onData, or the Error in the case of onError.
 
-/// A container object that wraps the [Kind] of event (OnData, OnDone, OnError),
+/// A container object that wraps the [NotificationKind] of event (OnData, OnDone, OnError),
 /// and the item or error that was emitted. In the case of onDone, no data is
-/// emitted as part of the [Notification].
-class RxNotification<T> {
-  /// References the [Kind] of this [Notification] event.
-  final Kind kind;
+/// emitted as part of the [RxNotification].
+abstract class RxNotification<T> {
+  /// References the [NotificationKind] of this [RxNotification] event.
+  final NotificationKind kind;
 
-  /// The data value, if applicable
-  final Object? _value;
+  const RxNotification._(this.kind);
 
-  /// The wrapped error and stack trace, if applicable
-  final ErrorAndStackTrace? errorAndStackTrace;
+  /// Constructs a [RxNotification] with [NotificationKind.data] and wraps a [value]
+  factory RxNotification.data(T value) => DataNotification<T>(value);
 
-  const RxNotification._(this.kind, this._value, this.errorAndStackTrace);
+  /// Constructs a [RxNotification] with [NotificationKind.done].
+  factory RxNotification.done() => DoneNotification();
 
-  /// Constructs a [Notification] which, depending on the [kind].
-  /// This is an internal constructor, and should not be used directly.
-  /// Use factory constructors instead. Will be removed in v0.29.0.
-  @Deprecated('Use factory constructors instead. Will be removed in v0.29.0')
-  const RxNotification(this.kind, this._value, this.errorAndStackTrace);
+  /// Constructs a [RxNotification] with [NotificationKind.error] and wraps an [error] and [stackTrace]
+  factory RxNotification.error(Object error, StackTrace? stackTrace) =>
+      ErrorNotification.from(error, stackTrace);
+}
 
-  /// Constructs a [Notification] with [Kind.onData] and wraps a [value]
-  factory RxNotification.onData(T value) =>
-      RxNotification<T>._(Kind.onData, value, null);
+/// TODO
+extension RxNotificationExtensions<T> on RxNotification<T> {
+  /// A test to determine if this [RxNotification] wraps a data event
+  bool get isData => kind == NotificationKind.data;
 
-  /// Constructs a [Notification] with [Kind.onDone].
-  factory RxNotification.onDone() =>
-      RxNotification<Never>._(Kind.onDone, EMPTY, null);
+  /// A test to determine if this [RxNotification] wraps a done event
+  bool get isDone => kind == NotificationKind.done;
 
-  /// Constructs a [Notification] with [Kind.onError] and wraps an [error] and [stackTrace]
-  factory RxNotification.onError(Object error, StackTrace? stackTrace) =>
-      RxNotification<Never>._(
-          Kind.onError, EMPTY, ErrorAndStackTrace(error, stackTrace));
+  /// A test to determine if this [RxNotification] wraps an error event
+  bool get isError => kind == NotificationKind.error;
 
-  /// @internal
-  /// Constructs a [Notification] with [Kind.onError] and wraps an [errorAndStackTrace].
-  factory RxNotification.onErrorFrom(
-          {required ErrorAndStackTrace errorAndStackTrace}) =>
-      RxNotification<Never>._(Kind.onError, EMPTY, errorAndStackTrace);
+  /// Returns data if [kind] is [NotificationKind.data], otherwise throws a [StateError] error.
+  T get requireDataValue => (this as DataNotification<T>).value;
+
+  /// TODO
+  T? get dataValueOrNull {
+    final self = this;
+    return self is DataNotification<T> ? self.value : null;
+  }
+
+  /// TODO
+  ErrorAndStackTrace get requireErrorAndStackTrace =>
+      (this as ErrorNotification).errorAndStackTrace;
+
+  /// TODO
+  ErrorAndStackTrace? get errorAndStackTraceOrNull {
+    final self = this;
+    return self is ErrorNotification ? self.errorAndStackTrace : null;
+  }
+
+  /// TODO
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  R when<R>({
+    required R Function(T value) data,
+    required R Function() done,
+    required R Function(ErrorAndStackTrace) error,
+  }) {
+    final self = this;
+    if (self is DataNotification<T>) {
+      return data(self.value);
+    }
+
+    if (self is DoneNotification) {
+      return done();
+    }
+
+    if (self is ErrorNotification) {
+      return error(self.errorAndStackTrace);
+    }
+
+    throw StateError('Unknown notification $self');
+  }
+}
+
+/// TODO
+class DataNotification<T> extends RxNotification<T> {
+  /// TODO
+  final T value;
+
+  /// TODO
+  const DataNotification(this.value) : super._(NotificationKind.data);
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is RxNotification &&
+      other is DataNotification &&
           runtimeType == other.runtimeType &&
-          kind == other.kind &&
-          _value == other._value &&
+          value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'DataNotification{value: $value}';
+}
+
+/// TODO
+class DoneNotification extends RxNotification<Never> {
+  /// TODO
+  const DoneNotification() : super._(NotificationKind.done);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DoneNotification && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => 0;
+
+  @override
+  String toString() => 'DoneNotification{}';
+}
+
+/// TODO
+class ErrorNotification extends RxNotification<Never> {
+  /// The wrapped error and stack trace, if applicable
+  final ErrorAndStackTrace errorAndStackTrace;
+
+  /// TODO
+  Object get error => errorAndStackTrace.error;
+
+  /// TODO
+  StackTrace? get stackTrace => errorAndStackTrace.stackTrace;
+
+  /// TODO
+  const ErrorNotification(this.errorAndStackTrace)
+      : super._(NotificationKind.error);
+
+  /// TODO
+  factory ErrorNotification.from(Object error, StackTrace? stackTrace) =>
+      ErrorNotification(ErrorAndStackTrace(error, stackTrace));
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ErrorNotification &&
+          runtimeType == other.runtimeType &&
           errorAndStackTrace == other.errorAndStackTrace;
 
   @override
-  int get hashCode =>
-      kind.hashCode ^ _value.hashCode ^ errorAndStackTrace.hashCode;
+  int get hashCode => errorAndStackTrace.hashCode;
 
   @override
-  String toString() {
-    switch (kind) {
-      case Kind.onData:
-        return 'Notification.onData{value: $_value}';
-      case Kind.onDone:
-        return 'Notification.onDone';
-      case Kind.onError:
-        final errorAndSt = errorAndStackTrace!;
-        return 'Notification.onError{error: ${errorAndSt.error}, stackTrace: ${errorAndSt.stackTrace}}';
-    }
-  }
-
-  /// A test to determine if this [Notification] wraps an onData event
-  bool get isOnData => kind == Kind.onData;
-
-  /// A test to determine if this [Notification] wraps an onDone event
-  bool get isOnDone => kind == Kind.onDone;
-
-  /// A test to determine if this [Notification] wraps an error event
-  bool get isOnError => kind == Kind.onError;
-
-  /// Returns data if [kind] is [Kind.onData], otherwise throws a [StateError] error.
-  T get requireData => isNotEmpty(_value)
-      ? _value as T
-      : (throw StateError(
-          'This notification has no data value, because its kind is $kind'));
+  String toString() =>
+      'ErrorNotification{error: $error, stackTrace: $stackTrace}';
 }

--- a/lib/src/utils/notification.dart
+++ b/lib/src/utils/notification.dart
@@ -2,7 +2,7 @@
 
 import 'package:rxdart/src/utils/error_and_stacktrace.dart';
 
-/// The type of event used in [RxNotification]
+/// The type of event used in [StreamNotification]
 enum NotificationKind {
   /// Specifies a data event
   data,
@@ -19,55 +19,60 @@ enum NotificationKind {
 
 /// A container object that wraps the [NotificationKind] of event (OnData, OnDone, OnError),
 /// and the item or error that was emitted. In the case of onDone, no data is
-/// emitted as part of the [RxNotification].
-abstract class RxNotification<T> {
-  /// References the [NotificationKind] of this [RxNotification] event.
+/// emitted as part of the [StreamNotification].
+abstract class StreamNotification<T> {
+  /// References the [NotificationKind] of this [StreamNotification] event.
   final NotificationKind kind;
 
-  const RxNotification._(this.kind);
+  const StreamNotification._(this.kind);
 
-  /// Constructs a [RxNotification] with [NotificationKind.data] and wraps a [value]
-  factory RxNotification.data(T value) => DataNotification<T>(value);
+  /// Constructs a [StreamNotification] with [NotificationKind.data] and wraps a [value]
+  factory StreamNotification.data(T value) => DataNotification<T>(value);
 
-  /// Constructs a [RxNotification] with [NotificationKind.done].
-  factory RxNotification.done() => DoneNotification();
+  /// Constructs a [StreamNotification] with [NotificationKind.done].
+  factory StreamNotification.done() => DoneNotification();
 
-  /// Constructs a [RxNotification] with [NotificationKind.error] and wraps an [error] and [stackTrace]
-  factory RxNotification.error(Object error, StackTrace? stackTrace) =>
+  /// Constructs a [StreamNotification] with [NotificationKind.error] and wraps an [error] and [stackTrace]
+  factory StreamNotification.error(Object error, StackTrace? stackTrace) =>
       ErrorNotification.from(error, stackTrace);
 }
 
-/// TODO
-extension RxNotificationExtensions<T> on RxNotification<T> {
-  /// A test to determine if this [RxNotification] wraps a data event
+/// Provides extension methods on [StreamNotification].
+extension StreamNotificationExtensions<T> on StreamNotification<T> {
+  /// A test to determine if this [StreamNotification] wraps a data event.
   bool get isData => kind == NotificationKind.data;
 
-  /// A test to determine if this [RxNotification] wraps a done event
+  /// A test to determine if this [StreamNotification] wraps a done event.
   bool get isDone => kind == NotificationKind.done;
 
-  /// A test to determine if this [RxNotification] wraps an error event
+  /// A test to determine if this [StreamNotification] wraps an error event.
   bool get isError => kind == NotificationKind.error;
 
-  /// Returns data if [kind] is [NotificationKind.data], otherwise throws a [StateError] error.
+  /// Returns data if [kind] is [NotificationKind.data],
+  /// otherwise throws a [TypeError] error.
+  /// See also [dataValueOrNull].
   T get requireDataValue => (this as DataNotification<T>).value;
 
-  /// TODO
+  /// Returns data if [kind] is [NotificationKind.data],
+  /// otherwise returns null.
   T? get dataValueOrNull {
     final self = this;
     return self is DataNotification<T> ? self.value : null;
   }
 
-  /// TODO
+  /// Returns error and stack trace if [kind] is [NotificationKind.error],
+  /// otherwise throws a [TypeError] error.
   ErrorAndStackTrace get requireErrorAndStackTrace =>
       (this as ErrorNotification).errorAndStackTrace;
 
-  /// TODO
+  /// Returns error and stack trace if [kind] is [NotificationKind.error],
+  /// otherwise returns null.
   ErrorAndStackTrace? get errorAndStackTraceOrNull {
     final self = this;
     return self is ErrorNotification ? self.errorAndStackTrace : null;
   }
 
-  /// TODO
+  /// Invokes the appropriate function on the [StreamNotification] based on the [kind].
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
   R when<R>({
@@ -93,7 +98,7 @@ extension RxNotificationExtensions<T> on RxNotification<T> {
 }
 
 /// TODO
-class DataNotification<T> extends RxNotification<T> {
+class DataNotification<T> extends StreamNotification<T> {
   /// TODO
   final T value;
 
@@ -115,7 +120,7 @@ class DataNotification<T> extends RxNotification<T> {
 }
 
 /// TODO
-class DoneNotification extends RxNotification<Never> {
+class DoneNotification extends StreamNotification<Never> {
   /// TODO
   const DoneNotification() : super._(NotificationKind.done);
 
@@ -132,7 +137,7 @@ class DoneNotification extends RxNotification<Never> {
 }
 
 /// TODO
-class ErrorNotification extends RxNotification<Never> {
+class ErrorNotification extends StreamNotification<Never> {
   /// The wrapped error and stack trace, if applicable
   final ErrorAndStackTrace errorAndStackTrace;
 

--- a/lib/src/utils/notification.dart
+++ b/lib/src/utils/notification.dart
@@ -15,13 +15,17 @@ enum Kind {
   onError
 }
 
+/// This is an alias for [RxNotification].
+@Deprecated('Use RxNotification<T> instead. Will be removed in v0.29.0')
+typedef Notification<T> = RxNotification<T>;
+
 /// A class that encapsulates the [Kind] of event, value of the event in case of
 /// onData, or the Error in the case of onError.
 
 /// A container object that wraps the [Kind] of event (OnData, OnDone, OnError),
 /// and the item or error that was emitted. In the case of onDone, no data is
 /// emitted as part of the [Notification].
-class Notification<T> {
+class RxNotification<T> {
   /// References the [Kind] of this [Notification] event.
   final Kind kind;
 
@@ -31,31 +35,37 @@ class Notification<T> {
   /// The wrapped error and stack trace, if applicable
   final ErrorAndStackTrace? errorAndStackTrace;
 
-  const Notification._(this.kind, this._value, this.errorAndStackTrace);
+  const RxNotification._(this.kind, this._value, this.errorAndStackTrace);
+
+  /// Constructs a [Notification] which, depending on the [kind].
+  /// This is an internal constructor, and should not be used directly.
+  /// Use factory constructors instead. Will be removed in v0.29.0.
+  @Deprecated('Use factory constructors instead. Will be removed in v0.29.0')
+  const RxNotification(this.kind, this._value, this.errorAndStackTrace);
 
   /// Constructs a [Notification] with [Kind.onData] and wraps a [value]
-  factory Notification.onData(T value) =>
-      Notification<T>._(Kind.onData, value, null);
+  factory RxNotification.onData(T value) =>
+      RxNotification<T>._(Kind.onData, value, null);
 
   /// Constructs a [Notification] with [Kind.onDone].
-  factory Notification.onDone() =>
-      const Notification<Never>._(Kind.onDone, EMPTY, null);
+  factory RxNotification.onDone() =>
+      RxNotification<Never>._(Kind.onDone, EMPTY, null);
 
   /// Constructs a [Notification] with [Kind.onError] and wraps an [error] and [stackTrace]
-  factory Notification.onError(Object error, StackTrace? stackTrace) =>
-      Notification<Never>._(
+  factory RxNotification.onError(Object error, StackTrace? stackTrace) =>
+      RxNotification<Never>._(
           Kind.onError, EMPTY, ErrorAndStackTrace(error, stackTrace));
 
   /// @internal
   /// Constructs a [Notification] with [Kind.onError] and wraps an [errorAndStackTrace].
-  factory Notification.onErrorFrom(
+  factory RxNotification.onErrorFrom(
           {required ErrorAndStackTrace errorAndStackTrace}) =>
-      Notification<T>._(Kind.onError, EMPTY, errorAndStackTrace);
+      RxNotification<Never>._(Kind.onError, EMPTY, errorAndStackTrace);
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is Notification &&
+      other is RxNotification &&
           runtimeType == other.runtimeType &&
           kind == other.kind &&
           _value == other._value &&

--- a/lib/src/utils/notification.dart
+++ b/lib/src/utils/notification.dart
@@ -30,7 +30,7 @@ abstract class StreamNotification<T> {
   factory StreamNotification.data(T value) => DataNotification<T>(value);
 
   /// Constructs a [StreamNotification] with [NotificationKind.done].
-  factory StreamNotification.done() => DoneNotification();
+  const factory StreamNotification.done() = DoneNotification;
 
   /// Constructs a [StreamNotification] with [NotificationKind.error] and wraps an [error] and [stackTrace]
   factory StreamNotification.error(Object error, StackTrace? stackTrace) =>

--- a/lib/src/utils/notification.dart
+++ b/lib/src/utils/notification.dart
@@ -33,8 +33,8 @@ abstract class StreamNotification<T> {
   const factory StreamNotification.done() = DoneNotification;
 
   /// Constructs a [StreamNotification] with [NotificationKind.error] and wraps an [error] and [stackTrace]
-  factory StreamNotification.error(Object error, StackTrace? stackTrace) =>
-      ErrorNotification.from(error, stackTrace);
+  factory StreamNotification.error(Object error, [StackTrace? stackTrace]) =>
+      ErrorNotification._internal(error, stackTrace);
 }
 
 /// Provides extension methods on [StreamNotification].
@@ -97,12 +97,12 @@ extension StreamNotificationExtensions<T> on StreamNotification<T> {
   }
 }
 
-/// TODO
+/// A notification representing a data event from a [Stream].
 class DataNotification<T> extends StreamNotification<T> {
-  /// TODO
+  /// The value of the data event.
   final T value;
 
-  /// TODO
+  /// Constructs a [DataNotification] with the provided [value].
   const DataNotification(this.value) : super._(NotificationKind.data);
 
   @override
@@ -119,9 +119,9 @@ class DataNotification<T> extends StreamNotification<T> {
   String toString() => 'DataNotification{value: $value}';
 }
 
-/// TODO
+/// A notification representing a done event from a [Stream].
 class DoneNotification extends StreamNotification<Never> {
-  /// TODO
+  /// Constructs a [DoneNotification].
   const DoneNotification() : super._(NotificationKind.done);
 
   @override
@@ -136,23 +136,23 @@ class DoneNotification extends StreamNotification<Never> {
   String toString() => 'DoneNotification{}';
 }
 
-/// TODO
+/// A notification representing an error event from a [Stream].
 class ErrorNotification extends StreamNotification<Never> {
   /// The wrapped error and stack trace, if applicable
   final ErrorAndStackTrace errorAndStackTrace;
 
-  /// TODO
+  /// The error of the error event.
   Object get error => errorAndStackTrace.error;
 
-  /// TODO
+  /// The stack trace of the error event, if available.
   StackTrace? get stackTrace => errorAndStackTrace.stackTrace;
 
-  /// TODO
+  /// Constructs an [ErrorNotification] with the provided [errorAndStackTrace].
   const ErrorNotification(this.errorAndStackTrace)
       : super._(NotificationKind.error);
 
-  /// TODO
-  factory ErrorNotification.from(Object error, StackTrace? stackTrace) =>
+  /// Constructs an [ErrorNotification] with the provided [error] and [stackTrace].
+  factory ErrorNotification._internal(Object error, StackTrace? stackTrace) =>
       ErrorNotification(ErrorAndStackTrace(error, stackTrace));
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
   - rx
 
 environment:
-  sdk: '>=2.13.0 <4.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dev_dependencies:
   build_runner: ^2.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
   - rx
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=2.13.0 <4.0.0'
 
 dev_dependencies:
   build_runner: ^2.1.2

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -1269,7 +1269,7 @@ void main() {
         final s = BehaviorSubject<int>.seeded(42);
         expect(
           s.lastEventOrNull,
-          Notification<int>.onData(42),
+          RxNotification<int>.onData(42),
         );
         expect(s.isLastEventValue, isTrue);
         expect(s.isLastEventError, isFalse);
@@ -1277,7 +1277,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          Notification<int>.onData(42),
+          RxNotification<int>.onData(42),
         );
         expect(s.stream.isLastEventValue, isTrue);
         expect(s.stream.isLastEventError, isFalse);
@@ -1290,7 +1290,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          Notification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.onError(exception, StackTrace.empty),
         );
         expect(s.isLastEventValue, isFalse);
         expect(s.isLastEventError, isTrue);
@@ -1298,7 +1298,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          Notification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.onError(exception, StackTrace.empty),
         );
         expect(s.stream.isLastEventValue, isFalse);
         expect(s.stream.isLastEventError, isTrue);
@@ -1312,7 +1312,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          Notification<int>.onData(42),
+          RxNotification<int>.onData(42),
         );
         expect(s.isLastEventValue, isTrue);
         expect(s.isLastEventError, isFalse);
@@ -1320,7 +1320,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          Notification<int>.onData(42),
+          RxNotification<int>.onData(42),
         );
         expect(s.stream.isLastEventValue, isTrue);
         expect(s.stream.isLastEventError, isFalse);
@@ -1334,7 +1334,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          Notification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.onError(exception, StackTrace.empty),
         );
         expect(s.isLastEventValue, isFalse);
         expect(s.isLastEventError, isTrue);
@@ -1342,7 +1342,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          Notification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.onError(exception, StackTrace.empty),
         );
         expect(s.stream.isLastEventValue, isFalse);
         expect(s.stream.isLastEventError, isTrue);
@@ -1355,7 +1355,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          Notification<int>.onData(42),
+          RxNotification<int>.onData(42),
         );
         expect(s.isLastEventValue, isTrue);
         expect(s.isLastEventError, isFalse);
@@ -1363,7 +1363,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          Notification<int>.onData(42),
+          RxNotification<int>.onData(42),
         );
         expect(s.stream.isLastEventValue, isTrue);
         expect(s.stream.isLastEventError, isFalse);
@@ -1377,7 +1377,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          Notification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.onError(exception, StackTrace.empty),
         );
         expect(s.isLastEventValue, isFalse);
         expect(s.isLastEventError, isTrue);
@@ -1385,7 +1385,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          Notification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.onError(exception, StackTrace.empty),
         );
         expect(s.stream.isLastEventValue, isFalse);
         expect(s.stream.isLastEventError, isTrue);

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -1269,7 +1269,7 @@ void main() {
         final s = BehaviorSubject<int>.seeded(42);
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.onData(42),
+          RxNotification<int>.data(42),
         );
         expect(s.isLastEventValue, isTrue);
         expect(s.isLastEventError, isFalse);
@@ -1277,7 +1277,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.onData(42),
+          RxNotification<int>.data(42),
         );
         expect(s.stream.isLastEventValue, isTrue);
         expect(s.stream.isLastEventError, isFalse);
@@ -1290,7 +1290,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.isLastEventValue, isFalse);
         expect(s.isLastEventError, isTrue);
@@ -1298,7 +1298,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.stream.isLastEventValue, isFalse);
         expect(s.stream.isLastEventError, isTrue);
@@ -1312,7 +1312,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.onData(42),
+          RxNotification<int>.data(42),
         );
         expect(s.isLastEventValue, isTrue);
         expect(s.isLastEventError, isFalse);
@@ -1320,7 +1320,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.onData(42),
+          RxNotification<int>.data(42),
         );
         expect(s.stream.isLastEventValue, isTrue);
         expect(s.stream.isLastEventError, isFalse);
@@ -1334,7 +1334,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.isLastEventValue, isFalse);
         expect(s.isLastEventError, isTrue);
@@ -1342,7 +1342,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.stream.isLastEventValue, isFalse);
         expect(s.stream.isLastEventError, isTrue);
@@ -1355,7 +1355,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.onData(42),
+          RxNotification<int>.data(42),
         );
         expect(s.isLastEventValue, isTrue);
         expect(s.isLastEventError, isFalse);
@@ -1363,7 +1363,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.onData(42),
+          RxNotification<int>.data(42),
         );
         expect(s.stream.isLastEventValue, isTrue);
         expect(s.stream.isLastEventError, isFalse);
@@ -1377,7 +1377,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.isLastEventValue, isFalse);
         expect(s.isLastEventError, isTrue);
@@ -1385,7 +1385,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.onError(exception, StackTrace.empty),
+          RxNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.stream.isLastEventValue, isFalse);
         expect(s.stream.isLastEventError, isTrue);

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -1269,7 +1269,7 @@ void main() {
         final s = BehaviorSubject<int>.seeded(42);
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.data(42),
+          StreamNotification<int>.data(42),
         );
         expect(s.isLastEventValue, isTrue);
         expect(s.isLastEventError, isFalse);
@@ -1277,7 +1277,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.data(42),
+          StreamNotification<int>.data(42),
         );
         expect(s.stream.isLastEventValue, isTrue);
         expect(s.stream.isLastEventError, isFalse);
@@ -1290,7 +1290,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.error(exception, StackTrace.empty),
+          StreamNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.isLastEventValue, isFalse);
         expect(s.isLastEventError, isTrue);
@@ -1298,7 +1298,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.error(exception, StackTrace.empty),
+          StreamNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.stream.isLastEventValue, isFalse);
         expect(s.stream.isLastEventError, isTrue);
@@ -1312,7 +1312,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.data(42),
+          StreamNotification<int>.data(42),
         );
         expect(s.isLastEventValue, isTrue);
         expect(s.isLastEventError, isFalse);
@@ -1320,7 +1320,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.data(42),
+          StreamNotification<int>.data(42),
         );
         expect(s.stream.isLastEventValue, isTrue);
         expect(s.stream.isLastEventError, isFalse);
@@ -1334,7 +1334,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.error(exception, StackTrace.empty),
+          StreamNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.isLastEventValue, isFalse);
         expect(s.isLastEventError, isTrue);
@@ -1342,7 +1342,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.error(exception, StackTrace.empty),
+          StreamNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.stream.isLastEventValue, isFalse);
         expect(s.stream.isLastEventError, isTrue);
@@ -1355,7 +1355,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.data(42),
+          StreamNotification<int>.data(42),
         );
         expect(s.isLastEventValue, isTrue);
         expect(s.isLastEventError, isFalse);
@@ -1363,7 +1363,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.data(42),
+          StreamNotification<int>.data(42),
         );
         expect(s.stream.isLastEventValue, isTrue);
         expect(s.stream.isLastEventError, isFalse);
@@ -1377,7 +1377,7 @@ void main() {
 
         expect(
           s.lastEventOrNull,
-          RxNotification<int>.error(exception, StackTrace.empty),
+          StreamNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.isLastEventValue, isFalse);
         expect(s.isLastEventError, isTrue);
@@ -1385,7 +1385,7 @@ void main() {
         // the stream has the same value as the subject
         expect(
           s.stream.lastEventOrNull,
-          RxNotification<int>.error(exception, StackTrace.empty),
+          StreamNotification<int>.error(exception, StackTrace.empty),
         );
         expect(s.stream.isLastEventValue, isFalse);
         expect(s.stream.isLastEventError, isTrue);

--- a/test/transformers/dematerialize_test.dart
+++ b/test/transformers/dematerialize_test.dart
@@ -51,7 +51,7 @@ void main() {
   test('dematerializeTransformer.happyPath', () async {
     const expectedValue = 1;
     final stream = Stream.fromIterable(
-        [Notification.onData(expectedValue), Notification<int>.onDone()]);
+        [RxNotification.onData(expectedValue), RxNotification<int>.onDone()]);
 
     stream.transform(DematerializeStreamTransformer()).listen(
         expectAsync1((value) {
@@ -64,7 +64,7 @@ void main() {
 
   test('dematerializeTransformer.sadPath', () async {
     final stream = Stream.fromIterable(
-        [Notification<int>.onError(Exception(), Chain.current())]);
+        [RxNotification<int>.onError(Exception(), Chain.current())]);
 
     stream.transform(DematerializeStreamTransformer()).listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -75,7 +75,7 @@ void main() {
   test('dematerializeTransformer.onPause.onResume', () async {
     const expectedValue = 1;
     final stream = Stream.fromIterable(
-        [Notification.onData(expectedValue), Notification<int>.onDone()]);
+        [RxNotification.onData(expectedValue), RxNotification<int>.onDone()]);
 
     stream.transform(DematerializeStreamTransformer()).listen(
         expectAsync1((value) {

--- a/test/transformers/dematerialize_test.dart
+++ b/test/transformers/dematerialize_test.dart
@@ -50,8 +50,10 @@ void main() {
 
   test('dematerializeTransformer.happyPath', () async {
     const expectedValue = 1;
-    final stream = Stream.fromIterable(
-        [RxNotification.data(expectedValue), RxNotification<int>.done()]);
+    final stream = Stream.fromIterable([
+      StreamNotification.data(expectedValue),
+      StreamNotification<int>.done()
+    ]);
 
     stream.transform(DematerializeStreamTransformer()).listen(
         expectAsync1((value) {
@@ -64,7 +66,7 @@ void main() {
 
   test('dematerializeTransformer.sadPath', () async {
     final stream = Stream.fromIterable(
-        [RxNotification<int>.error(Exception(), Chain.current())]);
+        [StreamNotification<int>.error(Exception(), Chain.current())]);
 
     stream.transform(DematerializeStreamTransformer()).listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -74,8 +76,10 @@ void main() {
 
   test('dematerializeTransformer.onPause.onResume', () async {
     const expectedValue = 1;
-    final stream = Stream.fromIterable(
-        [RxNotification.data(expectedValue), RxNotification<int>.done()]);
+    final stream = Stream.fromIterable([
+      StreamNotification.data(expectedValue),
+      StreamNotification<int>.done()
+    ]);
 
     stream.transform(DematerializeStreamTransformer()).listen(
         expectAsync1((value) {

--- a/test/transformers/dematerialize_test.dart
+++ b/test/transformers/dematerialize_test.dart
@@ -51,7 +51,7 @@ void main() {
   test('dematerializeTransformer.happyPath', () async {
     const expectedValue = 1;
     final stream = Stream.fromIterable(
-        [RxNotification.onData(expectedValue), RxNotification<int>.onDone()]);
+        [RxNotification.data(expectedValue), RxNotification<int>.done()]);
 
     stream.transform(DematerializeStreamTransformer()).listen(
         expectAsync1((value) {
@@ -64,7 +64,7 @@ void main() {
 
   test('dematerializeTransformer.sadPath', () async {
     final stream = Stream.fromIterable(
-        [RxNotification<int>.onError(Exception(), Chain.current())]);
+        [RxNotification<int>.error(Exception(), Chain.current())]);
 
     stream.transform(DematerializeStreamTransformer()).listen(null,
         onError: expectAsync2((Exception e, StackTrace s) {
@@ -75,7 +75,7 @@ void main() {
   test('dematerializeTransformer.onPause.onResume', () async {
     const expectedValue = 1;
     final stream = Stream.fromIterable(
-        [RxNotification.onData(expectedValue), RxNotification<int>.onDone()]);
+        [RxNotification.data(expectedValue), RxNotification<int>.done()]);
 
     stream.transform(DematerializeStreamTransformer()).listen(
         expectAsync1((value) {

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -149,8 +149,8 @@ void main() {
           .concatWith([Stream<int>.error(exception)]).doOnEach((notification) {
         actual.add(notification);
 
-        if (notification.isOnError) {
-          stacktrace = notification.errorAndStackTrace?.stackTrace;
+        if (notification.isError) {
+          stacktrace = notification.errorAndStackTraceOrNull?.stackTrace;
         }
       });
 
@@ -158,9 +158,9 @@ void main() {
           emitsInOrder(<dynamic>[1, emitsError(isException), emitsDone]));
 
       await expectLater(actual, [
-        RxNotification.onData(1),
-        RxNotification<int>.onError(exception, stacktrace),
-        RxNotification<int>.onDone()
+        RxNotification.data(1),
+        RxNotification<int>.error(exception, stacktrace),
+        RxNotification<int>.done()
       ]);
     });
 

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -143,7 +143,7 @@ void main() {
 
     test('emits onEach Notifications for Data, Error, and Done', () async {
       StackTrace? stacktrace;
-      final actual = <Notification<int>>[];
+      final actual = <RxNotification<int>>[];
       final exception = Exception();
       final stream = Stream.value(1)
           .concatWith([Stream<int>.error(exception)]).doOnEach((notification) {
@@ -158,9 +158,9 @@ void main() {
           emitsInOrder(<dynamic>[1, emitsError(isException), emitsDone]));
 
       await expectLater(actual, [
-        Notification.onData(1),
-        Notification<int>.onError(exception, stacktrace),
-        Notification<int>.onDone()
+        RxNotification.onData(1),
+        RxNotification<int>.onError(exception, stacktrace),
+        RxNotification<int>.onDone()
       ]);
     });
 

--- a/test/transformers/do_test.dart
+++ b/test/transformers/do_test.dart
@@ -143,7 +143,7 @@ void main() {
 
     test('emits onEach Notifications for Data, Error, and Done', () async {
       StackTrace? stacktrace;
-      final actual = <RxNotification<int>>[];
+      final actual = <StreamNotification<int>>[];
       final exception = Exception();
       final stream = Stream.value(1)
           .concatWith([Stream<int>.error(exception)]).doOnEach((notification) {
@@ -158,9 +158,9 @@ void main() {
           emitsInOrder(<dynamic>[1, emitsError(isException), emitsDone]));
 
       await expectLater(actual, [
-        RxNotification.data(1),
-        RxNotification<int>.error(exception, stacktrace),
-        RxNotification<int>.done()
+        StreamNotification.data(1),
+        StreamNotification<int>.error(exception, stacktrace),
+        StreamNotification<int>.done()
       ]);
     });
 

--- a/test/transformers/materialize_test.dart
+++ b/test/transformers/materialize_test.dart
@@ -8,48 +8,48 @@ import '../utils.dart';
 void main() {
   test('Rx.materialize.happyPath', () async {
     final stream = Stream.value(1);
-    final notifications = <RxNotification<int>>[];
+    final notifications = <StreamNotification<int>>[];
 
     stream.materialize().listen(notifications.add, onDone: expectAsync0(() {
-      expect(
-          notifications, [RxNotification.data(1), RxNotification<int>.done()]);
+      expect(notifications,
+          [StreamNotification.data(1), StreamNotification<int>.done()]);
     }));
   });
 
   test('Rx.materialize.reusable', () async {
     final transformer = MaterializeStreamTransformer<int>();
     final stream = Stream.value(1).asBroadcastStream();
-    final notificationsA = <RxNotification<int>>[],
-        notificationsB = <RxNotification<int>>[];
+    final notificationsA = <StreamNotification<int>>[],
+        notificationsB = <StreamNotification<int>>[];
 
     stream.transform(transformer).listen(notificationsA.add,
         onDone: expectAsync0(() {
-      expect(
-          notificationsA, [RxNotification.data(1), RxNotification<int>.done()]);
+      expect(notificationsA,
+          [StreamNotification.data(1), StreamNotification<int>.done()]);
     }));
 
     stream.transform(transformer).listen(notificationsB.add,
         onDone: expectAsync0(() {
-      expect(
-          notificationsB, [RxNotification.data(1), RxNotification<int>.done()]);
+      expect(notificationsB,
+          [StreamNotification.data(1), StreamNotification<int>.done()]);
     }));
   });
 
   test('materializeTransformer.happyPath', () async {
     final stream = Stream.fromIterable(const [1]);
-    final notifications = <RxNotification<int>>[];
+    final notifications = <StreamNotification<int>>[];
 
     stream
         .transform(MaterializeStreamTransformer<int>())
         .listen(notifications.add, onDone: expectAsync0(() {
-      expect(
-          notifications, [RxNotification.data(1), RxNotification<int>.done()]);
+      expect(notifications,
+          [StreamNotification.data(1), StreamNotification<int>.done()]);
     }));
   });
 
   test('materializeTransformer.sadPath', () async {
     final stream = Stream<int>.error(Exception());
-    final notifications = <RxNotification<int>>[];
+    final notifications = <StreamNotification<int>>[];
 
     stream
         .transform(MaterializeStreamTransformer<int>())
@@ -66,14 +66,14 @@ void main() {
 
   test('materializeTransformer.onPause.onResume', () async {
     final stream = Stream.fromIterable(const [1]);
-    final notifications = <RxNotification<int>>[];
+    final notifications = <StreamNotification<int>>[];
 
     stream
         .transform(MaterializeStreamTransformer<int>())
         .listen(notifications.add, onDone: expectAsync0(() {
-      expect(notifications, <RxNotification<int>>[
-        RxNotification.data(1),
-        RxNotification<int>.done()
+      expect(notifications, <StreamNotification<int>>[
+        StreamNotification.data(1),
+        StreamNotification<int>.done()
       ]);
     }))
       ..pause()
@@ -92,7 +92,7 @@ void main() {
   });
 
   test('Rx.materialize.nullable', () {
-    nullableTest<RxNotification<String?>>(
+    nullableTest<StreamNotification<String?>>(
       (s) => s.materialize(),
     );
   });

--- a/test/transformers/materialize_test.dart
+++ b/test/transformers/materialize_test.dart
@@ -8,48 +8,48 @@ import '../utils.dart';
 void main() {
   test('Rx.materialize.happyPath', () async {
     final stream = Stream.value(1);
-    final notifications = <Notification<int>>[];
+    final notifications = <RxNotification<int>>[];
 
     stream.materialize().listen(notifications.add, onDone: expectAsync0(() {
-      expect(
-          notifications, [Notification.onData(1), Notification<int>.onDone()]);
+      expect(notifications,
+          [RxNotification.onData(1), RxNotification<int>.onDone()]);
     }));
   });
 
   test('Rx.materialize.reusable', () async {
     final transformer = MaterializeStreamTransformer<int>();
     final stream = Stream.value(1).asBroadcastStream();
-    final notificationsA = <Notification<int>>[],
-        notificationsB = <Notification<int>>[];
+    final notificationsA = <RxNotification<int>>[],
+        notificationsB = <RxNotification<int>>[];
 
     stream.transform(transformer).listen(notificationsA.add,
         onDone: expectAsync0(() {
-      expect(
-          notificationsA, [Notification.onData(1), Notification<int>.onDone()]);
+      expect(notificationsA,
+          [RxNotification.onData(1), RxNotification<int>.onDone()]);
     }));
 
     stream.transform(transformer).listen(notificationsB.add,
         onDone: expectAsync0(() {
-      expect(
-          notificationsB, [Notification.onData(1), Notification<int>.onDone()]);
+      expect(notificationsB,
+          [RxNotification.onData(1), RxNotification<int>.onDone()]);
     }));
   });
 
   test('materializeTransformer.happyPath', () async {
     final stream = Stream.fromIterable(const [1]);
-    final notifications = <Notification<int>>[];
+    final notifications = <RxNotification<int>>[];
 
     stream
         .transform(MaterializeStreamTransformer<int>())
         .listen(notifications.add, onDone: expectAsync0(() {
-      expect(
-          notifications, [Notification.onData(1), Notification<int>.onDone()]);
+      expect(notifications,
+          [RxNotification.onData(1), RxNotification<int>.onDone()]);
     }));
   });
 
   test('materializeTransformer.sadPath', () async {
     final stream = Stream<int>.error(Exception());
-    final notifications = <Notification<int>>[];
+    final notifications = <RxNotification<int>>[];
 
     stream
         .transform(MaterializeStreamTransformer<int>())
@@ -66,14 +66,14 @@ void main() {
 
   test('materializeTransformer.onPause.onResume', () async {
     final stream = Stream.fromIterable(const [1]);
-    final notifications = <Notification<int>>[];
+    final notifications = <RxNotification<int>>[];
 
     stream
         .transform(MaterializeStreamTransformer<int>())
         .listen(notifications.add, onDone: expectAsync0(() {
-      expect(notifications, <Notification<int>>[
-        Notification.onData(1),
-        Notification<int>.onDone()
+      expect(notifications, <RxNotification<int>>[
+        RxNotification.onData(1),
+        RxNotification<int>.onDone()
       ]);
     }))
       ..pause()
@@ -92,7 +92,7 @@ void main() {
   });
 
   test('Rx.materialize.nullable', () {
-    nullableTest<Notification<String?>>(
+    nullableTest<RxNotification<String?>>(
       (s) => s.materialize(),
     );
   });

--- a/test/transformers/materialize_test.dart
+++ b/test/transformers/materialize_test.dart
@@ -11,8 +11,8 @@ void main() {
     final notifications = <RxNotification<int>>[];
 
     stream.materialize().listen(notifications.add, onDone: expectAsync0(() {
-      expect(notifications,
-          [RxNotification.onData(1), RxNotification<int>.onDone()]);
+      expect(
+          notifications, [RxNotification.data(1), RxNotification<int>.done()]);
     }));
   });
 
@@ -24,14 +24,14 @@ void main() {
 
     stream.transform(transformer).listen(notificationsA.add,
         onDone: expectAsync0(() {
-      expect(notificationsA,
-          [RxNotification.onData(1), RxNotification<int>.onDone()]);
+      expect(
+          notificationsA, [RxNotification.data(1), RxNotification<int>.done()]);
     }));
 
     stream.transform(transformer).listen(notificationsB.add,
         onDone: expectAsync0(() {
-      expect(notificationsB,
-          [RxNotification.onData(1), RxNotification<int>.onDone()]);
+      expect(
+          notificationsB, [RxNotification.data(1), RxNotification<int>.done()]);
     }));
   });
 
@@ -42,8 +42,8 @@ void main() {
     stream
         .transform(MaterializeStreamTransformer<int>())
         .listen(notifications.add, onDone: expectAsync0(() {
-      expect(notifications,
-          [RxNotification.onData(1), RxNotification<int>.onDone()]);
+      expect(
+          notifications, [RxNotification.data(1), RxNotification<int>.done()]);
     }));
   });
 
@@ -59,8 +59,8 @@ void main() {
               expect(true, isFalse);
             }, count: 0), onDone: expectAsync0(() {
       expect(notifications.length, 2);
-      expect(notifications[0].isOnError, isTrue);
-      expect(notifications[1].isOnDone, isTrue);
+      expect(notifications[0].isError, isTrue);
+      expect(notifications[1].isDone, isTrue);
     }));
   });
 
@@ -72,8 +72,8 @@ void main() {
         .transform(MaterializeStreamTransformer<int>())
         .listen(notifications.add, onDone: expectAsync0(() {
       expect(notifications, <RxNotification<int>>[
-        RxNotification.onData(1),
-        RxNotification<int>.onDone()
+        RxNotification.data(1),
+        RxNotification<int>.done()
       ]);
     }))
       ..pause()

--- a/test/utils/notification_test.dart
+++ b/test/utils/notification_test.dart
@@ -2,7 +2,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('RxNotification', () {
+  group('StreamNotification', () {
     test('hashCode', () {
       final value1 = 1;
       final value2 = 2;
@@ -11,55 +11,55 @@ void main() {
       final st2 = StackTrace.current;
 
       expect(
-        RxNotification.data(value1).hashCode,
-        RxNotification.data(value1).hashCode,
+        StreamNotification.data(value1).hashCode,
+        StreamNotification.data(value1).hashCode,
       );
       expect(
-        RxNotification.data(value1).hashCode,
-        RxNotification<num>.data(value1).hashCode,
+        StreamNotification.data(value1).hashCode,
+        StreamNotification<num>.data(value1).hashCode,
       );
       expect(
-        RxNotification.data(value1).hashCode,
-        isNot(RxNotification.data(value2).hashCode),
-      );
-
-      expect(
-        RxNotification<int>.done().hashCode,
-        RxNotification<int>.done().hashCode,
-      );
-      expect(
-        RxNotification<int>.done().hashCode,
-        RxNotification<String>.done().hashCode,
+        StreamNotification.data(value1).hashCode,
+        isNot(StreamNotification.data(value2).hashCode),
       );
 
       expect(
-        RxNotification<int>.error(value1, st1).hashCode,
-        RxNotification<int>.error(value1, st1).hashCode,
+        StreamNotification<int>.done().hashCode,
+        StreamNotification<int>.done().hashCode,
       );
       expect(
-        RxNotification<int>.error(value1, st1).hashCode,
-        isNot(RxNotification<int>.error(value2, st1).hashCode),
-      );
-      expect(
-        RxNotification<int>.error(value1, st1).hashCode,
-        isNot(RxNotification<int>.error(value1, st2).hashCode),
-      );
-      expect(
-        RxNotification<int>.error(value1, st1).hashCode,
-        isNot(RxNotification<int>.error(value2, st2).hashCode),
+        StreamNotification<int>.done().hashCode,
+        StreamNotification<String>.done().hashCode,
       );
 
       expect(
-        RxNotification.data(value1).hashCode,
-        isNot(RxNotification<int>.done().hashCode),
+        StreamNotification<int>.error(value1, st1).hashCode,
+        StreamNotification<int>.error(value1, st1).hashCode,
       );
       expect(
-        RxNotification.data(value1).hashCode,
-        isNot(RxNotification<int>.error(value1, st1).hashCode),
+        StreamNotification<int>.error(value1, st1).hashCode,
+        isNot(StreamNotification<int>.error(value2, st1).hashCode),
       );
       expect(
-        RxNotification<int>.done().hashCode,
-        isNot(RxNotification<int>.error(value1, st1).hashCode),
+        StreamNotification<int>.error(value1, st1).hashCode,
+        isNot(StreamNotification<int>.error(value1, st2).hashCode),
+      );
+      expect(
+        StreamNotification<int>.error(value1, st1).hashCode,
+        isNot(StreamNotification<int>.error(value2, st2).hashCode),
+      );
+
+      expect(
+        StreamNotification.data(value1).hashCode,
+        isNot(StreamNotification<int>.done().hashCode),
+      );
+      expect(
+        StreamNotification.data(value1).hashCode,
+        isNot(StreamNotification<int>.error(value1, st1).hashCode),
+      );
+      expect(
+        StreamNotification<int>.done().hashCode,
+        isNot(StreamNotification<int>.error(value1, st1).hashCode),
       );
     });
 
@@ -71,156 +71,158 @@ void main() {
       final st2 = StackTrace.current;
 
       expect(
-        RxNotification.data(value1),
-        RxNotification.data(value1),
+        StreamNotification.data(value1),
+        StreamNotification.data(value1),
       );
       expect(
-        RxNotification.data(value1),
-        isNot(RxNotification<num>.data(value1)),
+        StreamNotification.data(value1),
+        isNot(StreamNotification<num>.data(value1)),
       );
       expect(
-        RxNotification.data(value1),
-        isNot(RxNotification.data(value2)),
-      );
-
-      expect(
-        RxNotification<int>.done(),
-        RxNotification<int>.done(),
-      );
-      expect(
-        RxNotification<int>.done(),
-        RxNotification<String>.done(),
+        StreamNotification.data(value1),
+        isNot(StreamNotification.data(value2)),
       );
 
       expect(
-        RxNotification<int>.error(value1, st1),
-        RxNotification<int>.error(value1, st1),
+        StreamNotification<int>.done(),
+        StreamNotification<int>.done(),
       );
       expect(
-        RxNotification<int>.error(value1, st1),
-        isNot(RxNotification<int>.error(value2, st1)),
-      );
-      expect(
-        RxNotification<int>.error(value1, st1),
-        isNot(RxNotification<int>.error(value1, st2)),
-      );
-      expect(
-        RxNotification<int>.error(value1, st1),
-        isNot(RxNotification<int>.error(value2, st2)),
+        StreamNotification<int>.done(),
+        StreamNotification<String>.done(),
       );
 
       expect(
-        RxNotification.data(value1),
-        isNot(RxNotification<int>.done()),
+        StreamNotification<int>.error(value1, st1),
+        StreamNotification<int>.error(value1, st1),
       );
       expect(
-        RxNotification.data(value1),
-        isNot(RxNotification<int>.error(value1, st1)),
+        StreamNotification<int>.error(value1, st1),
+        isNot(StreamNotification<int>.error(value2, st1)),
       );
       expect(
-        RxNotification<int>.done(),
-        isNot(RxNotification<int>.error(value1, st1)),
+        StreamNotification<int>.error(value1, st1),
+        isNot(StreamNotification<int>.error(value1, st2)),
+      );
+      expect(
+        StreamNotification<int>.error(value1, st1),
+        isNot(StreamNotification<int>.error(value2, st2)),
+      );
+
+      expect(
+        StreamNotification.data(value1),
+        isNot(StreamNotification<int>.done()),
+      );
+      expect(
+        StreamNotification.data(value1),
+        isNot(StreamNotification<int>.error(value1, st1)),
+      );
+      expect(
+        StreamNotification<int>.done(),
+        isNot(StreamNotification<int>.error(value1, st1)),
       );
     });
 
     test('toString', () {
       expect(
-        RxNotification.data(1).toString(),
+        StreamNotification.data(1).toString(),
         'DataNotification{value: 1}',
       );
 
       expect(
-        RxNotification<int>.done().toString(),
+        StreamNotification<int>.done().toString(),
         'DoneNotification{}',
       );
 
       expect(
-        RxNotification<int>.error(2, StackTrace.empty).toString(),
+        StreamNotification<int>.error(2, StackTrace.empty).toString(),
         'ErrorNotification{error: 2, stackTrace: }',
       );
     });
 
     test('requireData', () {
       expect(
-        RxNotification.data(1).requireDataValue,
+        StreamNotification.data(1).requireDataValue,
         1,
       );
 
       expect(
-        () => RxNotification<int>.done().requireDataValue,
+        () => StreamNotification<int>.done().requireDataValue,
         throwsA(isA<TypeError>()),
       );
 
       expect(
-        () => RxNotification<int>.error(2, StackTrace.empty).requireDataValue,
+        () =>
+            StreamNotification<int>.error(2, StackTrace.empty).requireDataValue,
         throwsA(isA<TypeError>()),
       );
     });
 
     test('errorAndStackTraceOrNull', () {
       expect(
-        RxNotification.data(1).errorAndStackTraceOrNull,
+        StreamNotification.data(1).errorAndStackTraceOrNull,
         isNull,
       );
 
       expect(
-        RxNotification<int>.done().errorAndStackTraceOrNull,
+        StreamNotification<int>.done().errorAndStackTraceOrNull,
         isNull,
       );
 
       expect(
-        RxNotification<int>.error(2, StackTrace.empty).errorAndStackTraceOrNull,
+        StreamNotification<int>.error(2, StackTrace.empty)
+            .errorAndStackTraceOrNull,
         ErrorAndStackTrace(2, StackTrace.empty),
       );
     });
 
     test('isOnData', () {
       expect(
-        RxNotification.data(1).isData,
+        StreamNotification.data(1).isData,
         isTrue,
       );
 
       expect(
-        RxNotification<int>.done().isData,
+        StreamNotification<int>.done().isData,
         isFalse,
       );
 
       expect(
-        RxNotification<int>.error(2, StackTrace.empty).isData,
+        StreamNotification<int>.error(2, StackTrace.empty).isData,
         isFalse,
       );
     });
 
     test('isOnDone', () {
       expect(
-        RxNotification.data(1).isDone,
+        StreamNotification.data(1).isDone,
         isFalse,
       );
 
       expect(
-        RxNotification<int>.done().isDone,
+        StreamNotification<int>.done().isDone,
         isTrue,
       );
 
       expect(
-        RxNotification<int>.error(2, StackTrace.empty).isDone,
+        StreamNotification<int>.error(2, StackTrace.empty).isDone,
         isFalse,
       );
     });
 
     test('isOnError', () {
       expect(
-        RxNotification.data(1).isError,
+        StreamNotification.data(1).isError,
         isFalse,
       );
 
       expect(
-        RxNotification<int>.done().isError,
+        StreamNotification<int>.done().isError,
         isFalse,
       );
 
       expect(
-        RxNotification<int>.error(2, StackTrace.empty).isError,
+        StreamNotification<int>.error(2, StackTrace.empty).isError,
         isTrue,
       );
     });

--- a/test/utils/notification_test.dart
+++ b/test/utils/notification_test.dart
@@ -2,7 +2,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Notification', () {
+  group('RxNotification', () {
     test('hashCode', () {
       final value1 = 1;
       final value2 = 2;
@@ -11,55 +11,55 @@ void main() {
       final st2 = StackTrace.current;
 
       expect(
-        Notification.onData(value1).hashCode,
-        Notification.onData(value1).hashCode,
+        RxNotification.onData(value1).hashCode,
+        RxNotification.onData(value1).hashCode,
       );
       expect(
-        Notification.onData(value1).hashCode,
-        Notification<num>.onData(value1).hashCode,
+        RxNotification.onData(value1).hashCode,
+        RxNotification<num>.onData(value1).hashCode,
       );
       expect(
-        Notification.onData(value1).hashCode,
-        isNot(Notification.onData(value2).hashCode),
-      );
-
-      expect(
-        Notification<int>.onDone().hashCode,
-        Notification<int>.onDone().hashCode,
-      );
-      expect(
-        Notification<int>.onDone().hashCode,
-        Notification<String>.onDone().hashCode,
+        RxNotification.onData(value1).hashCode,
+        isNot(RxNotification.onData(value2).hashCode),
       );
 
       expect(
-        Notification<int>.onError(value1, st1).hashCode,
-        Notification<int>.onError(value1, st1).hashCode,
+        RxNotification<int>.onDone().hashCode,
+        RxNotification<int>.onDone().hashCode,
       );
       expect(
-        Notification<int>.onError(value1, st1).hashCode,
-        isNot(Notification<int>.onError(value2, st1).hashCode),
-      );
-      expect(
-        Notification<int>.onError(value1, st1).hashCode,
-        isNot(Notification<int>.onError(value1, st2).hashCode),
-      );
-      expect(
-        Notification<int>.onError(value1, st1).hashCode,
-        isNot(Notification<int>.onError(value2, st2).hashCode),
+        RxNotification<int>.onDone().hashCode,
+        RxNotification<String>.onDone().hashCode,
       );
 
       expect(
-        Notification.onData(value1).hashCode,
-        isNot(Notification<int>.onDone().hashCode),
+        RxNotification<int>.onError(value1, st1).hashCode,
+        RxNotification<int>.onError(value1, st1).hashCode,
       );
       expect(
-        Notification.onData(value1).hashCode,
-        isNot(Notification<int>.onError(value1, st1).hashCode),
+        RxNotification<int>.onError(value1, st1).hashCode,
+        isNot(RxNotification<int>.onError(value2, st1).hashCode),
       );
       expect(
-        Notification<int>.onDone().hashCode,
-        isNot(Notification<int>.onError(value1, st1).hashCode),
+        RxNotification<int>.onError(value1, st1).hashCode,
+        isNot(RxNotification<int>.onError(value1, st2).hashCode),
+      );
+      expect(
+        RxNotification<int>.onError(value1, st1).hashCode,
+        isNot(RxNotification<int>.onError(value2, st2).hashCode),
+      );
+
+      expect(
+        RxNotification.onData(value1).hashCode,
+        isNot(RxNotification<int>.onDone().hashCode),
+      );
+      expect(
+        RxNotification.onData(value1).hashCode,
+        isNot(RxNotification<int>.onError(value1, st1).hashCode),
+      );
+      expect(
+        RxNotification<int>.onDone().hashCode,
+        isNot(RxNotification<int>.onError(value1, st1).hashCode),
       );
     });
 
@@ -71,156 +71,156 @@ void main() {
       final st2 = StackTrace.current;
 
       expect(
-        Notification.onData(value1),
-        Notification.onData(value1),
+        RxNotification.onData(value1),
+        RxNotification.onData(value1),
       );
       expect(
-        Notification.onData(value1),
-        isNot(Notification<num>.onData(value1)),
+        RxNotification.onData(value1),
+        isNot(RxNotification<num>.onData(value1)),
       );
       expect(
-        Notification.onData(value1),
-        isNot(Notification.onData(value2)),
-      );
-
-      expect(
-        Notification<int>.onDone(),
-        Notification<int>.onDone(),
-      );
-      expect(
-        Notification<int>.onDone(),
-        Notification<String>.onDone(),
+        RxNotification.onData(value1),
+        isNot(RxNotification.onData(value2)),
       );
 
       expect(
-        Notification<int>.onError(value1, st1),
-        Notification<int>.onError(value1, st1),
+        RxNotification<int>.onDone(),
+        RxNotification<int>.onDone(),
       );
       expect(
-        Notification<int>.onError(value1, st1),
-        isNot(Notification<int>.onError(value2, st1)),
-      );
-      expect(
-        Notification<int>.onError(value1, st1),
-        isNot(Notification<int>.onError(value1, st2)),
-      );
-      expect(
-        Notification<int>.onError(value1, st1),
-        isNot(Notification<int>.onError(value2, st2)),
+        RxNotification<int>.onDone(),
+        RxNotification<String>.onDone(),
       );
 
       expect(
-        Notification.onData(value1),
-        isNot(Notification<int>.onDone()),
+        RxNotification<int>.onError(value1, st1),
+        RxNotification<int>.onError(value1, st1),
       );
       expect(
-        Notification.onData(value1),
-        isNot(Notification<int>.onError(value1, st1)),
+        RxNotification<int>.onError(value1, st1),
+        isNot(RxNotification<int>.onError(value2, st1)),
       );
       expect(
-        Notification<int>.onDone(),
-        isNot(Notification<int>.onError(value1, st1)),
+        RxNotification<int>.onError(value1, st1),
+        isNot(RxNotification<int>.onError(value1, st2)),
+      );
+      expect(
+        RxNotification<int>.onError(value1, st1),
+        isNot(RxNotification<int>.onError(value2, st2)),
+      );
+
+      expect(
+        RxNotification.onData(value1),
+        isNot(RxNotification<int>.onDone()),
+      );
+      expect(
+        RxNotification.onData(value1),
+        isNot(RxNotification<int>.onError(value1, st1)),
+      );
+      expect(
+        RxNotification<int>.onDone(),
+        isNot(RxNotification<int>.onError(value1, st1)),
       );
     });
 
     test('toString', () {
       expect(
-        Notification.onData(1).toString(),
-        'Notification.onData{value: 1}',
+        RxNotification.onData(1).toString(),
+        'RxNotification.onData{value: 1}',
       );
 
       expect(
-        Notification<int>.onDone().toString(),
-        'Notification.onDone',
+        RxNotification<int>.onDone().toString(),
+        'RxNotification.onDone',
       );
 
       expect(
-        Notification<int>.onError(2, StackTrace.empty).toString(),
-        'Notification.onError{error: 2, stackTrace: }',
+        RxNotification<int>.onError(2, StackTrace.empty).toString(),
+        'RxNotification.onError{error: 2, stackTrace: }',
       );
     });
 
     test('requireData', () {
       expect(
-        Notification.onData(1).requireData,
+        RxNotification.onData(1).requireData,
         1,
       );
 
       expect(
-        () => Notification<int>.onDone().requireData,
+        () => RxNotification<int>.onDone().requireData,
         throwsStateError,
       );
 
       expect(
-        () => Notification<int>.onError(2, StackTrace.empty).requireData,
+        () => RxNotification<int>.onError(2, StackTrace.empty).requireData,
         throwsStateError,
       );
     });
 
     test('errorAndStackTrace', () {
       expect(
-        Notification.onData(1).errorAndStackTrace,
+        RxNotification.onData(1).errorAndStackTrace,
         isNull,
       );
 
       expect(
-        Notification<int>.onDone().errorAndStackTrace,
+        RxNotification<int>.onDone().errorAndStackTrace,
         isNull,
       );
 
       expect(
-        Notification<int>.onError(2, StackTrace.empty).errorAndStackTrace,
+        RxNotification<int>.onError(2, StackTrace.empty).errorAndStackTrace,
         ErrorAndStackTrace(2, StackTrace.empty),
       );
     });
 
     test('isOnData', () {
       expect(
-        Notification.onData(1).isOnData,
+        RxNotification.onData(1).isOnData,
         isTrue,
       );
 
       expect(
-        Notification<int>.onDone().isOnData,
+        RxNotification<int>.onDone().isOnData,
         isFalse,
       );
 
       expect(
-        Notification<int>.onError(2, StackTrace.empty).isOnData,
+        RxNotification<int>.onError(2, StackTrace.empty).isOnData,
         isFalse,
       );
     });
 
     test('isOnDone', () {
       expect(
-        Notification.onData(1).isOnDone,
+        RxNotification.onData(1).isOnDone,
         isFalse,
       );
 
       expect(
-        Notification<int>.onDone().isOnDone,
+        RxNotification<int>.onDone().isOnDone,
         isTrue,
       );
 
       expect(
-        Notification<int>.onError(2, StackTrace.empty).isOnDone,
+        RxNotification<int>.onError(2, StackTrace.empty).isOnDone,
         isFalse,
       );
     });
 
     test('isOnError', () {
       expect(
-        Notification.onData(1).isOnError,
+        RxNotification.onData(1).isOnError,
         isFalse,
       );
 
       expect(
-        Notification<int>.onDone().isOnError,
+        RxNotification<int>.onDone().isOnError,
         isFalse,
       );
 
       expect(
-        Notification<int>.onError(2, StackTrace.empty).isOnError,
+        RxNotification<int>.onError(2, StackTrace.empty).isOnError,
         isTrue,
       );
     });

--- a/test/utils/notification_test.dart
+++ b/test/utils/notification_test.dart
@@ -11,55 +11,55 @@ void main() {
       final st2 = StackTrace.current;
 
       expect(
-        RxNotification.onData(value1).hashCode,
-        RxNotification.onData(value1).hashCode,
+        RxNotification.data(value1).hashCode,
+        RxNotification.data(value1).hashCode,
       );
       expect(
-        RxNotification.onData(value1).hashCode,
-        RxNotification<num>.onData(value1).hashCode,
+        RxNotification.data(value1).hashCode,
+        RxNotification<num>.data(value1).hashCode,
       );
       expect(
-        RxNotification.onData(value1).hashCode,
-        isNot(RxNotification.onData(value2).hashCode),
-      );
-
-      expect(
-        RxNotification<int>.onDone().hashCode,
-        RxNotification<int>.onDone().hashCode,
-      );
-      expect(
-        RxNotification<int>.onDone().hashCode,
-        RxNotification<String>.onDone().hashCode,
+        RxNotification.data(value1).hashCode,
+        isNot(RxNotification.data(value2).hashCode),
       );
 
       expect(
-        RxNotification<int>.onError(value1, st1).hashCode,
-        RxNotification<int>.onError(value1, st1).hashCode,
+        RxNotification<int>.done().hashCode,
+        RxNotification<int>.done().hashCode,
       );
       expect(
-        RxNotification<int>.onError(value1, st1).hashCode,
-        isNot(RxNotification<int>.onError(value2, st1).hashCode),
-      );
-      expect(
-        RxNotification<int>.onError(value1, st1).hashCode,
-        isNot(RxNotification<int>.onError(value1, st2).hashCode),
-      );
-      expect(
-        RxNotification<int>.onError(value1, st1).hashCode,
-        isNot(RxNotification<int>.onError(value2, st2).hashCode),
+        RxNotification<int>.done().hashCode,
+        RxNotification<String>.done().hashCode,
       );
 
       expect(
-        RxNotification.onData(value1).hashCode,
-        isNot(RxNotification<int>.onDone().hashCode),
+        RxNotification<int>.error(value1, st1).hashCode,
+        RxNotification<int>.error(value1, st1).hashCode,
       );
       expect(
-        RxNotification.onData(value1).hashCode,
-        isNot(RxNotification<int>.onError(value1, st1).hashCode),
+        RxNotification<int>.error(value1, st1).hashCode,
+        isNot(RxNotification<int>.error(value2, st1).hashCode),
       );
       expect(
-        RxNotification<int>.onDone().hashCode,
-        isNot(RxNotification<int>.onError(value1, st1).hashCode),
+        RxNotification<int>.error(value1, st1).hashCode,
+        isNot(RxNotification<int>.error(value1, st2).hashCode),
+      );
+      expect(
+        RxNotification<int>.error(value1, st1).hashCode,
+        isNot(RxNotification<int>.error(value2, st2).hashCode),
+      );
+
+      expect(
+        RxNotification.data(value1).hashCode,
+        isNot(RxNotification<int>.done().hashCode),
+      );
+      expect(
+        RxNotification.data(value1).hashCode,
+        isNot(RxNotification<int>.error(value1, st1).hashCode),
+      );
+      expect(
+        RxNotification<int>.done().hashCode,
+        isNot(RxNotification<int>.error(value1, st1).hashCode),
       );
     });
 
@@ -71,156 +71,156 @@ void main() {
       final st2 = StackTrace.current;
 
       expect(
-        RxNotification.onData(value1),
-        RxNotification.onData(value1),
+        RxNotification.data(value1),
+        RxNotification.data(value1),
       );
       expect(
-        RxNotification.onData(value1),
-        isNot(RxNotification<num>.onData(value1)),
+        RxNotification.data(value1),
+        isNot(RxNotification<num>.data(value1)),
       );
       expect(
-        RxNotification.onData(value1),
-        isNot(RxNotification.onData(value2)),
-      );
-
-      expect(
-        RxNotification<int>.onDone(),
-        RxNotification<int>.onDone(),
-      );
-      expect(
-        RxNotification<int>.onDone(),
-        RxNotification<String>.onDone(),
+        RxNotification.data(value1),
+        isNot(RxNotification.data(value2)),
       );
 
       expect(
-        RxNotification<int>.onError(value1, st1),
-        RxNotification<int>.onError(value1, st1),
+        RxNotification<int>.done(),
+        RxNotification<int>.done(),
       );
       expect(
-        RxNotification<int>.onError(value1, st1),
-        isNot(RxNotification<int>.onError(value2, st1)),
-      );
-      expect(
-        RxNotification<int>.onError(value1, st1),
-        isNot(RxNotification<int>.onError(value1, st2)),
-      );
-      expect(
-        RxNotification<int>.onError(value1, st1),
-        isNot(RxNotification<int>.onError(value2, st2)),
+        RxNotification<int>.done(),
+        RxNotification<String>.done(),
       );
 
       expect(
-        RxNotification.onData(value1),
-        isNot(RxNotification<int>.onDone()),
+        RxNotification<int>.error(value1, st1),
+        RxNotification<int>.error(value1, st1),
       );
       expect(
-        RxNotification.onData(value1),
-        isNot(RxNotification<int>.onError(value1, st1)),
+        RxNotification<int>.error(value1, st1),
+        isNot(RxNotification<int>.error(value2, st1)),
       );
       expect(
-        RxNotification<int>.onDone(),
-        isNot(RxNotification<int>.onError(value1, st1)),
+        RxNotification<int>.error(value1, st1),
+        isNot(RxNotification<int>.error(value1, st2)),
+      );
+      expect(
+        RxNotification<int>.error(value1, st1),
+        isNot(RxNotification<int>.error(value2, st2)),
+      );
+
+      expect(
+        RxNotification.data(value1),
+        isNot(RxNotification<int>.done()),
+      );
+      expect(
+        RxNotification.data(value1),
+        isNot(RxNotification<int>.error(value1, st1)),
+      );
+      expect(
+        RxNotification<int>.done(),
+        isNot(RxNotification<int>.error(value1, st1)),
       );
     });
 
     test('toString', () {
       expect(
-        RxNotification.onData(1).toString(),
-        'RxNotification.onData{value: 1}',
+        RxNotification.data(1).toString(),
+        'DataNotification{value: 1}',
       );
 
       expect(
-        RxNotification<int>.onDone().toString(),
-        'RxNotification.onDone',
+        RxNotification<int>.done().toString(),
+        'DoneNotification{}',
       );
 
       expect(
-        RxNotification<int>.onError(2, StackTrace.empty).toString(),
-        'RxNotification.onError{error: 2, stackTrace: }',
+        RxNotification<int>.error(2, StackTrace.empty).toString(),
+        'ErrorNotification{error: 2, stackTrace: }',
       );
     });
 
     test('requireData', () {
       expect(
-        RxNotification.onData(1).requireData,
+        RxNotification.data(1).requireDataValue,
         1,
       );
 
       expect(
-        () => RxNotification<int>.onDone().requireData,
-        throwsStateError,
+        () => RxNotification<int>.done().requireDataValue,
+        throwsA(isA<TypeError>()),
       );
 
       expect(
-        () => RxNotification<int>.onError(2, StackTrace.empty).requireData,
-        throwsStateError,
+        () => RxNotification<int>.error(2, StackTrace.empty).requireDataValue,
+        throwsA(isA<TypeError>()),
       );
     });
 
-    test('errorAndStackTrace', () {
+    test('errorAndStackTraceOrNull', () {
       expect(
-        RxNotification.onData(1).errorAndStackTrace,
+        RxNotification.data(1).errorAndStackTraceOrNull,
         isNull,
       );
 
       expect(
-        RxNotification<int>.onDone().errorAndStackTrace,
+        RxNotification<int>.done().errorAndStackTraceOrNull,
         isNull,
       );
 
       expect(
-        RxNotification<int>.onError(2, StackTrace.empty).errorAndStackTrace,
+        RxNotification<int>.error(2, StackTrace.empty).errorAndStackTraceOrNull,
         ErrorAndStackTrace(2, StackTrace.empty),
       );
     });
 
     test('isOnData', () {
       expect(
-        RxNotification.onData(1).isOnData,
+        RxNotification.data(1).isData,
         isTrue,
       );
 
       expect(
-        RxNotification<int>.onDone().isOnData,
+        RxNotification<int>.done().isData,
         isFalse,
       );
 
       expect(
-        RxNotification<int>.onError(2, StackTrace.empty).isOnData,
+        RxNotification<int>.error(2, StackTrace.empty).isData,
         isFalse,
       );
     });
 
     test('isOnDone', () {
       expect(
-        RxNotification.onData(1).isOnDone,
+        RxNotification.data(1).isDone,
         isFalse,
       );
 
       expect(
-        RxNotification<int>.onDone().isOnDone,
+        RxNotification<int>.done().isDone,
         isTrue,
       );
 
       expect(
-        RxNotification<int>.onError(2, StackTrace.empty).isOnDone,
+        RxNotification<int>.error(2, StackTrace.empty).isDone,
         isFalse,
       );
     });
 
     test('isOnError', () {
       expect(
-        RxNotification.onData(1).isOnError,
+        RxNotification.data(1).isError,
         isFalse,
       );
 
       expect(
-        RxNotification<int>.onDone().isOnError,
+        RxNotification<int>.done().isError,
         isFalse,
       );
 
       expect(
-        RxNotification<int>.onError(2, StackTrace.empty).isOnError,
+        RxNotification<int>.error(2, StackTrace.empty).isError,
         isTrue,
       );
     });

--- a/test/utils/notification_test.dart
+++ b/test/utils/notification_test.dart
@@ -88,6 +88,10 @@ void main() {
         StreamNotification<int>.done(),
       );
       expect(
+        const StreamNotification<int>.done(),
+        StreamNotification<int>.done(),
+      );
+      expect(
         StreamNotification<int>.done(),
         StreamNotification<String>.done(),
       );


### PR DESCRIPTION
In flutter, there is `Notification` class https://api.flutter.dev/flutter/widgets/Notification-class.html, sometimes, it causes imports conflict