### PR TITLE
update ValueStreamBuilder

### DIFF
--- a/packages/rxdart_flutter/lib/src/value_stream_builder.dart
+++ b/packages/rxdart_flutter/lib/src/value_stream_builder.dart
@@ -157,11 +157,12 @@ class _ValueStreamBuilderState<T> extends State<ValueStreamBuilder<T>> {
 
     assert(subscription == null, 'Stream already subscribed');
     subscription = stream.listen(
-      (data) {
-        if (buildWhen?.call(currentData, data) ?? true) {
+      (newData) {
+        final previousData = currentData;
+        currentData = newData;
+        if (buildWhen == null || buildWhen(previousData, newData)) {
           setState(_emptyFn);
         }
-        currentData = data;
       },
       onError: (Object e, StackTrace s) {
         error = ErrorAndStackTrace(UnhandledStreamError(e), s);


### PR DESCRIPTION
This pull request includes several changes to the `ValueStreamBuilder` class in the `packages/rxdart_flutter` library. The changes focus on improving error handling, updating documentation, and enhancing the overall robustness of the `ValueStreamBuilder` class.

Improvements to error handling:

* [`packages/rxdart_flutter/lib/src/value_stream_builder.dart`](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0L105-R108): Replaced the `Object? error` field with `ErrorAndStackTrace? error` to better capture error details.
* [`packages/rxdart_flutter/lib/src/value_stream_builder.dart`](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0L144-R169): Updated the error handling logic to use the new `ErrorAndStackTrace` class and introduced a new `reportError` method for reporting errors consistently. [[1]](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0L144-R169) [[2]](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0R184-R232)

Documentation updates:

* [`packages/rxdart_flutter/lib/src/value_stream_builder.dart`](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0L19-R28): Enhanced the documentation for `ValueStreamBuilder` to clarify its requirements and added examples. [[1]](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0L19-R28) [[2]](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0R56)

Robustness improvements:

* [`packages/rxdart_flutter/lib/src/value_stream_builder.dart`](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0L131-R134): Updated the `build` method to return an `ErrorWidget` instead of throwing an error directly when an error occurs.
* [`packages/rxdart_flutter/lib/src/value_stream_builder.dart`](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0L236-R252): Improved the error messages in `UnhandledStreamError` and `ValueStreamHasNoValueError` classes to provide clearer guidance and formatting.