### PR TITLE
Update value_stream_builder.dart

### DIFF
--- a/packages/rxdart_flutter/lib/src/value_stream_builder.dart
+++ b/packages/rxdart_flutter/lib/src/value_stream_builder.dart
@@ -155,7 +155,7 @@ class _ValueStreamBuilderState<T> extends State<ValueStreamBuilder<T>> {
 
     final buildWhen = widget._buildWhen;
 
-    assert(subscription == null, 'Stream already subscribed');
+    assert(subscription == null, 'The stream is already listened to!');
     subscription = stream.listen(
       (newData) {
         final previousData = currentData;
@@ -180,7 +180,7 @@ class _ValueStreamBuilderState<T> extends State<ValueStreamBuilder<T>> {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty.lazy('currentData', () => currentData));
+    properties.add(DiagnosticsProperty.lazy('data', () => currentData));
     properties.add(DiagnosticsProperty('error', error));
     properties.add(DiagnosticsProperty('subscription', subscription));
   }


### PR DESCRIPTION
This pull request includes changes to the `ValueStreamBuilder` class in the `rxdart_flutter` package. The most important changes focus on improving the readability and clarity of the debug information.

Improvements to debug information:

* [`packages/rxdart_flutter/lib/src/value_stream_builder.dart`](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0L158-R158): Updated the assertion message to be more descriptive when a stream is already subscribed.
* [`packages/rxdart_flutter/lib/src/value_stream_builder.dart`](diffhunk://#diff-ec27ed414ff6b392ff2603eb61276335c6969b3bf0f17e354d144ce0d5a619c0L183-R183): Renamed the debug property from `currentData` to `data` for better clarity.