### PR TITLE
When onErrorResumeNext is used, error do not cancel to listen previous stream

### DIFF
--- a/lib/src/utils/forwarding_stream.dart
+++ b/lib/src/utils/forwarding_stream.dart
@@ -37,6 +37,7 @@ Stream<R> _forwardMulti<T, R>(
         sink.onData,
         onError: sink.onError,
         onDone: sink.onDone,
+        cancelOnError: true,
       );
       sink.setSubscription(subscription);
     }
@@ -86,6 +87,7 @@ Stream<R> _forward<T, R>(
         sink.onData,
         onError: sink.onError,
         onDone: sink.onDone,
+        cancelOnError: true,
       );
       sink.setSubscription(subscription);
 


### PR DESCRIPTION
When onErrorResumeNext is used, error do not cancel to listen previous stream.

here's test code

```dart
Rx.merge([
      Stream.periodic(const Duration(seconds: 1), (i) => i).map((event) => event + 1),
      Rx.concat([
        Rx.timer(1, const Duration(seconds: 5)),
        Stream.error(Exception("test"))
      ]).ignoreElements(),
    ])
        .asBroadcastStream()
        .doOnError((p0, p1) => print("!!!!! doOnError:$p0"))
        .onErrorResumeNext(Stream.periodic(const Duration(seconds: 1), (i) => i * 10))
        .listen((event) {
      print("!!!!! $event");
    }, onDone: () {
      print("!!!!! onDone");
    }, onError: (error, stacktrace) {
      print("!!!!! onError $error, $stacktrace");
    });
```

thanx