### PR TITLE
Make web examples runnable with latest dart

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,11 @@ Web and command-line examples can be found in the `example` folder.
  
 In order to run the web examples, please follow these steps:
 
-  1. Clone this repo and enter the directory
-  2. Run `dart pub get`
-  3. Run `dart run build_runner serve example`
-  4. Navigate to [http://localhost:8080/web/index.html](http://localhost:8080/web/index.html) in your browser
+  1. Run `dart pub global activate webdev`
+  2. Clone this repo and enter the directory
+  3. Run `dart pub get`
+  4. Run `webdev serve example`
+  5. Navigate to [http://localhost:8080/web/index.html](http://localhost:8080/web/index.html) in your browser
 
 ### Command Line Examples
 

--- a/lib/src/utils/empty.dart
+++ b/lib/src/utils/empty.dart
@@ -7,6 +7,7 @@ class _Empty {
 
 /// @internal
 /// Sentinel object used to represent a missing value (distinct from `null`).
+// ignore: unnecessary_nullable_for_final_variable_declarations
 const Object? EMPTY = _Empty(); // ignore: constant_identifier_names
 
 /// @internal

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 
 dev_dependencies:
   build_runner: ^2.1.2
-  build_web_compilers: ^3.0.0
-  lints: ^1.0.1
+  build_web_compilers: ^4.0.9
+  lints: ^2.0.0
   stack_trace: ^1.10.0
   test: ^1.17.12

--- a/test/subject/behavior_subject_test.dart
+++ b/test/subject/behavior_subject_test.dart
@@ -803,6 +803,7 @@ void main() {
       final a = BehaviorSubject.seeded('a');
       final b = BehaviorSubject.seeded('b');
       final bug =
+          // ignore: no_leading_underscores_for_local_identifiers
           Rx.combineLatest2(a, b, (String _a, String _b) => 'ab').shareValue();
       expect(await bug.first, 'ab');
       expect(await bug.first, 'ab');


### PR DESCRIPTION
- pubspec gets latest build_web_compilers
- README.md specifies working steps to run web examples
- minor linting issues are ignored