### PR TITLE
update docs DefaultIfEmptyExtension

### DIFF
--- a/packages/rxdart/lib/src/transformers/default_if_empty.dart
+++ b/packages/rxdart/lib/src/transformers/default_if_empty.dart
@@ -47,7 +47,8 @@ class DefaultIfEmptyStreamTransformer<S> extends StreamTransformerBase<S, S> {
       stream, (sink) => _DefaultIfEmptyStreamSink<S>(sink, defaultValue));
 }
 
-///
+/// Extend the Stream class with the ability to emit a single default item if the
+/// source Stream emits nothing.
 extension DefaultIfEmptyExtension<T> on Stream<T> {
   /// Emit items from the source Stream, or a single default item if the source
   /// Stream emits nothing.


### PR DESCRIPTION
This pull request includes a small change to the `packages/rxdart/lib/src/transformers/default_if_empty.dart` file. The change improves the documentation for the `DefaultIfEmptyExtension` extension by adding a more detailed description of its functionality.

Documentation improvement:

* [`packages/rxdart/lib/src/transformers/default_if_empty.dart`](diffhunk://#diff-9e17f68b1d9ea5cd466a4503d45f0cc4040d4057c0228d15e338967201bd0eb1L50-R51): Updated the comment to explain that the extension allows the Stream class to emit a single default item if the source Stream emits nothing.