### PR TITLE
Make StartWithErrorStreamTransformer available in API

### DIFF
--- a/packages/rxdart/lib/transformers.dart
+++ b/packages/rxdart/lib/transformers.dart
@@ -29,6 +29,7 @@ export 'src/transformers/scan.dart';
 export 'src/transformers/skip_last.dart';
 export 'src/transformers/skip_until.dart';
 export 'src/transformers/start_with.dart';
+export 'src/transformers/start_with_error.dart';
 export 'src/transformers/start_with_many.dart';
 export 'src/transformers/switch_if_empty.dart';
 export 'src/transformers/switch_map.dart';


### PR DESCRIPTION
Hi,

I'm trying to make BahaviorSubject with reset feature (as mentioned in #774) and I need StartWithErrorStreamTransformer for it. But it's not available in the API. Can we add it?